### PR TITLE
Remove the link to the interactive session at OCamlPro's website

### DIFF
--- a/site/learn/tutorials/basics.md
+++ b/site/learn/tutorials/basics.md
@@ -6,8 +6,6 @@
 
 ## Running OCaml code
 
-The easiest way to get started is to run an interactive session in your browser, at <http://try.ocamlpro.com/>.
-
 To install OCaml on your computer, see the [Install](/docs/install.html) documentation.
 
 To quickly try small OCaml expressions, you can use a toplevel, or REPL (Read–Eval–Print Loop). The `ocaml` command provides a very basic toplevel (you should install `rlwrap` through your system package manager and run `rlwrap ocaml` to get history navigation). If you can install it through [OPAM](/docs/install.html#OPAM) or your system package manger, we recommend the use of the [utop](https://github.com/diml/utop) toplevel instead, which has the same basic interface but is much more convenient to use (history navigation, auto-completion, etc.).


### PR DESCRIPTION
FWIW: as a newbie, I found it much harder to work with that interactive demo and learn OCaml as it is both out-dated ([28 issues](https://github.com/OCamlPro/tryocaml/issues) and [5 PRs](https://github.com/OCamlPro/tryocaml/pulls) still open waiting to be fixed/merged) and not being actively maintained (`Latest commit ddd533d  on Feb 24, 2015`).
