### PR TITLE
Replace "News from INRIA" by a small code snippet

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -183,6 +183,22 @@
 	  <a href="planet/" class="btn pull-right"
 	     >More news <i class="icon-arrow-right"></i></a>
 	</div>
+
+<div class="span6">
+An example (or get <a href="taste.html">a stronger taste</a>):
+
+<pre class="listing" ml:content="ocaml noeval">
+type 'a tree = Leaf of 'a  |  Node of 'a tree * 'a tree
+
+let rec exists_leaf test = function
+  | Leaf v -> test v
+  | Node (left, right) ->
+      exists_leaf test left || exists_leaf test right
+
+let has_even_leaf tree =
+  exists_leaf (fun n -> n mod 2 = 0) tree
+</pre></div>
+
       </div><!--/row-->
     </div><!--/.fluid-container-->
 

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -182,12 +182,6 @@
 
 	  <a href="planet/" class="btn pull-right"
 	     >More news <i class="icon-arrow-right"></i></a>
-
-	  <h2 style="clear: both" >News from Inria</h2>
-
-	  <div id="news"
-	       ml:content="news http://caml.inria.fr/news.en.rss"
-	       ></div>
 	</div>
       </div><!--/row-->
     </div><!--/.fluid-container-->

--- a/src/html/taste.html
+++ b/src/html/taste.html
@@ -198,7 +198,7 @@ sigma (fun x -> x * x) [1; 2; 3];;
     operators. Such expressions can be defined as a new data type,
     as follows:
   </p>
-<pre class="listing" ml:content="ocaml">
+<pre class="listing" ml:content="ocaml silent">
   type expression =
     | Num of int
     | Var of string

--- a/src/html/tutorials/99problems.html
+++ b/src/html/tutorials/99problems.html
@@ -160,7 +160,7 @@ function toggleContent(id) {
 
 <div class="question medium" id="q7">
   <div class="title">Flatten a nested list structure.</div>
-<pre ml:content="ocaml">
+<pre ml:content="ocaml silent">
   (* There is no nested list type in OCaml, so we need to define one
      first. A node of a nested list is either an element, or a list of
      nodes. *)

--- a/src/html/tutorials/format.html
+++ b/src/html/tutorials/format.html
@@ -492,7 +492,7 @@ Prix TTC <b></b>=<b></b> 100 Euros
       interactive system</a>):
     </p>
 
-<pre class="listing" ml:content="ocaml">
+<pre class="listing" ml:content="ocaml silent">
   type lambda =
     | Lambda of string * lambda
     | Var of string


### PR DESCRIPTION
The "News from INRIA" feed was relatively outdated and, I think, used free space on the front page for something that wasn't really worth it (if one want to underline INRIA's role in OCaml development, I'm sure there are better ways to do, such as putting more emphasis on the research around OCaml).

I replaced it with a "minimum viable snippet" that shows a small example of OCaml code that is, I think, a reasonable compromise between "simple to understand" and "interesting". I think it's important to have such a snippet somewhere on the front page, but I'm not insisting on either this location on the page, or this particular snippet (which could be replaced by a simpler one).

In the process of putting this snippet, I've added a few options to the "binding" for OCaml code highlighting (having the toplevel output around like for all other code examples would consume too much space).
