### PR TITLE
Fix typos, change style

### DIFF
--- a/site/learn/tutorials/pointers.md
+++ b/site/learn/tutorials/pointers.md
@@ -10,16 +10,16 @@ They are used either implicitly (in the most cases), or explicitly (in
 the rare occasions where implicit pointers are not more handy). The vast
 majority of pointers usages that are found in usual programming
 languages simply disappear in OCaml, or more exactly, those pointers are
-totally automatically handled by the compiler and the OCaml programmer
-can safely just ignore their existence, focusing on the semantic of its
+totally automatically handled by the compiler. Thus, the OCaml programmer
+can safely ignore the existence of pointers, focusing on the semantics of their
 program.<br />
- For instance lists or trees are defined without explicit pointers using
+ For instance, lists or trees are defined without explicit pointers using
 a concrete datatype definition. The underlying implementation uses
 pointers, but this is hidden from the programmer since pointer
 handling is done by the compiler.
 
 In the rare occasions where explicit pointers are needed (the most
-common case is when translating in OCaml an algorithm described in a
+common case is when translating into OCaml an algorithm described in a
 classic imperative language), OCaml provides references that are
 full-fledged pointers, even first class citizen pointers (references can
 be passed as argument, embedded into arbitrary data structures, and
@@ -157,7 +157,7 @@ let ( ^:= ) p v =
   | Null -> invalid_arg "Attempt to assign the null pointer"
   | Pointer r -> r := v;;
 ```
-Now we define the allocation of a new pointer initialized to points to a
+Now we define the allocation of a new pointer initialized to point to a
 given value:
 
 ```ocamltop


### PR DESCRIPTION
- Removes superfluous "just"
- "semantic" -> "semantics"
- Stylistic change. Splits sentence to avoid referring to pointers with "their" and the developer with "it". That combination is confusing in my opinion.
- Adds missing comma
- "in" -> "into"
- "points" -> "point"
