### PR TITLE
Discourage use of 4.02.0

### DIFF
--- a/site/releases/index.md
+++ b/site/releases/index.md
@@ -7,7 +7,8 @@ Official releases of OCaml occur about once per year.
 * OCaml [4.02.3](4.02.html), released Jul 27, 2015.
 * OCaml [4.02.2](4.02.html), released Jun 17, 2015.
 * OCaml [4.02.1](4.02.html), released Oct 14, 2014.
-* OCaml [4.02.0](4.02.html), released Aug 29, 2014.
+* OCaml [4.02.0](4.02.html), released Aug 29, 2014.  
+      (4.02.0 suffers from one known bug that noticeably increases compilation time, you should use 4.02.1 or later versions instead.)
 * OCaml [4.01.0](4.01.0.html), released Sep 12, 2013.
 * OCaml [4.00.1](4.00.1.html), released Oct 5, 2012.
 * OCaml [3.12.1](3.12.1.html), released July 4, 2011.


### PR DESCRIPTION
Hugo Herbelin ( @herbelin ) reports that he mistakenly tried 4.02.0 and observed massive Coq compilation times. I'm trying to update the web-facing information to avoid users getting caught like this.
