### PR TITLE
Add dsheets to about page and re-add Anil

### DIFF
--- a/site/about.md
+++ b/site/about.md
@@ -38,6 +38,8 @@ infrastructure and tooling for the site. At the time of writing, the
 - [Amir Chaudhry](http://amirchaudhry.com)
 - [Louis Gesbert](http://github.com/AltGr/)
 - [Fabrice Le Fessant](http://www.lefessant.net/)
+- [Anil Madhavapeddy](http://anil.recoil.org)
+- [David Sheets](https://github.com/dsheets)
 - [Christophe Troestler](https://github.com/Chris00)
 - [Philippe Wang](http://philippewang.info/CL/)
 


### PR DESCRIPTION
Anil maintains the machine that the site is actually served from, hence he's part of the 'www project'.
David also has access to that machine and merges PRs, hence should be on this list too.

Related to #754 
