### PR TITLE
Fixed dead links.

### DIFF
--- a/site/learn/index.fr.md
+++ b/site/learn/index.fr.md
@@ -169,7 +169,7 @@ OCaml est un langage générique de programmation, de puissance industrielle, qu
 	       >“découvre” des algorithmes qui étaient inconnus
 	       auparavant</a>.
 	    Elle a été couronnée
-	    <a href="http://www.mcs.anl.gov/research/opportunities/wilkinsonprize/3rd-1999.php"
+	    <a href="http://www.mcs.anl.gov/about-us/j-h-wilkinson-prize-numerical-software"
 	       >par le prix J. H. Wilkinson du logiciel numérique</a>,
 	    qui prime les développements qui excèlent dans toutes les phases
 	    de la préparation d'un logiciel numérique de haute qualité.

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -173,7 +173,7 @@
 	    <a href="http://www.fftw.org/pldi99.ps.gz"
 	       >“discovered” algorithms that were previously unknown</a>.
 	    It was awarded the
-	    <a href="http://www.mcs.anl.gov/research/opportunities/wilkinsonprize/3rd-1999.php"
+	    <a href="http://www.mcs.anl.gov/about-us/j-h-wilkinson-prize-numerical-software"
 	       >J. H. Wilkinson Prize for Numerical Software</a>
 	    that rewards software that "best addresses all phases of
 	    the preparation of high quality numerical software."

--- a/site/learn/success.fr.md
+++ b/site/learn/success.fr.md
@@ -202,7 +202,7 @@ Transformées de Fourier Discrètes (DFT). Elle emploie un puissant
 optimiseur symbolique écrit en OCaml qui, étant donné un entier N,
 produit du code C hautement optimisé pour effectuer des DFTs de taille
 N. FFTW a reçu en 1999 le [prix
-Wilkinson](http://www.mcs.anl.gov/research/opportunities/wilkinsonprize/3rd-1999.php)
+Wilkinson](http://www.mcs.anl.gov/about-us/j-h-wilkinson-prize-numerical-software)
 pour les logiciels de calcul numérique.
 
 Des mesures effectuées sur diverses plate-formes montrent que les

--- a/site/learn/success.md
+++ b/site/learn/success.md
@@ -204,7 +204,7 @@ fast](http://www.fftw.org/benchfft/) C library for computing Discrete
 Fourier Transforms (DFT). It uses a powerful symbolic optimizer written
 in OCaml which, given an integer N, generates highly optimized C code to
 compute DFTs of size N. FFTW was awarded the 1999 [Wilkinson
-prize](http://www.mcs.anl.gov/research/opportunities/wilkinsonprize/3rd-1999.php)
+prize](http://www.mcs.anl.gov/about-us/j-h-wilkinson-prize-numerical-software)
 for numerical software.
 
 Benchmarks, performed on on a variety of platforms, show that FFTW's

--- a/site/learn/tutorials/functional_programming.it.md
+++ b/site/learn/tutorials/functional_programming.it.md
@@ -174,7 +174,7 @@ f 99;;
 ```
 
 In ingegneria questa è per noi una sufficiente [prova attraverso
-esempio](http://www.princeton.edu/%7Esacm/humor/proof.html "http://www.princeton.edu/~sacm/humor/proof.html")
+esempio](https://web.archive.org/web/20080223145218/http://www.princeton.edu/~sacm/humor/proof.html "http://www.princeton.edu/~sacm/humor/proof.html")
 perché possiamo stabilire che `plus 2` è la funzione che aggiunge 2 alle
 cose.
 

--- a/site/learn/tutorials/functional_programming.zh.md
+++ b/site/learn/tutorials/functional_programming.zh.md
@@ -126,7 +126,7 @@ f 99;;
 ```
 
 在工程上这已经足够[proof by
-example](http://www.princeton.edu/%7Esacm/humor/proof.html "http://www.princeton.edu/~sacm/humor/proof.html")让我们声明`plus 2`是一个给整数加2的函数。
+example](https://web.archive.org/web/20080223145218/http://www.princeton.edu/~sacm/humor/proof.html "http://www.princeton.edu/~sacm/humor/proof.html")让我们声明`plus 2`是一个给整数加2的函数。
 
 回到原始的定义，让我们把第一个参数(`a`)换成2:
 

--- a/site/learn/tutorials/if_statements_loops_and_recursion.it.md
+++ b/site/learn/tutorials/if_statements_loops_and_recursion.it.md
@@ -862,7 +862,7 @@ thread](http://mirror.ocamlcore.org/caml.inria.fr/pub/ml-archives/caml-list/2003
 > designed for C programmers. It's no surprise, therefore, that the
 > imperative solution is easier. OCaml, not being a [bondage and
 > discipline
-> language](http://www.elsewhere.org/jargon/html/entry/bondage-and-discipline-language.html "http://www.elsewhere.org/jargon/html/entry/bondage-and-discipline-language.html"),
+> language](https://web.archive.org/web/20110611043853/http://www.elsewhere.org/jargon/html/entry/bondage-and-discipline-language.html "http://www.elsewhere.org/jargon/html/entry/bondage-and-discipline-language.html"),
 > doesn't mind you using the imperative approach when it makes sense.
 > 
 > Here is the outline of the imperative approach by Fabrice Le Fessant:

--- a/site/learn/tutorials/if_statements_loops_and_recursion.it.md
+++ b/site/learn/tutorials/if_statements_loops_and_recursion.it.md
@@ -95,7 +95,7 @@ let f x y =
 
 Indizio: aggiungete delle parentesi intorno all'intera espressione if.
 Unisce `y` come un [diodo
-elettronico](http://www.noir-medical.com/graphics/diode_graph.gif "http://www.noir-medical.com/graphics/diode_graph.gif").
+elettronico](https://en.wikipedia.org/wiki/Diode#Current.E2.80.93voltage_characteristic "https://en.wikipedia.org/wiki/Diode#Current.E2.80.93voltage_characteristic").
 
 La funzione `abs` (valore assoluto) è definita in `Pervasives` come:
 

--- a/site/learn/tutorials/if_statements_loops_and_recursion.ja.md
+++ b/site/learn/tutorials/if_statements_loops_and_recursion.ja.md
@@ -89,7 +89,7 @@ let f x y =
 ```
 
 ヒント: if 式のまわりにカッコを補うとよい。 `y`を
-[ダイオード](http://www.noir-medical.com/graphics/diode_graph.gif "http://www.noir-medical.com/graphics/diode_graph.gif")ではさんだようになっている。
+[ダイオード](https://en.wikipedia.org/wiki/Diode#Current.E2.80.93voltage_characteristic "https://en.wikipedia.org/wiki/Diode#Current.E2.80.93voltage_characteristic")ではさんだようになっている。
 
 `abs` (絶対値)関数は、 `Pervasives` でこう定義されている:
 

--- a/site/learn/tutorials/if_statements_loops_and_recursion.ja.md
+++ b/site/learn/tutorials/if_statements_loops_and_recursion.ja.md
@@ -817,7 +817,7 @@ throw するので、単純に while ループを脱出でき、 *さらに、* 
 といった、本質的に手続き型の、C
 プログラマ向けに作られたようなAPIを扱うときには。手続き型の解法のほうが簡単だということに、別に驚くことはない。
 OCaml は、[緊縛と調教
-言語](http://www.elsewhere.org/jargon/html/entry/bondage-and-discipline-language.html "http://www.elsewhere.org/jargon/html/entry/bondage-and-discipline-language.html")
+言語](https://web.archive.org/web/20110611043853/http://www.elsewhere.org/jargon/html/entry/bondage-and-discipline-language.html "http://www.elsewhere.org/jargon/html/entry/bondage-and-discipline-language.html")
 にあらず。手続き型のアプローチがわかりやすいときは、それを使えばいいのだ。
 
 これは、 Fabrice Le Fessant による、手続き型のアプローチの、概形だ:

--- a/site/learn/tutorials/performance_and_profiling.ja.md
+++ b/site/learn/tutorials/performance_and_profiling.ja.md
@@ -892,7 +892,7 @@ let () =
 のプロファイラにネイティブ対応している。 Linux の場合 `gprof` を使う。
 
 ネイティブコードのプロファイルの実例を示すにあたり、
-エラトステネスの篩([元コード](http://www.bagley.org/%7Edoug/ocaml/Notes/lazy.shtml "http://www.bagley.org/~doug/ocaml/Notes/lazy.shtml"))
+エラトステネスの篩([元コード](https://web.archive.org/web/20020611073618/http://www.bagley.org/~doug/ocaml/Notes/lazy.shtml "http://www.bagley.org/~doug/ocaml/Notes/lazy.shtml"))
 で最初の3000個の素数を求める。
 このプログラムはチュートリアルの範囲外のテクニックである stream と
 camlp4 を使っている。

--- a/site/learn/tutorials/structure_of_ocaml_programs.ja.md
+++ b/site/learn/tutorials/structure_of_ocaml_programs.ja.md
@@ -120,7 +120,7 @@ my_ref := 100
 Cには、入れ子関数の概念がないと言ってよい。GCCは、入れ子関数をCプログラマに提供しているが、この拡張を実際に使っているプログラムをみたことがない。それはさておき、info
 gccの、入れ子関数についてのページをのせておこう。
 
-日本語訳 http://www.sra.co.jp/wingnut/gcc/gcc-j.html\#Nested%20Functions
+日本語訳 https://web.archive.org/web/20070328133739/http://www.sra.co.jp/wingnut/gcc/gcc-j.html#Nested%20Functions
 
 ネストした関数 とは、なにか別の関数のなかで定義された関数である。(GNU
 C++ ではネストした関数はサポートしていない。)

--- a/site/releases/3.12.1.md
+++ b/site/releases/3.12.1.md
@@ -84,11 +84,6 @@ notes](http://caml.inria.fr/pub/distrib/ocaml-3.12/notes/README.win32).
  interface. Some features require the [Cygwin](http://cygwin.com/)
  environment. However, the compilers generate true Win32 executables,
  which do not require Cygwin to run.
-* [Microsoft-based native Win32 port
- (3.12.1)](http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1-win-msvc.exe).
- A self installer. The interactive loop comes with a simple graphical
- user interface. Some features require Microsoft Visual C++ and
- Microsoft Assembler.
 * [Cygwin](http://cygwin.com/)-based port. Requires Cygwin. No
  graphical user interface is provided. The compilers generate
  executables that do require Cygwin. The precompiled binaries are

--- a/site/releases/svn.md
+++ b/site/releases/svn.md
@@ -18,7 +18,7 @@ The address of the repository is `http://caml.inria.fr/svn`. To check
 out a local, working copy of the sources:
 
 ```
-svn checkout http://caml.inria.fr/svn/dir
+svn checkout http://caml.inria.fr/svn
 ```
 where *dir* is the subdirectory of interest (see table below).
 


### PR DESCRIPTION
I crawled the page for dead links and tried to fix as many of the broken links as possible. I used the new location for moved content and archive.org for content that totally disappeared from the internet.

Notes:
- The diode_graph.gif was already replaced in the english version, so i did the same to the other languages who still linked to that missing image.
- The 3.12 release has no public MSVC version, so i completly removed the paragraph about that version from the release page.
- The svn checkout example also resulted to a 404 error due to the '/dir' suffix, so i removed that.
