### PR TITLE
Update compiling_with_gnu_make.md

### DIFF
--- a/site/learn/tutorials/compiling_with_gnu_make.md
+++ b/site/learn/tutorials/compiling_with_gnu_make.md
@@ -5,7 +5,7 @@
 *Table of contents*
 
 ## Using GNU make with OCamlMakefile
-[OCamlMakefile](https://bitbucket.org/mmottl/ocaml-makefile) is
+[OCamlMakefile](http://mmottl.github.io/ocaml-makefile/) is
 a generic Makefile that greatly facilitates the process of compiling
 complex OCaml projects.
 


### PR DESCRIPTION
It looks like Markus Mottl has moved away from bitbucket. The [old link](https://bitbucket.org/mmottl/ocaml-makefile) goes to a redirection page that suggest [this page](http://mmottl.github.io/ocaml-makefile/) I used in this pull-request. One might prefer to directly link to the source repository, but this page's documentation is interesting and seems fairly complete -- one may wonder whether it could even replace the current `compiling_with_gnu_make` page.
