### PR TITLE
Improve body text contrast.

### DIFF
--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -216,7 +216,7 @@ body {
   font-family: Domine, serif;
   font-size: 14px;
   line-height: 24px;
-  color: #404040;
+  color: #000000;
   background-color: #ffffff;
 }
 a {
@@ -830,7 +830,7 @@ pre {
   padding: 0 3px 2px;
   font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
   font-size: 12px;
-  color: #404040;
+  color: #000000;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;
   border-radius: 3px;
@@ -889,7 +889,7 @@ legend {
   margin-bottom: 24px;
   font-size: 21px;
   line-height: 48px;
-  color: #404040;
+  color: #202020;
   border: 0;
   border-bottom: 1px solid #e5e5e5;
 }


### PR DESCRIPTION
The current choice of slightly gray text on white is very hard to read on some
devices.  This fixes the colors to be black on white, to make large bodies of
text and the tutorials easier on the eyes.

(I made this same change to realworldocaml.org after several requests from
reviewers)
