### PR TITLE
Make sure snippets are available before translated indexes are built

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -16,6 +16,8 @@ DEP_CONTENT_GEN = template/main.mpp template/footer.mpp \
   script/breadcrumb script/translations \
   script/lang_of_filename script/translate script/link_of_lang
 
+DEP_SNIPPETS = template/front_code_snippet.html template/learn_code_snippet.html
+
 ifeq ("$(OCAML_VERSION)", "3.12.1")
 COMPILER_LIBS_PREPARE = ocamlc -c errors.mli &&
 COMPILER_LIBS = dynlink.cma toplevellib.cma
@@ -91,11 +93,6 @@ script/%.cmi script/%.cmo: script/%.ml
 TRASH += template/front_code_snippet.html \
   $(addprefix script/, breadcrumb rss2html ocamltohtml md_preprocess \
   code_top relative_urls translations)
-
-ocaml.org/index.html:template/front_code_snippet.html script/rss2html
-ocaml.org/community/index.html:script/rss2html
-ocaml.org/community/planet.html:script/rss2html
-ocaml.org/learn/index.html: template/learn_code_snippet.html
 
 # Camlp4 tutorials
 CAMLP4_TUT_DIR = learn/tutorials/camlp4_3.10

--- a/Makefile.from_md
+++ b/Makefile.from_md
@@ -4,7 +4,7 @@ include Makefile.common
 
 DEP_CONTENT_MD = script/code_top $(OMD_PP) script/ocamltohtml script/rss2html
 
-ocaml.org/%.html: site/%.md $(DEP_CONTENT_GEN) $(DEP_CONTENT_MD)
+ocaml.org/%.html: site/%.md $(DEP_CONTENT_GEN) $(DEP_CONTENT_MD) $(DEP_SNIPPETS)
 	mkdir -p "$(shell dirname $@)"
 	if grep -q '*Table of contents*' "$<" ; then $(MAKE) -f Makefile.from_md "$@.toc" ; fi
 	$(MAKE) -f Makefile.from_md "$@.tmp"


### PR DESCRIPTION
The first `make` used to fail on `ocaml.org/index.fr.html` because `template/front_code_snippet.html` was not built yet.

I think this new dependency layout is valid and gets rid of the special non-translated page dependencies.
