### PR TITLE
href="about.html" -> href="/about.html"

### DIFF
--- a/template/footer.mpp
+++ b/template/footer.mpp
@@ -40,7 +40,7 @@
     <ul>
       <li><a href="https://github.com/ocaml/ocaml.org/issues"
 	     target="_blank" >Feedback</a></li>
-      <li><a href="about.html">About This Site</a></li>
+      <li><a href="/about.html">About This Site</a></li>
     <li><a href="https://github.com/ocaml/ocaml.org/"
 	   target="_blank" >Find Us on GitHub</a></li>
     </ul>


### PR DESCRIPTION
The "about this site" link was relative, leading to 404 when clicked from a subdir (ex: go to docs and then click about).
