### PR TITLE
Add Citrix company description to companies.html

### DIFF
--- a/src/html/companies.html
+++ b/src/html/companies.html
@@ -59,6 +59,10 @@
 	 href="http://www.citrix.com">Citrix</a>, <span class=
 	 "country">United Kindgom</span>.
       <div class="description">
+         Citrix uses OCaml in XenServer, a world-class server virtualization
+         system. We also offer a full open-source variant of XenServer called
+         the Xen Cloud Platform, or XCP. Follow along with our OCaml development
+         at <a href="https://github.com/xen-org">github.com/xen-org</a>.
       </div>
     </div>
 


### PR DESCRIPTION
Citrix's entry was looking pretty pithy in comparison to the rest, so I updated it to include details about how we use OCaml, and a link to our github page.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
