### PR TITLE
FAQ: clarify section on mutually recursive functors

### DIFF
--- a/site/learn/faq.md
+++ b/site/learn/faq.md
@@ -594,12 +594,31 @@ printing functions by the high level printing functions provided by
 
 ## Module Language
 
-#### Can I have two mutually recursive compilation units / structures / signatures / functors?
+#### Can I have two mutually recursive structures, signatures, functors?
 
-Currently not in the stable langage. However there exists an [OCaml
-extension](http://caml.inria.fr/pub/docs/manual-ocaml/extn.html#sec220)
-(which is subject to change or removal at any time) which addresses some
-of these problems.
+Yes, but they cannot be toplevel, and structures always have to have 
+an explcit signature. Recursive structures may be defined as follows:
+
+```ocamltop
+module rec A : sig
+  type a = { x: int }
+end = struct
+  type a = { x: int }
+  let b : B.b = { y = 1.0 }
+end and B : sig
+  type b = { y: float }
+end = struct
+  type b = { y: float }
+  let a : A.a = { x = 1 }
+end
+```
+
+In a similar way, mutually recursive signatures and functors can also
+be defined.
+
+Note that recursive compilation units are not possible: the toplevel
+structures and signatures corresponding to `.ml`/`.mli` files cannot
+have loops in the dependency graph.
 
 #### How do I express sharing constraints between modules?
 

--- a/site/learn/faq.md
+++ b/site/learn/faq.md
@@ -594,10 +594,10 @@ printing functions by the high level printing functions provided by
 
 ## Module Language
 
-#### Can I have two mutually recursive structures, signatures, functors?
+#### Can I have two mutually recursive structures, signatures, functors inside a single compilation unit?
 
-Yes, but they cannot be toplevel, and structures always have to have 
-an explcit signature. Recursive structures may be defined as follows:
+Yes, but structures always have to have  an explcit signature. 
+Recursive structures may be defined as follows:
 
 ```ocamltop
 module rec A : sig
@@ -616,9 +616,36 @@ end
 In a similar way, mutually recursive signatures and functors can also
 be defined.
 
-Note that recursive compilation units are not possible: the toplevel
-structures and signatures corresponding to `.ml`/`.mli` files cannot
-have loops in the dependency graph.
+#### Can I have two mutually recursive compilation units?
+
+With any two compilation units (`.ml` or `.mli` files), there must always
+exist an order in which it is possible to compile them sequentially.
+This precludes most kinds of recursion between compilation units.
+
+However, two implementations can be recursive on types by exporting abstract
+versions of the types in the interfaces, with the manifest versions in 
+the implementations referring to the actual types.
+
+For example, consider these `x.ml`/`x.mli` files:
+
+```ocamltop
+type a (* only in x.ml: *) = Y.a
+type b =
+| BNone
+| BOne of a
+```
+
+and `y.ml`/`y.mli` files:
+
+```ocamltop
+type b (* only in y.ml: *) = X.b
+type a =
+| ANone
+| AOne of b
+```
+
+In this way, cooperation between the `X` and `Y` modules allows 
+the recursive value `X.BOne (Y.AOne (X.BOne ...))` to be produced.
 
 #### How do I express sharing constraints between modules?
 


### PR DESCRIPTION
It referred to the entire chapter 7 as "subject to change at any time", which is
just meaningless FUD, and did not give a good example.

Oh, and the link was broken, because the anchor order was changed and
this wasn't even pointing at the recursive modules section (which prompted
me to inline the example).
