### PR TITLE
FAQ: remove odd FIXME

### DIFF
--- a/site/learn/faq.md
+++ b/site/learn/faq.md
@@ -565,8 +565,6 @@ let f (o : < g : 'a. 'a -> 'a >) x y = o#g x, o#g y;;
 type id = { g : 'a. 'a -> 'a };;
 let f r x y = r.g x, r.g y;;
 ```
-FIXME: A direct way now exists.
-
 
 ###  Input/output
 


### PR DESCRIPTION
Per discussion on `#ocaml` on irc.freenode.net it does not seem that a more direct way exists.
Both of these fail to typecheck:
- `let f g = let h: type a. a -> a = g in h x, h y;;`
- `let f g = let h: 'a . 'a -> 'a = g in h x, h y;;`
