### PR TITLE
remove a misleading discussion on single-line comments

### DIFF
--- a/src/html/tutorials/basics.html
+++ b/src/html/tutorials/basics.html
@@ -12,8 +12,7 @@
  *)
 </pre>
 
-<p class="first_para">In other words, the commenting convention is very similar to original C (<code>/* ... */</code>).</p>
-<p>There is currently no single-line comment syntax (like <code># ...</code> in Perl or <code>// ...</code> in C99/C++/Java). At some point the use of <code>## ...</code> was mooted, and I very much recommend that the OCaml guys add this in the future (however, with <a href="http://cocan.org/tips/single_line_comment_syntax" class="external" title="http://cocan.org/tips/single_line_comment_syntax">good editor support</a>, single-line comment syntax is not really missed).</p>
+<p class="first_para">In other words, the commenting convention is very similar to original C (<code>/* ... */</code>). There is currently no single-line comment syntax (like <code># ...</code> in Perl or <code>// ...</code> in C99/C++/Java).</p>
 <p>OCaml counts nested <code>(* ... *)</code> blocks, and this allows you to comment out regions of code very easily:</p>
 <pre ml:content="ocaml noeval">
 (* This code is broken ...


### PR DESCRIPTION
The discussion contains a personal (from whom?) suggestion about OCaml style and is inappropriate in a tutorial aimed at people who see the language for the first time.
