### PR TITLE
Use local Facebook logo image to repair broken image in the Learn section

### DIFF
--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -117,7 +117,7 @@
 
           <p><a href="https://www.facebook.com"><img style="float:
           left; margin-right: 10px; margin-bottom: 10px"
-          src="https://www.facebookbrand.com/img/assets/asset.f.logo.lg.png"
+          src="/img/users/facebook.png"
 						     ></a>To
             handle their huge PHP codebase, Facebook developed
             <a href="https://github.com/facebook/pfff/wiki/Main"


### PR DESCRIPTION
This PR fixes a broken image link on the frontpage of the _Learn_ section.