### PR TITLE
Fix typo in C/C++ comparison

### DIFF
--- a/site/learn/tutorials/hashtbl.md
+++ b/site/learn/tutorials/hashtbl.md
@@ -84,7 +84,7 @@ Hashtbl.find my_hash "t"
 
 
 To find out whether there is an
-entry in the `my_hash` for a letter we would do:
+entry in `my_hash` for a letter we would do:
 
 ```ocamltop
 Hashtbl.mem my_hash "h"

--- a/site/learn/tutorials/hashtbl.md
+++ b/site/learn/tutorials/hashtbl.md
@@ -45,14 +45,16 @@ Hashtbl.add my_hash "w" "world";
 Hashtbl.add my_hash "w" "wine";;
 ```
 If we want to find one element in `my_hash` that has an `"h"` in it then we
-would write. Notice how it only returns just one element? That element
-was the last one entered in with the value of `"h"`.
+would write: 
 
 ```ocamltop 
 Hashtbl.find my_hash "h"
 ```
+Notice how it returns just one element? That element
+was the last one entered in with the value of `"h"`.
+
 What we probably want is all the elements that start with `"h"`. To do
-this we want to find all of them. What better name for this then
+this we want to *find all* of them. What better name for this then
 `find_all`?
 
 ```ocamltop

--- a/site/learn/tutorials/structure_of_ocaml_programs.md
+++ b/site/learn/tutorials/structure_of_ocaml_programs.md
@@ -150,7 +150,7 @@ C/C++
 ```C
 int a = 0; int *my_ptr = &a;
 *my_ptr = 100;
-*my_ptr
+*my_ptr;
 ```
 References have their place, but you may find that you don't use
 references very often. Much more often you'll be using


### PR DESCRIPTION
Example C expression lacked trailing semicolon
