### PR TITLE
Style fix for overlapping content with pre within blockquote

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -85,6 +85,7 @@ table.expanding_include_4, table.expanding_include_5, table.expanding_include_6 
 
 /* FIXME: OCaml code should be in <pre> with a distinct class? */
 pre { line-height: 135%; }
+blockquote pre { margin-top: 10px }  /* better styling for quoted code pieces */
 code, .gutter pre {
   font-family: "Droid Sans Mono", Consolas, monospace;
 }


### PR DESCRIPTION
Before:
![image 2015-12-06 at 9 49 31 pm](https://cloud.githubusercontent.com/assets/7809/11618142/fbb52fbe-9c64-11e5-8ffb-6d38b48cd0f8.png)

After:
![image 2015-12-06 at 9 54 57 pm](https://cloud.githubusercontent.com/assets/7809/11618136/e982a5ec-9c64-11e5-9594-31b43e5fe525.png)
