### PR TITLE
Change the license

### DIFF
--- a/site/docs/license.fr.md
+++ b/site/docs/license.fr.md
@@ -3,60 +3,12 @@
 # La licence d'OCaml
 
 <p>
-In the following, &#8220;the Library&#8221; refers to all files marked &#8220;Copyright
-Inria&#8221; in the following directories and their sub-directories of the
-distribution:
+In the following, &#8220;the OCaml Core System&#8221; refers to all files marked &#8220;Copyright INRIA&#8221; in this distribution.
 </p>
-<blockquote><p>
-  <tt>asmrun</tt>, 
-  <tt>byterun</tt>, 
-  <tt>camlp4</tt>, 
-  <tt>config</tt>, 
-  <tt>otherlibs</tt>, 
-  <tt>stdlib</tt>, 
-  <tt>win32caml</tt>
-
-</p></blockquote>
 <p>
-and &#8220;the Compiler&#8221; refers to all files marked &#8220;Copyright
-Inria&#8221; in the following directories and their sub-directories:
-</p>
-<blockquote><p>
-  <tt>asmcomp</tt>,
-  <tt>boot</tt>,
-  <tt>bytecomp</tt>,
-  <tt>debugger</tt>,
-  <tt>driver</tt>,
-  <tt>lex</tt>,
-  <tt>ocamldoc</tt>,
-  <tt>parsing</tt>,
-  <tt>tools</tt>,
-  <tt>toplevel</tt>,
-  <tt>typing</tt>,
-  <tt>utils</tt>,
-  <tt>yacc</tt>
-
-</p></blockquote>
-
-<p>
-The Compiler is distributed under the terms of the <a href="#qpl" shape="rect">Q Public License</a> version 1.0
- with a change to choice of law (included below).
-</p>
-
-<p>
-The Library is distributed under the terms of the <a href="#lgpl" shape="rect">GNU
+The OCaml Core System is distributed under the terms of the <a href="#lgpl" shape="rect">GNU
 Library General Public License</a> version 2 (included below). 
 </p>
-
-<p>
-
-As a special exception to the Q Public Licence, you may develop
-application programs, reusable components and other software items
-that link with the original or modified versions of the Compiler
-and are not made available to the general public, without any of the
-additional requirements listed in clause 6c of the Q Public licence.
-</p>
-
 <p>
 As a special exception to the GNU Library General Public License, you
 may link, statically or dynamically, a "work that uses the Library"
@@ -72,111 +24,6 @@ License.  This exception does not however invalidate any other reasons
 why the executable file might be covered by the GNU Library General
 Public License.
 </p>
-
-<h2><a name="qpl" id="qpl"><!--0--></a>The Q Public License, version 1.0</h2>
-<pre xml:space="preserve">
-              Copyright (C) 1999 Troll Tech AS, Norway.
-                  Everyone is permitted to copy and
-                  distribute this license document.
-
-The intent of this license is to establish freedom to share and change
-the software regulated by this license under the open source model.
-
-This license applies to any software containing a notice placed by the
-copyright holder saying that it may be distributed under the terms of
-the Q Public License version 1.0. Such software is herein referred to
-as the Software. This license covers modification and distribution of
-the Software, use of third-party application programs based on the
-Software, and development of free software which uses the Software.
-
-                            Granted Rights
-
-1. You are granted the non-exclusive rights set forth in this license
-provided you agree to and comply with any and all conditions in this
-license. Whole or partial distribution of the Software, or software
-items that link with the Software, in any form signifies acceptance of
-this license.
-
-2. You may copy and distribute the Software in unmodified form
-provided that the entire package, including - but not restricted to -
-copyright, trademark notices and disclaimers, as released by the
-initial developer of the Software, is distributed.
-
-3. You may make modifications to the Software and distribute your
-modifications, in a form that is separate from the Software, such as
-patches. The following restrictions apply to modifications:
-
-      a. Modifications must not alter or remove any copyright notices
-      in the Software.
-
-      b. When modifications to the Software are released under this
-      license, a non-exclusive royalty-free right is granted to the
-      initial developer of the Software to distribute your
-      modification in future versions of the Software provided such
-      versions remain available under these terms in addition to any
-      other license(s) of the initial developer.
-
-4. You may distribute machine-executable forms of the Software or
-machine-executable forms of modified versions of the Software,
-provided that you meet these restrictions:
-
-      a. You must include this license document in the distribution.
-
-      b. You must ensure that all recipients of the machine-executable
-      forms are also able to receive the complete machine-readable
-      source code to the distributed Software, including all
-      modifications, without any charge beyond the costs of data
-      transfer, and place prominent notices in the distribution
-      explaining this.
-
-      c. You must ensure that all modifications included in the
-      machine-executable forms are available under the terms of this
-      license.
-
-5. You may use the original or modified versions of the Software to
-compile, link and run application programs legally developed by you or
-by others.
-
-6. You may develop application programs, reusable components and other
-software items that link with the original or modified versions of the
-Software. These items, when distributed, are subject to the following
-requirements:
-
-      a. You must ensure that all recipients of machine-executable
-      forms of these items are also able to receive and use the
-      complete machine-readable source code to the items without any
-      charge beyond the costs of data transfer.
-
-      b. You must explicitly license all recipients of your items to
-      use and re-distribute original and modified versions of the
-      items in both machine-executable and source code forms. The
-      recipients must be able to do so without any charges whatsoever,
-      and they must be able to re-distribute to anyone they choose.
-
-      c. If the items are not available to the general public, and the
-      initial developer of the Software requests a copy of the items,
-      then you must supply one.
-
-                       Limitations of Liability
-
-In no event shall the initial developers or copyright holders be
-liable for any damages whatsoever, including - but not restricted to -
-lost revenue or profits or other direct, indirect, special, incidental
-or consequential damages, even if they have been advised of the
-possibility of such damages, except to the extent invariable law, if
-any, provides otherwise.
-
-                             No Warranty
-
-The Software and this license document are provided AS IS with NO
-WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN,
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-
-                            Choice of Law
-
-This license is governed by the Laws of France.
-</pre>
-
 
 <h2><a name="lgpl" id="lgpl"><!--0--></a>The GNU Library General Public License, version 2</h2>
 

--- a/site/docs/license.md
+++ b/site/docs/license.md
@@ -3,60 +3,12 @@
 # OCaml's License
 
 <p>
-In the following, &#8220;the Library&#8221; refers to all files marked &#8220;Copyright
-Inria&#8221; in the following directories and their sub-directories of the
-distribution:
+In the following, &#8220;the OCaml Core System&#8221; refers to all files marked &#8220;Copyright INRIA&#8221; in this distribution.
 </p>
-<blockquote><p>
-  <tt>asmrun</tt>, 
-  <tt>byterun</tt>, 
-  <tt>camlp4</tt>, 
-  <tt>config</tt>, 
-  <tt>otherlibs</tt>, 
-  <tt>stdlib</tt>, 
-  <tt>win32caml</tt>
-
-</p></blockquote>
 <p>
-and &#8220;the Compiler&#8221; refers to all files marked &#8220;Copyright
-Inria&#8221; in the following directories and their sub-directories:
-</p>
-<blockquote><p>
-  <tt>asmcomp</tt>,
-  <tt>boot</tt>,
-  <tt>bytecomp</tt>,
-  <tt>debugger</tt>,
-  <tt>driver</tt>,
-  <tt>lex</tt>,
-  <tt>ocamldoc</tt>,
-  <tt>parsing</tt>,
-  <tt>tools</tt>,
-  <tt>toplevel</tt>,
-  <tt>typing</tt>,
-  <tt>utils</tt>,
-  <tt>yacc</tt>
-
-</p></blockquote>
-
-<p>
-The Compiler is distributed under the terms of the <a href="#qpl" shape="rect">Q Public License</a> version 1.0
- with a change to choice of law (included below).
-</p>
-
-<p>
-The Library is distributed under the terms of the <a href="#lgpl" shape="rect">GNU
+The OCaml Core System is distributed under the terms of the <a href="#lgpl" shape="rect">GNU
 Library General Public License</a> version 2 (included below). 
 </p>
-
-<p>
-
-As a special exception to the Q Public Licence, you may develop
-application programs, reusable components and other software items
-that link with the original or modified versions of the Compiler
-and are not made available to the general public, without any of the
-additional requirements listed in clause 6c of the Q Public licence.
-</p>
-
 <p>
 As a special exception to the GNU Library General Public License, you
 may link, statically or dynamically, a "work that uses the Library"
@@ -72,111 +24,6 @@ License.  This exception does not however invalidate any other reasons
 why the executable file might be covered by the GNU Library General
 Public License.
 </p>
-
-<h2><a name="qpl" id="qpl"><!--0--></a>The Q Public License, version 1.0</h2>
-<pre xml:space="preserve">
-              Copyright (C) 1999 Troll Tech AS, Norway.
-                  Everyone is permitted to copy and
-                  distribute this license document.
-
-The intent of this license is to establish freedom to share and change
-the software regulated by this license under the open source model.
-
-This license applies to any software containing a notice placed by the
-copyright holder saying that it may be distributed under the terms of
-the Q Public License version 1.0. Such software is herein referred to
-as the Software. This license covers modification and distribution of
-the Software, use of third-party application programs based on the
-Software, and development of free software which uses the Software.
-
-                            Granted Rights
-
-1. You are granted the non-exclusive rights set forth in this license
-provided you agree to and comply with any and all conditions in this
-license. Whole or partial distribution of the Software, or software
-items that link with the Software, in any form signifies acceptance of
-this license.
-
-2. You may copy and distribute the Software in unmodified form
-provided that the entire package, including - but not restricted to -
-copyright, trademark notices and disclaimers, as released by the
-initial developer of the Software, is distributed.
-
-3. You may make modifications to the Software and distribute your
-modifications, in a form that is separate from the Software, such as
-patches. The following restrictions apply to modifications:
-
-      a. Modifications must not alter or remove any copyright notices
-      in the Software.
-
-      b. When modifications to the Software are released under this
-      license, a non-exclusive royalty-free right is granted to the
-      initial developer of the Software to distribute your
-      modification in future versions of the Software provided such
-      versions remain available under these terms in addition to any
-      other license(s) of the initial developer.
-
-4. You may distribute machine-executable forms of the Software or
-machine-executable forms of modified versions of the Software,
-provided that you meet these restrictions:
-
-      a. You must include this license document in the distribution.
-
-      b. You must ensure that all recipients of the machine-executable
-      forms are also able to receive the complete machine-readable
-      source code to the distributed Software, including all
-      modifications, without any charge beyond the costs of data
-      transfer, and place prominent notices in the distribution
-      explaining this.
-
-      c. You must ensure that all modifications included in the
-      machine-executable forms are available under the terms of this
-      license.
-
-5. You may use the original or modified versions of the Software to
-compile, link and run application programs legally developed by you or
-by others.
-
-6. You may develop application programs, reusable components and other
-software items that link with the original or modified versions of the
-Software. These items, when distributed, are subject to the following
-requirements:
-
-      a. You must ensure that all recipients of machine-executable
-      forms of these items are also able to receive and use the
-      complete machine-readable source code to the items without any
-      charge beyond the costs of data transfer.
-
-      b. You must explicitly license all recipients of your items to
-      use and re-distribute original and modified versions of the
-      items in both machine-executable and source code forms. The
-      recipients must be able to do so without any charges whatsoever,
-      and they must be able to re-distribute to anyone they choose.
-
-      c. If the items are not available to the general public, and the
-      initial developer of the Software requests a copy of the items,
-      then you must supply one.
-
-                       Limitations of Liability
-
-In no event shall the initial developers or copyright holders be
-liable for any damages whatsoever, including - but not restricted to -
-lost revenue or profits or other direct, indirect, special, incidental
-or consequential damages, even if they have been advised of the
-possibility of such damages, except to the extent invariable law, if
-any, provides otherwise.
-
-                             No Warranty
-
-The Software and this license document are provided AS IS with NO
-WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN,
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
-
-                            Choice of Law
-
-This license is governed by the Laws of France.
-</pre>
-
 
 <h2><a name="lgpl" id="lgpl"><!--0--></a>The GNU Library General Public License, version 2</h2>
 


### PR DESCRIPTION
ocaml/ocaml Apparently INRIA has recently dumped the Q Public License for OCaml and switch to LGPL 2.1 for everything, including the compiler and libraries
