### PR TITLE
Fix a bug in p65 of 99 problems

### DIFF
--- a/site/learn/tutorials/99problems.md
+++ b/site/learn/tutorials/99problems.md
@@ -1613,7 +1613,7 @@ SOLUTION
 >        let l' = layout (depth + 1) (x_root - spacing) l
 >        and r' = layout (depth + 1) (x_root + spacing) r in
 >        N (x, x_root,depth, l',r') in
->   layout 1 ((1 lsl (tree_height - 1)) - translate_dst) t
+>   layout 1 ((1 lsl (tree_height - 1)) - (1 lsl translate_dst) + 1) t
 > ```
 
 ```ocamltop


### PR DESCRIPTION
Hi,
I think there is an error in this solution. For example, it cannot handle this tree correctly:

``` ocaml
let htree =
    let leaf x = Node (x,Empty,Empty) in
    Node('n', Empty,
         Node('u', Node('p', Empty, leaf 'q'), Empty));;
```

The correct answer should be:

``` ocaml
N (n, 1, 1, E, N (u, 5, 2, N (p, 3, 3, E, N (q, 4, 4, E, E)), E))
```

But the original solution gives:

``` ocaml
N (n, 5, 1, E, N (u, 9, 2, N (p, 7, 3, E, N (q, 8, 4, E, E)), E))
```
