### PR TITLE
Fix 'explicitely' typo.

### DIFF
--- a/site/learn/tutorials/objects.md
+++ b/site/learn/tutorials/objects.md
@@ -516,7 +516,7 @@ let o =
 ```
 This object has a type, which is defined by its public methods only.
 Values are not visible and neither are private methods (not shown).
-Unlike records, such a type does not need to be predefined explicitely,
+Unlike records, such a type does not need to be predefined explicitly,
 but doing so can make things clearer. We can do it like this:
 
 ```ocamltop

--- a/site/learn/tutorials/ocamlbuild/A_plugin_example_for_compiling_LaTeX.md
+++ b/site/learn/tutorials/ocamlbuild/A_plugin_example_for_compiling_LaTeX.md
@@ -7,7 +7,7 @@ pdfLaTeX, MakeIndex, HeVeA \(both monolithic html and html by chapter via
 HaChA\) and Pgf/TikZ picture extraction to PNG for the html versions.
 However as the plugin below it assumes that LaTeX will converge in two
 iterations for the PDF and the master tex file chapter dependencies must
-be explicitely stated.
+be explicitly stated.
 
 See the example below using beautiful syntax highlighting
 [here](http://gallium.inria.fr/~pouillar/ocamlbuild/plugin_example.html).

--- a/site/learn/tutorials/ocamlbuild/Compiling_C_with_gcc.md
+++ b/site/learn/tutorials/ocamlbuild/Compiling_C_with_gcc.md
@@ -7,7 +7,7 @@ don't need to specify anything particular to build simple executables.
 Another approach is to use the
 [ocamlbuild-ctools](http://dvide.com/labs/ocamlbuild-ctools) plugin
 which provides support for both `gcc` and the MSVC tool chain, but
-you'll have to explicitely list object files to link your executables.
+you'll have to explicitly list object files to link your executables.
 
 The example uses `avr-gcc` to produce `%.elf` executables for
 microcontrollers, but it's just a matter of substituting `avr-gcc` with

--- a/site/learn/tutorials/pointers.md
+++ b/site/learn/tutorials/pointers.md
@@ -6,7 +6,7 @@
 
 ## Status of pointers in OCaml
 Pointers exist in OCaml, and in fact they spread all over the place.
-They are used either implicitely (in the most cases), or explicitely (in
+They are used either implicitly (in the most cases), or explicitly (in
 the rare occasions where implicit pointers are not more handy). The vast
 majority of pointers usages that are found in usual programming
 languages simply disappear in OCaml, or more exactly, those pointers are
@@ -229,7 +229,7 @@ contains the concatenation of the two lists `l1` and `l2`, thus the list
 `l1` no longer exists: in some sense `append` *consumes* its first
 argument. In other words, the value of a list data now depends on its
 history, that is on the sequence of function calls that use the value.
-This strange behaviour leads to a lot of difficulties when explicitely
+This strange behaviour leads to a lot of difficulties when explicitly
 manipulating pointers. Try for instance, the seemingly harmless:
 
 ```ocamltop


### PR DESCRIPTION
I was reading the pointer guide and noticed "explicitely" in a few places instead of "explicitly", here's a patch that removes all occurrences of the former :smile:
