### PR TITLE
Remove references to soon to be deprecated services.

### DIFF
--- a/IDEAS.org
+++ b/IDEAS.org
@@ -79,9 +79,7 @@
 
 * List of Libraries
   - something like [[http://hackage.haskell.org/packages/hackage.html][hackage]]
-  - [[http://oasis.ocamlcore.org/dev/home][oasis-db]] project provides a good starting point
-  - may require also automatically pulling information from github and
-    ocamlforge
+  - may require also automatically pulling information from github
 
 ** Desired features
   - provide download links to latest and previous versions of library
@@ -98,10 +96,7 @@
 
 * Search Email Lists
   The main OCaml List and Beginner's list are both difficult to search
-  over. An improved interface would be nice. In addition, there are
-  actually numerous other OCaml related mailing lists (e.g. virtually
-  every project on the forge). Should at least link to them and/or
-  integrate search over all lists.
+  over. An improved interface would be nice.
 
   Make it easy to subscribe to mailing lists. Simply check a box in
   your account settings page.

--- a/site/community/mailing_lists.md
+++ b/site/community/mailing_lists.md
@@ -7,9 +7,7 @@
 Mailing lists and other forums used to discuss OCaml in general are
 listed below. There are thousands of other forums related to
 individual projects. Several mailing lists are hosted on the
-[lists.ocaml.org](http://lists.ocaml.org) domain. Projects on the
-[OCaml Forge](http://forge.ocamlcore.org/) often have mailing lists
-associated with them, and projects on
+[lists.ocaml.org](http://lists.ocaml.org) domain. Projects on
 [GitHub](https://github.com/trending?l=ocaml&since=monthly) actively
 use GitHub's Issue system for discussions.
 

--- a/site/learn/libraries.md
+++ b/site/learn/libraries.md
@@ -17,18 +17,9 @@ the most popular sites where you can find them.
   libraries here that people haven't pushed to OPAM for one reason or
   another.
 
-* [OCaml Forge](http://forge.ocamlcore.org/) is a code hosting site
-  dedicated to OCaml projects. Hundreds of libraries are hosted
-  here. Like GitHub, many of these libraries are in OPAM, but you'll
-  possibly find many here that aren't.
-
 * [Bitbucket](https://bitbucket.org/repo/all/relevance?name=ocaml&language=ocaml)
   is yet another code hosting site. It is far less used amongst OCaml
   programmers, but click the link to find those that are.
-
-* [OASIS-DB](http://oasis.ocamlcore.org/dev/home) is a collection of
-  released OCaml packages. It is an alternative packaging system to
-  obtain OCaml libraries.
 
 * [Caml Hump](http://caml.inria.fr/cgi-bin/hump.en.cgi) is now
  deprecated. For many years, it was the definitive source to search


### PR DESCRIPTION
* oasis.ocamlcore.org is deprecated
* the forge related services will be deprecated in 2017 (mailing list, hosting).

Context:
https://forge.ocamlcore.org/forum/forum.php?forum_id=958
https://forge.ocamlcore.org/forum/forum.php?forum_id=959