### PR TITLE
Fix links to CUFP slides (Verlaguet)

### DIFF
--- a/site/learn/index.fr.md
+++ b/site/learn/index.fr.md
@@ -118,7 +118,7 @@ OCaml est un langage générique de programmation, de puissance industrielle, qu
 	    Voir
 	    <a href="http://www.youtube.com/watch?v=gKWNjFagR9k"
 	       >l'exposé à CUFP</a> de Julien Verlaguet et
-	    <a href="http://cufp.org/sites/all/files/slides/2013/verlaguet.pdf"
+	    <a href="http://cufp.org/2013/slides/verlaguet.pdf"
 	       >sa présentation</a>.</p>
 
 	  <footer>

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -125,7 +125,7 @@
 	    See Julien Verlaguet's
 	    <a href="http://www.youtube.com/watch?v=gKWNjFagR9k"
 	       >CUFP talk</a> and
-	    <a href="http://cufp.org/sites/all/files/slides/2013/verlaguet.pdf"
+	    <a href="http://cufp.org/2013/slides/verlaguet.pdf"
 	       >slides</a>.</p>
 
 	  <footer>


### PR DESCRIPTION
Right now from there: http://ocaml.org/learn/ we are lead to a 404 for Facebook's CUFP slides.
