### PR TITLE
tutorial/Basics: advertise utop more prominently

### DIFF
--- a/site/learn/tutorials/basics.md
+++ b/site/learn/tutorials/basics.md
@@ -8,18 +8,31 @@
 
 The easiest way to get started is to run an interactive session in your browser, at <http://try.ocamlpro.com/>.
 
-To test things on your own computer, run the `ocaml` command and enter statements in the standard REPL (Read–Eval–Print Loop) provided.
+To install OCaml on your computer, see the [Install](/docs/install.html) documentation.
+
+To quickly try small OCaml expressions, you can use a toplevel, or REPL (Read–Eval–Print Loop). The `ocaml` command provides a very basic toplevel (you should install `rlwrap` through your system package manager and run `rlwrap ocaml` to get history navigation). If you can install it through [OPAM](/docs/install.html#OPAM) or your system package manger, we recommend the use of the [utop](https://github.com/diml/utop) toplevel instead, which has the same basic interface but is much more convenient to use (history navigation, auto-completion, etc.).
+
 Use `;;` to indicate that you've finished entering each statement:
 
-```shell
+```console
 $ ocaml
-        OCaml version 4.01.0
+        OCaml version 4.02.3
 
 # 1+1;;
 - : int = 2
 ```
 
-The `ocaml` interpreter is very basic; install and run [utop][] for an extended REPL.
+```console
+───────┬────────────────────────────────────────────────────────────┬─────
+       │ Welcome to utop version 1.18 (using OCaml version 4.02.3)! │     
+       └────────────────────────────────────────────────────────────┘     
+
+Type #utop_help for help about using utop.
+
+─( 10:12:16 )─< command 0 >───────────────────────────────────────────────
+utop # 1 + 1;;
+- : int = 2
+```
 
 To compile an OCaml program named `my_prog.ml` to a native executable, use `ocamlbuild my_prog.native`:
 


### PR DESCRIPTION
This proposed  change comes from the discussion in ocaml/ocaml#241 , where @jwatzman points out that `utop` does not have enough visibility in the "Basics" tutorial -- it is mentioned, but maybe it should be emphasized more.

It is hard to be informative yet concise enough: I realize this Basics tutorial is the first approach of OCaml content, so it should be to the point and should not drown the reader in pointless distinctions. Maybe the utop can be made more visible (than the previous mention) but more concise (than this proposed change).

We may need to differentiate better between a page that would be "a tour of the language" (let me show you why you should care, without necessarily having you run code) and "basic setup if you know you want to use". Currently the Basics tutorial tries to do both and it is non-optimal at them both.

For reference to the Install page, I used full URLs instead of relative navigation. Is there a preferred way?
