### PR TITLE
Update simple typo.

### DIFF
--- a/site/learn/tutorials/basics.md
+++ b/site/learn/tutorials/basics.md
@@ -146,7 +146,7 @@ repeated ("hello", 3)     (* OCaml will spot the mistake *)
 ```
 
 ## Defining a function
-You all know how to define a function (or static method, for Java-heads)
+We all know how to define a function (or static method, for Java-heads)
 in our existing languages. How do we do it in OCaml?
 
 The OCaml syntax is pleasantly concise. Here's a function which takes


### PR DESCRIPTION
Either:
"**We** all know how to define a function (or static method, for Java-heads) in **our** existing languages"
or:
"**You** all know how to define a function (or static method, for Java-heads) in **your** existing languages"

sound better. I vote for the former since it's more friendly. =)
