### PR TITLE
Improve the install page, fix some typos.

### DIFF
--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -11,11 +11,9 @@ ways. Broadly, the options are:
   Mac OS X, ...)
 * install from source code.
 
-These different options are detailed below and explain how to install
-the OCaml compiler and libraries that have been packaged in one way or
-another. Also, see [here](/learn/libraries.html) for additional
-resources to find OCaml libraries.
-
+The following sections explain how to use each of these methods.
+For additional information about finding and installing OCaml libraries,
+see the [libraries](/learn/libraries.html) page.
 
 ## OPAM
 
@@ -26,14 +24,14 @@ and serves as the de facto master set of OCaml packages. OPAM also
 provides features that would be unavailable with the other methods,
 such as the ability to have multiple versions of OCaml installed at
 the same time, or have multiple universes of packages for different
-projects with conflicting package constraints. Get an overview by
+projects with conflicting package dependencies. Get an overview by
 visiting [OPAM's main page](http://opam.ocaml.org/).
 
-Note there is a bootstrapping issue since OPAM is itself implemented
+Note that there is a bootstrapping issue, since OPAM is itself implemented
 in OCaml. You can follow the instructions
 [here](http://software.opensuse.org/download.html?project=home%3Aocaml&package=ocaml)
 to first install OPAM using an OS specific package
-manager. Alternatively, you can compile from source by grabbing one
+manager. Alternatively, you can compile from source by grabbing one of
 the recent [releases](https://github.com/ocaml/opam/releases). More
 information is available in the [Quick
 Install](http://opam.ocaml.org/doc/Quick_Install.html) and [Advanced
@@ -50,17 +48,22 @@ OPAM is written and maintained by [OCamlPro](http://www.ocamlpro.com/) and
 
 
 ## Debian
-OCaml is very easy to install under [Debian](http://www.debian.org). We
-recommend you install `ocaml-nox` to develop applications not needing
-the graphics library or `ocaml` if you need the
-[Graphics](http://caml.inria.fr/pub/docs/manual-ocaml/libgraph.html)
-module. We also recommend you install
+OCaml is very easy to install on [Debian](http://www.debian.org).
 
-* `ocaml-native-compilers` to be able to compile your program the
- native code (this is not available on some more obscure
+```
+apt-get install ocaml
+```
+
+If you are not going to develop graphical applications, you may want
+to install `ocaml-nox`; otherwise install the `ocaml` package.
+
+We also recommend you to install the following packages:
+
+* `ocaml-native-compilers` to be able to compile native binaries
+ (this is not available on some more obscure
  architectures).
 * `ocaml-doc` to have the reference manual.
-* `tuareg-mode`, a Emacs mode for OCaml.
+* `tuareg-mode`, an Emacs mode for OCaml.
 * `ocaml-findlib` and `oasis` to install and use libraries (and their
  dependencies) easily.
 * `libpcre-ocaml-dev` which is a binding to PCRE.
@@ -69,10 +72,11 @@ Check the [packages available in
 Debian](http://packages.debian.org/search?keywords=ocaml&searchon=all&suite=testing&section=all).
 
 ## Ubuntu
-[Ubuntu](http://www.ubuntu.com/) being a derivative of Debian, it
-inherits its ease of install of [OCaml
-packages](http://packages.ubuntu.com/search?keywords=ocaml). The same
-recommendations as for Debian hold.
+[Ubuntu](http://www.ubuntu.com/) is a Debian derivative and uses the same package 
+manager, so Debian instructions are applicable to it too.
+
+You can view the list of OCaml packages in Ubuntu repositories
+[here](http://packages.ubuntu.com/search?keywords=ocaml).
 
 ## Fedora
 Since [Fedora 8](http://fedoraproject.org/), Fedora has excellent
@@ -122,7 +126,7 @@ core languages and supplimentary libraries, documentation, examples and
 development tools. There is a framework available to make adding new
 ocaml application and libraries easy.
 
-To install the OCaml compiler using packages do:
+To install the OCaml compiler from packages, do:
 
 ```bash
 pkg_add -r ocaml
@@ -139,7 +143,7 @@ To install the developer documentation, examples and emacs editing
 macros use the `ocaml-doc`, `ocaml-examples` and `ocaml-mode.el`
 packages.
 
-The same packages can be installed via the port system. There is a a
+The same packages can be installed via the port system. There is a
 large set of libraries available in the `devel` category of the ports
 system as well as in the specific topic-related categories.
 
@@ -157,10 +161,13 @@ available execute
 ```bash
 emerge -S ocaml 
 ```
+
 ## SuSE
-Getting Started with OCaml on [SuSE](https://www.suse.com/) is part in
-the standard distribution. In openSuse 12.1, the package name is
-`ocaml-3.12.0-11.1.2` (outdated).
+OCaml can be installed from the repositories on both OpenSuSE and SLES:
+
+```
+zypper install ocaml
+```
 
 ## Mageia
 [Mageia](http://www.mageia.org/) has some support for OCaml in the
@@ -196,7 +203,7 @@ urpmi camlp4-devel ocaml-doc ocaml-findlib-devel \
   ocaml-ounit-devel ocaml-sexplib-devel ocaml-xml-light-devel \
   ocamlmakefile
 ```
-To list OCaml packages use:
+To list OCaml packages, use:
 
 ```bash
 urpmq --list | grep ocaml
@@ -217,8 +224,8 @@ notes](http://caml.inria.fr/pub/distrib/ocaml-4.00/notes/README.win32).
  (4.00.1)](http://protz.github.io/ocaml-installer/). A self
  installer. The interactive loop comes with a simple graphical user
  interface. Some features require the Cygwin environment, which the
- installer can fetch for you. However, the compilers are, and
- generate true Win32 executables, which do not require Cygwin to run.
+ installer can fetch for you. However, the compilers are true Win32 executables,
+ and binaries they generate do not require Cygwin to run too.
 * Microsoft-based native Win32 ports. No binary distributions
  available yet; download the source distribution and compile it. Build
  instructions including required tools (Cygwin required) and download
@@ -244,12 +251,17 @@ To install libraries, you may use
 [Wodi](http://wodi.forge.ocamlcore.org/) or OPAM.
 
 ## Mac OS X
-Under Mac OS X, there are, at least for the base package, a few different
+On Mac OS X, there are, at least for the base package, a few different
 ways to go: Use OPAM; Install the binary package from Inria; Install via Fink;
 Install via MacPorts; or build it manually from
 sources. For each of these approaches, you will need to have at least
 the OS X developer tools installed — any other requirements will be
 discussed below.
+
+If you want a graphical interface for the interactive interpreter,
+you may use [CocOCaml](http://www.cs.unm.edu/~wneumann/cococaml/).
+It will work with any OCaml installation, regardless of the installation
+method you choose.
 
 ###  Inria's binary package
 This is the easiest way to set up a basic OCaml installation for OS X.
@@ -259,12 +271,6 @@ follow the instructions from there. Requirements for this package are OS
 X 10.4.x (Tiger), with X11 and the XCode tools (v2.4) installed. It
 appears that that this installation was built with the TCL/TK interface.
 Also, X11 is not needed to compile code.
-
-Also available as a binary package, and usable with any of the OCaml
-installations described on this page is
-[CocOCaml](http://www.cs.unm.edu/~wneumann/cococaml/), a Cocoa
-application allowing for easy interaction with the OCaml toplevel
-environment.
 
 ###  Fink
 [Fink](http://fink.sourceforge.net/ "Fink") is the most prevalent
@@ -364,11 +370,11 @@ There exists an Xcode plugin integrating OCaml developement in Xcode.
 This plugin is always under development and still lacks of features,
 however it gives useful features for developing applications:
 
-* create a OCaml projet or target with Xcode
+* create an OCaml project or target with Xcode
 * add files to this target like you do for a C program
 * modify the OCaml compiler or linker settings through the Xcode's
  build-in build setting GUI.
-* adding a library in library build phase of a OCaml target
+* add a library in library build phase of an OCaml target
 * syntax higlighting
 * use ocamllex and ocamlyacc
 * use of the native compiler (select architecture "ppc" instead of the
@@ -376,7 +382,7 @@ however it gives useful features for developing applications:
 * dependance between source files
 * mixing OCaml and C code
 
-Still being in beta it does not yet support the following:
+Still being in beta, it does not yet support the following:
 
 * better dependance between source files (you must put them manually
  in the good order in the target build phase)
@@ -498,7 +504,7 @@ will send hello.app's output to the console).
 
 ###  Tips
 **Documentation.** To get quick access to the documentation of a module
-(whatever the editor you use) use
+(whatever the editor you use), use
 [Quicksilver](http://qsapp.com/) to index the libref/
 directory of ocaml's documentation. Since ocamldoc generates the
 documentation of a module M in a file M.html, you can access it by


### PR DESCRIPTION
Improved the install page a little, fixed some typos and odd (as of me) wording.
The XCode plugin section that says there's no native compiler for Intel makes me think it needs complete rewrite, but I'm not using either OS X or said plugin so I can't really say anything here.
