### PR TITLE
Oud presentations

### DIFF
--- a/site/meetings/ocaml/2016/index.md
+++ b/site/meetings/ocaml/2016/index.md
@@ -30,7 +30,8 @@ The following works will be presented as 20 minute talks.
   [Abstract](https://github.com/hannesm/conex-paper/raw/master/paper.pdf)  
   Hannes Mehnert and Louis Gesbert
 
-- Generic Programming in OCaml  
+- Generic Programming in OCaml --
+  [Abstract](Balestrieri-Mauny-generic_programming_in_OCaml.pdf)  
   Florent Balestrieri and Michel Mauny
 
 - Improving the OCaml Web Stack: Motivations and Progress  
@@ -57,7 +58,8 @@ The following works will be presented as 20 minute talks.
 - Semantics of the Lambda intermediate language  
   Pierre Chambart
 
-- Statistically profiling memory in OCaml  
+- Statistically profiling memory in OCaml --
+  [Abstract](Jourdan-statistically_profiling_memory_in_OCaml.pdf)  
   Jacques-Henri Jourdan
 
 - Sundials/ML: interfacing with numerical solvers  

--- a/site/meetings/ocaml/2016/index.md
+++ b/site/meetings/ocaml/2016/index.md
@@ -65,7 +65,7 @@ The following works will be presented as 20 minute talks.
 
 - The State of the OCaml Platform: September 2016 --
   [Abstract](http://www.ocamlpro.com/wp-content/uploads/2016/08/2016_OUD_gesbert_madhavapeddy.pdf)  
-  Louis Gesbert and Anil Madhavapeddy
+  Louis Gesbert, on behalf of the OCaml Platform team
 
 - Who's got your Mail? Mr. Mime! --
   [Abstract](http://din.osau.re/mrmime.pdf),


### PR DESCRIPTION
```
OUD 2016 -- extended abstracts that were sent by email

I plan to eventually upload everyone's extended abstract in
a proposals subdirectory as was done for OUD 2013, but I think it's
best to wait until after the workshop to leave people additional time
to reformulate/improve their abstract while working on their
presentation.
```
