### PR TITLE
Improved French pages

### DIFF
--- a/site/community/mailing_lists.fr.md
+++ b/site/community/mailing_lists.fr.md
@@ -2,6 +2,8 @@
 
 *Table of contents*
 
+# Liste de diffusion OCaml
+
 ###  La liste de diffusion OCaml : caml-list AT inria.fr
 La liste de diffusion OCaml s'adresse à tous les utilisateurs des
 implémentations OCaml de l'Inria. Le but de cette tribune est de mettre

--- a/site/community/support.fr.md
+++ b/site/community/support.fr.md
@@ -6,11 +6,14 @@
 Le développement d'OCaml est dirigé par
 l'[Inria](http://caml.inria.fr/). La communauté des développeurs OCaml
 vous aidera volontiers sur la [liste de diffusion
-officielle](mailing_lists.html). Un support commercial est fourni par
+officielle](mailing_lists.fr.html). Un support commercial est fourni par
 [OCamlPro](#ocamlpro).
 
-## Le Consortium à l'Inria
-e Consortium OCaml fédère les efforts de conception et de développement
+## Le Consortium Caml à l'Inria
+
+<img src="/img/inria.png" alt="Inria" style="height: 70px">
+
+Le Consortium Caml fédère les efforts de conception et de développement
 du langage OCaml et de son environnement. Le Consortium permet à ses
 membres de montrer leur intérêt pour le langage OCaml et de soutenir son
 développement. Ils bénéficient de plus d'une [license
@@ -25,27 +28,27 @@ dissémination, mais aussi pour sa pérennité.
 ###  Membres
 
 
-<table>
+<table style="width: 100%">
 <tbody>
-<tr class="odd">
-<td align="left"><a href="http://www.cea.fr"><img src="img/cea.png" alt="CEA" /></a></td>
-<td align="left"><a href="http://www.citrix.com"><img src="img/citrix.png" alt="Citrix" /></a></td>
-<td align="left"><a href="http://www.dassault-aviation.com"><img src="img/dassault-aviation.png" alt="Dassault Aviation" /></a></td>
+<tr style="height: 70px">
+<td align="left"><a href="http://www.cea.fr"><img src="/img/cea.png" alt="CEA" /></a></td>
+<td align="left"><a href="http://www.citrix.com"><img src="/img/citrix.png" alt="Citrix" /></a></td>
+<td align="left"><a href="http://www.dassault-aviation.com"><img src="/img/dassault-aviation.png" alt="Dassault Aviation" /></a></td>
 </tr>
-<tr class="even">
-<td align="left"><a href="http://www.3ds.com"><img src="img/3ds.png" alt="Dassault System" /></a></td>
-<td align="left"><a href="http://www.esterel-technologies.com"><img src="img/esterel.png" alt="Esterel Technologies" /></a></td>
-<td align="left"><a href="http://www.janestreet.com"><img src="img/janestreet.png" alt="Jane Street" /></a></td>
+<tr style="height: 70px">
+<td align="left"><a href="http://www.3ds.com"><img src="/img/3ds.png" alt="Dassault System" /></a></td>
+<td align="left"><a href="http://www.esterel-technologies.com"><img src="/img/esterel.png" alt="Esterel Technologies" /></a></td>
+<td align="left"><a href="http://www.janestreet.com"><img src="/img/janestreet.png" alt="Jane Street" /></a></td>
 </tr>
-<tr class="odd">
-<td align="left"><a href="http://www.lexifi.com"><img src="img/lexifi.png" alt="Lexifi" /></a></td>
-<td align="left"><a href="http://www.microsoft.com"><img src="img/microsoft.png" alt="Microsoft" /></a></td>
-<td align="left"><a href="http://www.mlstate.com"><img src="img/mlstate.png" alt="MLState" /></a></td>
+<tr style="height: 70px">
+<td align="left"><a href="http://www.lexifi.com"><img src="/img/lexifi.png" alt="Lexifi" /></a></td>
+<td align="left"><a href="http://www.microsoft.com"><img src="/img/microsoft.png" alt="Microsoft" /></a></td>
+<td align="left"><a href="http://www.mlstate.com"><img src="/img/mlstate.png" alt="MLState" /></a></td>
 </tr>
-<tr class="even">
-<td align="left"><a href="http://www.mylife.com"><img src="img/mylife.png" alt="Mylife.com" /></a></td>
-<td align="left"><a href="http://www.simcorp.com"><img src="img/simcorp.png" alt="SimCorp" /></a></td>
-<td align="left"><a href="http://www.ocamlpro.com"><img src="img/ocamlpro.png" alt="OCamlPro" /></a></td>
+<tr style="height: 70px">
+<td align="left"><a href="http://www.mylife.com"><img src="/img/mylife.png" alt="Mylife.com" /></a></td>
+<td align="left"><a href="http://www.simcorp.com"><img src="/img/simcorp.png" alt="SimCorp" /></a></td>
+<td align="left"><a href="http://www.ocamlpro.com"><img src="/img/ocamlpro.png" alt="OCamlPro" /></a></td>
 </tr>
 </tbody>
 </table>
@@ -71,6 +74,9 @@ un représentant habilité de l'Inria, une facture correspondant au
 montant de votre participation financière vous sera envoyée.
 
 ## Support commercial par OCamlPro
+
+### <img src="/img/ocamlpro.png" alt="OCamlPro" style="height: 2ex; vertical-align: text-bottom" />
+
 Un support commercial est fourni par
 [OCamlPro](http://www.ocamlpro.com/). OCamlPro offre un éventail de
 services, du simple support au développement avancé en OCaml, des


### PR DESCRIPTION
- On mailing_lists.fr.html, fix the "en" link that didn't work on Chrome
- On support.fr.html, fix the table of consortium members, and link directly
  to mailing_lists.fr.html.
