### PR TITLE
Better mailing-lists page

### DIFF
--- a/site/community/mailing_lists.md
+++ b/site/community/mailing_lists.md
@@ -25,9 +25,14 @@ the subscribers of the list. Messages are generally in English but
 sometimes also in French. In 2010, the list has about 1500 subscribers,
 who exchange about 300 messages per month.
 
-[Subscribe](https://sympa.inria.fr/sympa/subscribe/caml-list) | [Inria
-Archives](https://sympa.inria.fr/sympa/arc/caml-list) | [Google Groups
-Archives](http://groups.google.com/groups?group=fa.caml)
+[Subscribe](https://sympa.inria.fr/sympa/subscribe/caml-list)
+|
+[Inria Archives](https://sympa.inria.fr/sympa/arc/caml-list)
+|
+[Gmane archives](http://news.gmane.org/gmane.comp.lang.caml.inria)
+
+The [OCaml Weekly News](alan.petitepomme.net/cwn/) also provides
+a curated summary of caml-list discussions.
 
 ### OCaml Beginners
 *ocaml_beginners AT yahoogroups.com*  

--- a/site/community/mailing_lists.md
+++ b/site/community/mailing_lists.md
@@ -71,6 +71,14 @@ ask, just ask, and be patient: not everyone is in the same timezone. The
 IRC Channel can be accessed through a web interface or any regular IRC
 client.
 
+Public channel logs are available at <http://irclog.whitequark.org/ocaml/>
+
+If you wish to use a web-based IRC client, you can use Freenode's
+webchat <https://webchat.freenode.net/>. For a fancier/nicer
+interface, you may try
+<https://vector.im/beta/#/room/#freenode_#ocaml:matrix.org> -- it
+requires registration but is otherwise free.
+
 ### IRC Channel - French
 *irc.freenode.net #ocaml-fr*  
 As above, but for French speakers.


### PR DESCRIPTION
This is a first step towards improving our "places where community discussions happen" information on ocaml.org, taking ideas from #699 and the recent [caml-list discussions](https://sympa.inria.fr/sympa/arc/caml-list/2016-07/msg00018.html).

The changes currently proposed only do the minimal thing, which is to add more information to the page https://ocaml.org/community/mailing_lists.html, reachable from the "Community" page by cliking the "see more lists" link. I think that the community page itself should be changed to de-emphasize Mailing-lists and instead present "Discussion places" (including mailing-list, IRC, and maybe in the future some shiny 4.0 discussion with beginner questions and virtual reality pokemons or something).

I'm frustrated by the choice of presenting only a subset of the options on the Community page; I'm tempted to remove caml-annouce and lists.ocaml.org and replace them by the IRC channel and, for example, Caml Weekly News -- because subjectively they feel more important for the frontpage space. But I wonder if we couldn't just list all communication channels on the Community page, instead of this weird two-page split that makes many options harder to reach than they should be.
