### PR TITLE
Remove two references to an old ocaml.org repository

### DIFF
--- a/src/html/companies.html
+++ b/src/html/companies.html
@@ -404,7 +404,7 @@
       <small>Appearance of a company's name here does not necessarily
       imply endorsement by that company of OCaml or of the
       descriptions provided here. Company representatives should <a
-      href="https://github.com/agarwal/ocamlweb">contact us</a> to
+      href="https://github.com/ocaml/ocaml.org">contact us</a> to
       have information about their company removed, modified, or
       added.</small>
     </div>

--- a/src/html/tutorials/index.html
+++ b/src/html/tutorials/index.html
@@ -14,7 +14,7 @@
     <small>Many of the tutorials below need updating and tutorials on
     many new topics are needed. Please contribute by visiting this
     project's repo on <a
-    href="https://github.com/agarwal/ocamlweb">github</a>. Thanks!</small>
+    href="https://github.com/ocaml/ocaml.org">github</a>. Thanks!</small>
   </div>
 
   <table border="0">


### PR DESCRIPTION
https://github.com/agarwal/ocamlweb gives a 404, so I used https://github.com/ocaml/ocaml.org instead.
