### PR TITLE
FAQ and tutorials cleanup

### DIFF
--- a/site/learn/faq.md
+++ b/site/learn/faq.md
@@ -6,6 +6,71 @@ which is widely used by the OCaml community.
 
 *Table of contents*
 
+## General Questions
+#### What is OCaml?
+
+OCaml is a programming language. It is a functional language, since the
+basic units of programs are functions. It is a strongly-typed language;
+it means that the objects that you use belong to a set that has a name,
+called its type. In OCaml, types are managed by the computer, the user
+has nothing to do about types (types are synthesized). The language is
+available on almost every Unix platform (including Linux and MacOS X)
+and on PCs under Windows. A brief tour on main
+[features](description.html) of OCaml.
+
+#### Under what licensing terms is the OCaml software available?
+
+The OCaml system is open source software: the compiler is distributed
+under the terms of the Q Public License, and its library is under LGPL;
+please read the [license](/docs/license.html) document for more details. A
+BSD-style license is also available for a fee through the [OCaml
+Consortium](/community/support.html#consortium).
+
+#### What is the meaning of the name “OCaml”
+
+CAML once was an acronym that stood for “Categorical Abstract Machine
+Language”, an abstract machine its early versions targeted. The evaluation model
+has changed since then, but the name stuck.
+
+The “O” stands for “objective” and was added when the language got object-oriented
+programming capabilities.
+
+#### Do you write “Caml” or “CAML”, “OCaml”, “Ocaml” or “OCAML”?
+
+We write OCaml.
+According to usual rules for acronyms, we should write CAML, as we
+write USA. On the other hand, this upper case name seems to yell all
+over the place, and writing OCaml is far more pretty and elegant — with
+“O” and “C” capitalized.
+
+#### Is OCaml a compiled or interpreted language?
+
+OCaml is compiled. However, the OCaml compiler offers a top-level
+interactive loop, that is similar to an interpreter. In fact, in the
+interactive system, the user may type in program chunks (we call these
+pieces OCaml “phrases”) that the system handles at once, compiling them,
+executing them, and writing their results.
+
+#### What are the differences between Caml V3.1, Caml Light, and OCaml?
+
+These are different Caml implementations that have been developed
+successively at Inria. These systems share many features since they all
+implement the core of the OCaml language; so the basic syntax is nearly
+the same. However, all these systems have their own extensions to the
+Caml core language.<br />
+Caml V3.1 is no longer maintained nor distributed. [Caml
+Light](../caml-light/) is no longer developed, but still maintained.
+Because of its stable status, it is actively used in education. Most
+other users have switched to OCaml, the latest variant of the language.
+This is the version we suggest using in new software developments. See
+our brief [history](history.html) of the OCaml language.
+
+#### How to report a bug in the compilers?
+
+Use the [bug tracking system](http://caml.inria.fr/mantis/) to browse
+bug reports and features request, and submit new ones.
+
+
 ## Core Language
 * * *
 
@@ -526,75 +591,6 @@ functions from the `format` module, it is considered good programming
 habit to open `format` globally in order to completely mask low level
 printing functions by the high level printing functions provided by
 `format`.
-
-## General Questions
-#### What is OCaml?
-
-OCaml is a programming language. It is a functional language, since the
-basic units of programs are functions. It is a strongly-typed language;
-it means that the objects that you use belong to a set that has a name,
-called its type. In OCaml, types are managed by the computer, the user
-has nothing to do about types (types are synthesized). The language is
-available on almost every Unix platform (including Linux and MacOS X)
-and on PCs under Windows. A brief tour on main
-[features](description.html) of OCaml.
-
-#### Under what licensing terms is the OCaml software available?
-
-The OCaml system is open source software: the compiler is distributed
-under the terms of the Q Public License, and its library is under LGPL;
-please read the [license](/docs/license.html) document for more details. A
-BSD-style license is also available for a fee through the [OCaml
-Consortium](/community/support.html#consortium).
-
-#### What is the meaning of the name “OCaml”
-
-“Caml” is an acronym: it stands for “Categorical Abstract Machine
-Language”. The “Categorical Abstract Machine” is an abstract machine to
-define and execute functions. It is issued from theoretical
-considerations on the relationship between category theory and
-lambda-calculus. The first Caml compiler produced code for this abstract
-machine (in 1984). The “O” stands for “Objective” and was added after
-object oriented features were available in the language.<br />
- In addition, OCaml is issued from the ML programming language, designed
-by Robin Milner in 1978, and used as the programming language to write
-the “proof tactics” in the LCF proof system.
-
-#### Do you write “Caml” or “CAML”, “OCaml”, “Ocaml” or “OCAML”?
-
-We write OCaml.
-According to usual rules for acronyms, we should write CAML, as we
-write USA. On the other hand, this upper case name seems to yell all
-over the place, and writing OCaml is far more pretty and elegant — with
-“O” and “C” capitalized.
-
-#### Is OCaml a compiled or interpreted language?
-
-OCaml is compiled. However each OCaml compiler offers a top-level
-interactive loop, that is similar to an interpreter. In fact, in the
-interactive system, the user may type in program chunks (we call these
-pieces OCaml “phrases”) that the system handles at once, compiling them,
-executing them, and writing their results.
-
-#### What are the differences between Caml V3.1, Caml Light, and OCaml?
-
-These are different Caml implementations that have been developed
-successively at Inria. These systems share many features since they all
-implement the core of the OCaml language; so the basic syntax is nearly
-the same. However, all these systems have their own extensions to the
-Caml core language.<br />
- Caml V3.1 is no longer maintained nor distributed. [Caml
-Light](../caml-light/) is no longer developed, but still maintained.
-Because of its stable status, it is actively used in education. Most
-other users have switched to OCaml, the latest variant of the language.
-This is the version we suggest using in new software developments. See
-our brief [history](history.html) of the OCaml language.
-
-#### How to report a bug in the compilers?
-
-Use the [bug tracking system](http://caml.inria.fr/mantis/) to browse
-bug reports and features request, and submit new ones.
-
 
 ## Module Language
 

--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -23,7 +23,7 @@ automatically.
 In this section, we will first see how to compile a simple program using
 only ocamlc or ocamlopt. Then we will see how to use libraries and how
 to take advantage of the
-[findlib](http://www.camlcity.org/archive/programming/findlib.html)
+[findlib](http://projects.camlcity.org/projects/findlib.html)
 system, which provides the `ocamlfind` command.
 
 ###  `ocamlc` and `ocamlopt`

--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -143,3 +143,4 @@ necessary. See next section.
 
 - [GNU make](compiling_with_gnu_make.html)
 - [OMake](compiling_with_omake.html)
+- [Oasis](setting_up_with_oasis.html)

--- a/site/learn/tutorials/index.md
+++ b/site/learn/tutorials/index.md
@@ -88,11 +88,6 @@ tracker there to request or offer new tutorials. Thanks!
  computation](http://www.southampton.ac.uk/~fangohr/software/ocamltutorial/)
  (by Thomas Fiscbacher), covers a broad sample of OCaml, from the
  basics to the C api.
-* [A Concise Introduction to
- OCaml](http://www.csc.villanova.edu/~dmatusze/resources/ocaml/ocaml.html)
- (by David Matuszek) gives a concise, yet broad, overview of the
- language and the standard library. It is rather old but most of what
- it says remains valid.
 
 ###  WikiBooks on OCaml
 
@@ -110,9 +105,6 @@ tools and libraries.
 * [Camlp4
  Tutorial](http://ambassadortothecomputers.blogspot.com/p/reading-camlp4.html)
  (by Jake Donham), to build syntax extensions for OCaml with Camlp4.
-* [Camlp4
- Tutorial](http://brion.inria.fr/gallium/index.php/Syntax_extension_tutorial),
- to build syntax extensions for OCaml with Camlp4.
 * [OCamllex
  Tutorial](http://plus.kaist.ac.kr/~shoh/ocaml/ocamllex-ocamlyacc/ocamllex-tutorial/)
  (by SooHyoung Oh), on how to create lexers using the `ocamllex` tool
@@ -126,6 +118,8 @@ tools and libraries.
  (by SooHyoung Oh), on how to create graphical applications with the
  LablGTK library.
 * [Camlp5](camlp5.html)
+* [A Guide to Extension Points in OCaml](http://whitequark.org/blog/2014/04/16/a-guide-to-extension-points-in-ocaml/)
+  (by whitequark), on using PPX, the syntax extensions API that superseded camlp4.
 
 ###  Coming From Another Language
 
@@ -134,11 +128,10 @@ with another language.
 
 * [Beyond functional programming in Haskell: an introduction to
  OCaml](http://www.cs.uu.nl/wiki/pub/Stc/BeyondFunctionalProgrammingInHaskell:AnIntroductionToOCaml/ocaml.pdf)
+* [OCaml for Haskellers](http://blog.ezyang.com/2010/10/ocaml-for-haskellers/)
 
 ###  Advanced Tutorials & Articles
 
 * [Manual](http://caml.inria.fr/pub/docs/manual-ocaml/)
-* [Using, Understanding, and Unraveling The OCaml
- Language](http://caml.inria.fr/pub/docs/u3-ocaml/index.html), *From
- Practice to Theory and vice versa*, by Didier Rémy.
-* [Functional Unparsing](http://www.brics.dk/RS/98/12/)
+* [Detecting use cases for GADTs in OCaml](http://mads-hartmann.com/ocaml/2015/01/05/gadt-ocaml.html),
+  (by Mads Hartmann), on using generalized algebraic data types in writing interpreters.


### PR DESCRIPTION
These changes are quite opinionated. If you don't agree with some of them, I'll exclude them from the pull request.

The FAQ: soft questions like licensing and name capitalization placed after heavy technical questions look a bit odd, as of me. Also, rephrased the name meaning paragraph to make it clear that the original meaning is now irrelevant.

The compliation tutorial: since many people are going to use Oasis at some point, a pointer to it is useful I guess.

The tutorial list:
- Removed the Functional Unparsing paper reference. Excellent paper, but the code is in SML and the Printf module makes it of little practical interest for most people. :)
- Removed a dead link to a camlp4 tutorial (brion.inria.fr/gallium/index.php/Syntax_extension_tutorial)
- Removed the link to Understanding and Unraveling OCaml, since it's already in the books section.
- Removed the link to "A Concise Introduction to OCaml". It's indeed mostly valid, but it contains odd things like the SML syntax for loading files into the REPL, inaccurate references (Ullman's book is about SML, not CAML), and assertions that OCaml is purely functional, despite allowing side effects. People searching for tutorials will probably be confused, and since it's over 15 years old, it's unlikely we can convince the author to update it.
- Added references to PPX and GADT tutorials.

The book list:
- Removed the reference to the "Think OCaml" book. In its current state it will confuse beginners more than help them, since it's an incomplete translation of a Python book to OCaml: Python code snippets here and there, missing sections etc., and it probably leaves a wrong impression about the language as it pays very little attention to topics like data types and pattern matching and makes no mention of the module system at all, essentially teaching OCaml like it's Python. I hope the authors complete it some day.
