### PR TITLE
Fix error in section on mutual recursion

### DIFF
--- a/site/learn/faq.md
+++ b/site/learn/faq.md
@@ -287,11 +287,11 @@ Functions may be mutually recursive:
 
 ```ocamltop
 let rec odd n =
-  if n = 0 then true
-  else if n = 1 then false else even (n - 1)
-and even n =
   if n = 0 then false
-  else if n = 1 then true else odd (n - 1);;
+  else if n = 1 then true else even (n - 1)
+and even n =
+  if n = 0 then true
+  else if n = 1 then false else odd (n - 1);;
 ```
 
 #### How to apply a function?


### PR DESCRIPTION
The code illustrating mutual recursion to determine parity returned incorrect values. As given, `even 5` returned true and `odd 5` returned false.
