### PR TITLE
Add OCaml Labs blog to the planet feed list

### DIFF
--- a/planet_feeds.txt
+++ b/planet_feeds.txt
@@ -47,6 +47,7 @@ Mindy Preston|http://www.somerandomidiot.com/blog/categories/ocaml/atom.xml
 Mike Lin|http://www.blogger.com/feeds/3693082774051755513/posts/default/-/OCaml
 Mike McClurg|http://mcclurmc.wordpress.com/feed/
 OCaml Book|http://ocaml-book.com/blog?format=rss
+OCaml Labs|https://ocaml.io/index.php?title=Blog:News&feed=rss
 OCaml Labs compiler hacking|http://ocamllabs.github.com/compiler-hacking/rss.xml
 OCamlCore Forge News|http://forge.ocamlcore.org/export/rss20_news.php
 OCamlCore Forge Projects|http://forge.ocamlcore.org/export/rss20_projects.php


### PR DESCRIPTION
Blog name: OCaml Labs
URL: https://ocaml.io/index.php?title=Blog:News&feed=rss
Personal/institutional: institutional
