### PR TITLE
releases: reformulate 'latest' handling

### DIFF
--- a/site/releases/index.md
+++ b/site/releases/index.md
@@ -1,12 +1,14 @@
 <!-- ((! set title Releases !)) ((! set releases !)) -->
 
 #Releases
-Here's a list of all OCaml releases. See also the
-[install](/docs/install.html) page for instructions on installing
-OCaml by other means, such as the OPAM package manager and platform
-specific package managers.
 
-* OCaml [latest](latest/)
+The [latest](latest/) page points to the most recent release of the
+OCaml compiler distribution. Below is a list of the recent releases.
+
+See also the [install](/docs/install.html) page for instructions on
+installing OCaml by other means, such as the OPAM package manager and
+platform specific package managers.
+
 * OCaml [4.03.0](4.03.html), released Apr 25, 2016.
 * OCaml [4.02.3](4.02.html), released Jul 27, 2015.
 * OCaml [4.02.2](4.02.html), released Jun 17, 2015.


### PR DESCRIPTION
I found having an explicit list item "latest", followed by another item "4.03.0", was a bit awkward. What do you think?
