### PR TITLE
Gtk tutorial updates

### DIFF
--- a/site/learn/tutorials/introduction_to_gtk.md
+++ b/site/learn/tutorials/introduction_to_gtk.md
@@ -43,6 +43,8 @@ and a button in the main area which you can press:
 open GMain
 open GdkKeysyms
 
+let locale = GtkMain.Main.init ()
+
 let main () =
   let window = GWindow.window ~width:320 ~height:240
                               ~title:"Simple lablgtk program" () in

--- a/site/learn/tutorials/introduction_to_gtk.md
+++ b/site/learn/tutorials/introduction_to_gtk.md
@@ -18,7 +18,7 @@ Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH");;
 
 [Gtk+](http://www.gtk.org/ "http://www.gtk.org/") is a toolkit for
 writing graphical applications, and
-[lablgtk](http://wwwfun.kurims.kyoto-u.ac.jp/soft/olabl/lablgtk.html "http://wwwfun.kurims.kyoto-u.ac.jp/soft/olabl/lablgtk.html")
+[lablgtk](http://lablgtk.forge.ocamlcore.org/ "http://lablgtk.forge.ocamlcore.org/")
 is the OCaml interface for Gtk. Gtk and lablgtk are available for Unix
 and Windows platforms.
 

--- a/site/learn/tutorials/introduction_to_gtk.md
+++ b/site/learn/tutorials/introduction_to_gtk.md
@@ -20,13 +20,7 @@ Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH");;
 writing graphical applications, and
 [lablgtk](http://wwwfun.kurims.kyoto-u.ac.jp/soft/olabl/lablgtk.html "http://wwwfun.kurims.kyoto-u.ac.jp/soft/olabl/lablgtk.html")
 is the OCaml interface for Gtk. Gtk and lablgtk are available for Unix
-and Windows platforms. In this tutorial I'm going to concentrate on the
-older but more stable Gtk version 1.2. Gtk 2.x has some
-incompatibilities with Gtk 1.2, although mostly you won't notice the
-difference. On Windows, Gtk 1.2 has a non-native look and feel, but this
-is corrected in Gtk 2.x by the use of
-[Gtk-Wimp](http://gtk-wimp.sourceforge.net/ "http://gtk-wimp.sourceforge.net/")
-(a Windows native theme for Gtk).
+and Windows platforms.
 
 Lablgtk makes ambitious use of advanced features of the OCaml type
 system. Make sure you're familiar with labelled and optional arguments


### PR DESCRIPTION
Example program used to segfault because of missing GtkMain.Main.init call.
Removed references to obsolete Gtk 1.2. Examples seem to work well in Gtk2.
Replaced the old lablgtk link with an OCaml Forge link, the original website is obsolete it seems.
