### PR TITLE
Add Homebrew installation section in install.md

### DIFF
--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -304,6 +304,26 @@ be used to download and build the following packages:
 * `tuareg-mode.el` A GNU Emacs/XEmacs major mode for editing OCaml
  programs.
 
+### Homebrew
+[Homebrew](http://brew.sh/) is a new and upcoming package management
+system for Mac OS X and has a very large community.
+Homebrew requires the command line tools for Xcode and either bash or zsh to
+[install](https://github.com/Homebrew/homebrew/wiki/Installation).
+
+After installing Homebrew, you can install OCaml by issuing the following
+command:
+
+```bash
+brew install ocaml
+```
+
+You can then install [OPAM](http://opam.ocaml.org/), the
+OCaml package manager, which will give you access to all its
+[packages](http://opam.ocaml.org/pkg/) by running:
+
+```bash
+brew install opam
+```
 
 
 ### Building from sources


### PR DESCRIPTION
I was looking to install OCaml and couldn't find a section for installing it using Homebrew so I decided to write it because the `ocaml` package (version 4.01.0) already existed in the Homebrew formulae: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/objective-caml.rb

Let me know if any of the wording, organization, etc. should be changed! :smile: 
