### PR TITLE
Use the same OPAM new package table generation system as opam2web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ template/front_code_snippet.html
 template/learn_code_snippet.html
 .DS_Store
 script/link_of_lang
+script/generate_opam_update_list
+opam_update_list

--- a/Makefile.common
+++ b/Makefile.common
@@ -32,6 +32,14 @@ CODE_TYPE_DEP = $(addprefix script/code_types., cmi cmo cmx)
 template/%_code_snippet.html:template/%_code_snippet.md $(OMD_PP)
 	cat "$<" | $(OMD_PP) | ${OMD} -o $@
 
+opam_update_list: script/generate_opam_update_list
+	script/generate_opam_update_list
+
+script/generate_opam_update_list: script/generate_opam_update_list.ml
+	cd script && \
+	$(OCAMLOPT) -o ../"$@" -package opam,opamfu,opam2web,cow.syntax \
+	  -linkpkg -syntax camlp4o generate_opam_update_list.ml
+
 script/lang_of_filename: script/lang_of_filename.ml $(UTILS_DEP)
 	cd script && \
 	$(OCAMLOPT) -o ../"$@" -package str,netstring -linkpkg \

--- a/Makefile.from_md
+++ b/Makefile.from_md
@@ -4,6 +4,13 @@ include Makefile.common
 
 DEP_CONTENT_MD = script/code_top $(OMD_PP) script/ocamltohtml script/rss2html
 
+USE_OPAM_UPDATE_LIST = \
+	ocaml.org/index.html \
+	ocaml.org/index.fr.html \
+	ocaml.org/platform/index.html
+
+$(USE_OPAM_UPDATE_LIST): opam_update_list
+
 ocaml.org/%.html: site/%.md $(DEP_CONTENT_GEN) $(DEP_CONTENT_MD) $(DEP_SNIPPETS)
 	mkdir -p "$(shell dirname $@)"
 	if grep -q '*Table of contents*' "$<" ; then $(MAKE) -f Makefile.from_md "$@.toc" ; fi

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ Building the html pages requires:
 * ocamlfind
 * mpp >= 0.1.2
 * omd >= 0.7.5
+* opam2web >= 1.3.1
 * netstring, netclient, equeue-ssl, and rss (for rss2html.ml)
 * lablgtk2 (optional, for the Gtk tutorial)
 
 If you use opam (>= 1.1), the OCaml packages above can be installed by
 running:
 
-    opam install ocamlfind mpp omd ssl ocamlnet ocamlrss
+    opam install ocamlfind mpp omd ssl ocamlnet ocamlrss opam2web
 
 Note that you need `libssl-dev` to be able to compile and use `ssl`.
 `libssl-dev` is the name of a debian package, if you're using another system,

--- a/script/generate_opam_update_list.ml
+++ b/script/generate_opam_update_list.ml
@@ -1,0 +1,38 @@
+let packages_base = "https://opam.ocaml.org/packages/" in
+let u = O2wUniverse.of_repositories ~preds:[] OpamfUniverse.Index_all [`opam] in
+let dates_fn pkg =
+  try OpamPackage.Map.find pkg u.OpamfUniverse.pkgs_dates
+  with Not_found -> 0.
+in
+let updates = O2wStatistics.top_packages
+  ~reverse:true ~ntop:6 dates_fn u.OpamfUniverse.max_packages
+in
+let rows = List.map
+  (fun (pkg, update_tm) ->
+    let open OpamPackage in
+    let name = name pkg in
+    let version = version pkg in
+    let pkg_name = Name.to_string name in
+    let pkg_version = Version.to_string version in
+    let pkg_href =
+      OpamfUniverse.Pkg.href ~href_base:Uri.(of_string packages_base)
+        name version
+    in
+    let pkg_date = O2wMisc.string_of_timestamp update_tm in
+    <:html<<tr>
+      <td><a href=$uri: pkg_href$>$str: pkg_name$</a></td>
+      <td><a href=$uri: pkg_href$>$str: pkg_version$</a></td>
+      <td>$str: pkg_date$</td>
+    </tr>&>>
+  ) updates
+in
+let opam_update_list = open_out "opam_update_list" in
+List.iter (fun xml ->
+  let xml_out = Cow.Xml.make_output ~decl:false (`Channel opam_update_list) in
+  List.iter (Cow.Xml.output xml_out) ((`Dtd None)::(Template.serialize xml))
+) rows;
+close_out opam_update_list
+
+(* Local Variables: *)
+(* compile-command: "make --no-print-directory -k -C .. script/generate_opam_update_list" *)
+(* End: *)

--- a/template/front_package.mpp
+++ b/template/front_package.mpp
@@ -13,14 +13,7 @@
     </thead>
     <tbody>
 ((! cmd bash
-if [[ -f opam-update-list ]]
-then
-cat opam-update-list
-else
-for i in {1..6} ; do
-echo '<tr><td><a href="#">placeholder</a></td><td><a href="#">0.0.1</a></td><td><a href="#">12 Feb 2013</a></td></tr>'
-done
-fi
+cat opam_update_list
 !))
     </tbody>
 </table>


### PR DESCRIPTION
Fixes #253. Fixes #326. Fixes #412.

Not the prettiest implementation or least redundant but it gets the job done. The server will need to have opam installed and periodically run

``` bash
opam update
script/generate_opam_update_list
make
```

or something similar. I don't really know what the present update script looks like because it's not in this repository for some reason.

Also, I didn't know whether to list more transitive dependencies in the README or if just opam2web >= 1.3.1 was enough.

It's probably wise to play around with this a little locally and then on a test server before actually deploying but I have no idea what the deploy procedures look like. I hope this works for you. I'll be happy to support this feature now and in the future.
