### PR TITLE
Update the information on the OCaml MOOC

### DIFF
--- a/site/index.md
+++ b/site/index.md
@@ -94,10 +94,10 @@
 
                         <li class="announcement"><article>
 			  <h1><a title="MOOC OCaml (Online Course)"
-			       href="https://www.france-universite-numerique-mooc.fr/courses/parisdiderot/56002/session01/about">MOOC OCaml (Online Course)</a></h1>
-			  <p>October 19, 2015</p>
+			       href="https://www.fun-mooc.fr/courses/parisdiderot/56002S02/session02/about">MOOC OCaml (Online Course)</a></h1>
+			  <p>September 26, 2016 - <a title="Registration for the OCaml MOOC" href="https://www.fun-mooc.fr/courses/parisdiderot/56002S02/session02/about">register now!</a></p>
 			  <a title="MOOC OCaml (Online Course)"
-			     href="https://www.france-universite-numerique-mooc.fr/courses/parisdiderot/56002/session01/about">
+			     href="https://www.fun-mooc.fr/courses/parisdiderot/56002S02/session02/about">
 			    <img alt="" src="/img/announcement.svg" class="svg" />
 			    <img alt="" src="/img/announcement.png" class="png" />
 			  </a>

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -36,6 +36,20 @@
             </footer>
         </section>
         <section class="span4 condensed">
+            <h1 class="ruled"><a href="tutorials/">Online courses</a> &amp; <a href="faq.html">FAQ</a></h1>
+	  <p class="documentation-video video16-9"
+	     style="padding-bottom: 50%"><!-- Adjust => avoid horiz bars -->
+	    <iframe src="https://www.dailymotion.com/video/x2ymo3x_fun-mooc-introduction-to-functional-programming-in-ocaml_school"
+		    frameborder="0" webkitallowfullscreen
+		    mozallowfullscreen allowfullscreen></iframe>
+	  </p>
+          The first MOOC entirely centered around OCaml is now online.
+          Learn more, and register <a href="https://www.france-universite-numerique-mooc.fr/courses/parisdiderot/56002/session01/about"> on the FUN platform </a>
+            <footer>
+                <p>more to come...</p>
+            </footer>
+        </section>
+        <section class="span4 condensed">
             <h1 class="ruled"><a href="tutorials/">Tutorials</a> &amp; <a href="faq.html">FAQ</a></h1>
             <ul>
                 <li><a href="tutorials/basics.html">Basics</a></li>

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -36,20 +36,6 @@
             </footer>
         </section>
         <section class="span4 condensed">
-            <h1 class="ruled"><a href="tutorials/">Online courses</a> &amp; <a href="faq.html">FAQ</a></h1>
-	  <p class="documentation-video video16-9"
-	     style="padding-bottom: 50%"><!-- Adjust => avoid horiz bars -->
-	    <iframe src="https://www.dailymotion.com/video/x2ymo3x_fun-mooc-introduction-to-functional-programming-in-ocaml_school"
-		    frameborder="0" webkitallowfullscreen
-		    mozallowfullscreen allowfullscreen></iframe>
-	  </p>
-          The first MOOC entirely centered around OCaml is now online.
-          Learn more, and register <a href="https://www.france-universite-numerique-mooc.fr/courses/parisdiderot/56002/session01/about"> on the FUN platform </a>
-            <footer>
-                <p>more to come...</p>
-            </footer>
-        </section>
-        <section class="span4 condensed">
             <h1 class="ruled"><a href="tutorials/">Tutorials</a> &amp; <a href="faq.html">FAQ</a></h1>
             <ul>
                 <li><a href="tutorials/basics.html">Basics</a></li>
@@ -85,9 +71,14 @@
     </div>
     <div class="row">
         <section class="span4 condensed">
-          <h1 class="ruled"><a href="/community/media.html">Slides &amp; Videos</a></h1>
+          <h1 class="ruled"><a href="/community/media.html">Online Courses, Slides &amp; Videos</a></h1>
+
+<iframe frameborder="0" width="380" height="220" src="http://www.dailymotion.com/embed/video/x2ymo3x" allowfullscreen></iframe><br /><a href="http://www.dailymotion.com/video/x2ymo3x_fun-mooc-introduction-to-functional-programming-in-ocaml_school" target="_blank"> A massive open online course (MOOC) entirely centered around OCaml</a> <i>is now available, and runs once a year!</i>
+	  <p>
+          Learn more, and <a href="https://www.fun-mooc.fr/courses/parisdiderot/56002S02/session02/about">register now on the FUN platform!</a>
+	  </p>
 		  <p class="documentation-video" style="margin-bottom:0">
-<iframe src="//www.slideshare.net/slideshow/embed_code/43836300" width="340" height="290" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
+<iframe src="http://www.slideshare.net/slideshow/embed_code/43836300" width="340" height="290" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
           </p>
 
           <p>An invited talk by Xavier Leroy explaining the current state
@@ -101,7 +92,7 @@
 			</p>
 	  <p class="documentation-video video16-9"
 	     style="padding-bottom: 50%"><!-- Adjust => avoid horiz bars -->
-	    <iframe src="//player.vimeo.com/video/14313378?portrait=0&amp;color=ff9933"
+	    <iframe src="http://player.vimeo.com/video/14313378?portrait=0&amp;color=ff9933"
 		    frameborder="0" webkitallowfullscreen
 		    mozallowfullscreen allowfullscreen></iframe>
 	  </p>


### PR DESCRIPTION
The second session is now open for registration: added dates, fixed pointers in the event feed; also added largest blurb and video in the Learn page.
