### PR TITLE
Fixing history

### DIFF
--- a/src/html/history.fr.html
+++ b/src/html/history.fr.html
@@ -20,9 +20,11 @@
     de l'<a href="http://www.inria.fr/index.fr.html"
     >Inria</a>, dirigée par
       <a href="http://cristal.inria.fr/~huet/" >Gérard Huet</a>. Son
-      développement continue aujourd'hui dans
-      l'équipe <a href="http://www.inria.fr/recherche/equipes/cristal.en.html"
-      >Cristal</a>.</p>
+      développement a continué dans l'équipe
+	  <a href="http://cristal.inria.fr/">Cristal</a>,
+	  et aujourd'hui dans son successeur, 
+	  <a href="http://gallium.inria.fr/">Gallium</a>.
+	</p>
 
     <h2>L'origine</h2>
 

--- a/src/html/history.fr.html
+++ b/src/html/history.fr.html
@@ -29,7 +29,7 @@
     <h2>L'origine</h2>
 
     <p>L'équipe Formel commença à s'intéresser au langage ML en
-      1980–81. ML était le <em>méta-langage</em> de la version
+      1980–81. ML était le <em>métalangage</em> de la version
       d'Édimbourg de l'assistant de preuve LCF, tous deux conçus
       par <a href="http://www.cl.cam.ac.uk/~rm135/" >Robin
 	Milner</a>. Il était implanté par une sorte d'interprète écrit en

--- a/src/html/history.html
+++ b/src/html/history.html
@@ -21,9 +21,10 @@
     by <a href="http://www.inria.fr/index.en.html"
     >Inria</a>'s <em>Formel</em> team, headed
     by <a href="http://cristal.inria.fr/~huet/" >Gérard Huet</a>.  Its
-    development now continues within
-    the <a href="http://www.inria.fr/recherche/equipes/cristal.en.html"
-    >Cristal</a> team.</p>
+    development continued within the 
+	<a href="http://cristal.inria.fr/">Cristal</a> team, and its
+	current successor, <a href="http://gallium.inria.fr/">Gallium</a>.
+	</p>
 
     <h2><a name="origin"></a>The Origin</h2>
 

--- a/src/html/history.html
+++ b/src/html/history.html
@@ -103,7 +103,7 @@
 	Cousineau</a> to develop a new implementation of ML, based on the
       CAM.  However, the language that we ended up implementing was not
       Standard ML, but... Caml.  Why? Our main reason for developing
-      Caml was to use it for sofware development inside Formel. Indeed,
+      Caml was to use it for software development inside Formel. Indeed,
       it was used for developing
       the <a href="http://coq.inria.fr/" >Coq</a> system,
       which, following
@@ -183,7 +183,7 @@
     offered a high-level module system, designed
     by <a href="http://cristal.inria.fr/~xleroy/" >Xavier Leroy</a>
     and inspired by the module system of Standard ML.  This module
-    system provides powerful abstraction and parameterization
+    system provides powerful abstraction and parametrization
     facilities for programming in the large.
     </p>
 


### PR DESCRIPTION
The history page contains spelling mistakes and mentions Cristal as the current Inria tem developing OCaml, instead of Galllium. 
