### PR TITLE
Wrong LGPL clause number referenced in exception

### DIFF
--- a/site/docs/license.md
+++ b/site/docs/license.md
@@ -67,7 +67,7 @@ additional requirements listed in clause 6 of the GNU Library General
 Public License.  By "a publicly distributed version of the Library",
 we mean either the unmodified Library as distributed by Inria, or a
 modified version of the Library that is distributed under the
-conditions defined in clause 3 of the GNU Library General Public
+conditions defined in clause 2 of the GNU Library General Public
 License.  This exception does not however invalidate any other reasons
 why the executable file might be covered by the GNU Library General
 Public License.


### PR DESCRIPTION
Hi,
The clause number referenced in the exception is apparently wrong
See
https://github.com/ocaml/ocaml/commit/2d26308ad4d34ea0c00e44db62c4c24c7031c78c#diff-9879d6db96fd29134fc802214163b95a
(same problem on Inria's website : http://caml.inria.fr/ocaml/license.en.html )
Have a nice day,
Camille
