### PR TITLE
Fix "from source" installation method

### DIFF
--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -537,7 +537,7 @@ See [here](https://github.com/hcarty/ocamlbrew).
 
 
 ## From Source
-Download the [latest development version](/releases/svn.html) using
-subversion and follow the instructions included therein. This is
-unlikely the method you want to use unless you are a developer of the
-OCaml compiler itself or trying to install on some esoteric platforms.
+
+Download the [source for your preferred OCaml release](/releases/)
+(or take the [development version](/releases/svn.html) using
+Subversion or Git) and follow the instructions included therein.


### PR DESCRIPTION
There should be at least a link on that page to get `ocaml-4.01.0.tar.gz`.

I removed “This is unlikely the method you want to use unless you are a developer of the OCaml compiler itself or trying to install on some esoteric platforms.” because there are many cases when one would prefer getting the original sources.
