### PR TITLE
added link to init Emacs docs

### DIFF
--- a/site/learn/tutorials/get_up_and_running.md
+++ b/site/learn/tutorials/get_up_and_running.md
@@ -300,6 +300,8 @@ $ opam pin add <your_package_name> . -y
 
 ## Elisp for OCaml coding
 
+Code for the [Emacs init file](https://www.gnu.org/software/emacs/manual/html_node/emacs/Init-File.html).
+
 ```elisp
 ;; OCaml code
 (add-hook


### PR DESCRIPTION
Hi there,

The Emacs init file can be in different places, not necessarily init.el (as implied by the text). Hence the pointer to help for newcomers.

Cheers,
tpltnt