### PR TITLE
Fix Tutorials.Modules (fr) header overlaying breadcrumbs and lang selector

### DIFF
--- a/site/learn/tutorials/modules.fr.md
+++ b/site/learn/tutorials/modules.fr.md
@@ -2,8 +2,7 @@
 
 *Table of contents*
 
-Modules
--------
+# Modules
 
 ## Usage standard
 


### PR DESCRIPTION
Apparently ---- underlining in markdown creates an H2 header which has different styling in bootstrap_mod.css than an H1 header such that the header box ends up catching most clicks on the breadcrumb or language selector links.
