### PR TITLE
Fix french translation of "Tutorials"

### DIFF
--- a/translations/en_to_fr.txt
+++ b/translations/en_to_fr.txt
@@ -7,7 +7,7 @@
 "Find Us on GitHub" -> "Dépôt GitHub"
 "News" -> "Nouvelles"
 "Code Examples" -> "Exemples de code"
-"Tutorials" -> "Tutoriaux"
+"Tutorials" -> "Tutoriels"
 "Books" -> "Livres"
 "Success Stories" -> "Cas d'usage"
 "Manual" -> "Manuel"


### PR DESCRIPTION
Hi,

This PR fix the french translation of `Tutorials` which should be `Tutoriels` instead of `Tutoriaux` - see [tutoriels](https://fr.wiktionary.org/wiki/tutoriels) and [tutoriaux](https://fr.wiktionary.org/wiki/tutoriaux) from wiktionary.