### PR TITLE
Fix typo

### DIFF
--- a/site/learn/tutorials/format.md
+++ b/site/learn/tutorials/format.md
@@ -331,7 +331,7 @@ Thus the problem is to pretty-print the values of a concrete data type
 that models a language of expressions that defines functions and their
 applications to arguments.
 
-First, I give the abstract syntax of lambda-terms (we illustrate is in
+First, I give the abstract syntax of lambda-terms (we illustrate it in
 the [interactive system](../description.html#Interactivity)):
 
 ```ocamltop


### PR DESCRIPTION
Hi,

This PR fix a simple typo - `is` instead of `it`.