### PR TITLE
Deprecate and archive camlp4 and web tutorials

### DIFF
--- a/site/learn/tutorials/camlp4_3.10/dynamic_functor_example.md
+++ b/site/learn/tutorials/camlp4_3.10/dynamic_functor_example.md
@@ -3,6 +3,8 @@
 
 # Dynamic Functor Example
 
+**Deprecation Warning:** this tutorial describes technology that is considered obsolete. It's been replaced by [extensions points and ppx rewriters](http://caml.inria.fr/pub/docs/manual-ocaml-4.02/extn.html#sec243)
+
 dynamic_functor_example.ml:
 
 ```ocaml

--- a/site/learn/tutorials/camlp4_3.10/dynamic_old_syntax.md
+++ b/site/learn/tutorials/camlp4_3.10/dynamic_old_syntax.md
@@ -3,6 +3,8 @@
 
 # Dynamic Old Syntax
 
+**Deprecation Warning:** this tutorial describes technology that is considered obsolete. It's been replaced by [extensions points and ppx rewriters](http://caml.inria.fr/pub/docs/manual-ocaml-4.02/extn.html#sec243)
+
 dynamic_old_syntax.ml:
 
 ```ocaml

--- a/site/learn/tutorials/camlp4_3.10/foreach_tutorial.md
+++ b/site/learn/tutorials/camlp4_3.10/foreach_tutorial.md
@@ -4,6 +4,8 @@
 
 # Foreach Tutorial (Camlp4 3.10)
 
+**Deprecation Warning:** this tutorial describes technology that is considered obsolete. It's been replaced by [extensions points and ppx rewriters](http://caml.inria.fr/pub/docs/manual-ocaml-4.02/extn.html#sec243)
+
 This is a tutorial that guides you, step by step, how to write syntax
 extension using Camlp4 in Objective CAML. The example we present in this
 tutorial should give you a practical idea how syntax extension works,

--- a/site/learn/tutorials/camlp4_3.10/index.md
+++ b/site/learn/tutorials/camlp4_3.10/index.md
@@ -4,6 +4,8 @@
 
 # Camlp4 3.10
 
+**Deprecation Warning:** this tutorial describes technology that is considered obsolete. It's been replaced by [extensions points and ppx rewriters](http://caml.inria.fr/pub/docs/manual-ocaml-4.02/extn.html#sec243)
+
 **Camlp4**, the OCaml "pre-processor pretty printer" is an advanced
 macro system which allows complex abstract syntax tree transformations
 on ocaml programs, and on other recursive decent grammars.

--- a/site/learn/tutorials/camlp4_3.10/quick_non_extensible_example.md
+++ b/site/learn/tutorials/camlp4_3.10/quick_non_extensible_example.md
@@ -3,6 +3,8 @@
 
 # Quick Non Extensible Example
 
+**Deprecation Warning:** this tutorial describes technology that is considered obsolete. It's been replaced by [extensions points and ppx rewriters](http://caml.inria.fr/pub/docs/manual-ocaml-4.02/extn.html#sec243)
+
 quick_non_extensible_example.ml
 
 ```ocaml

--- a/site/learn/tutorials/camlp4_3.10/static_functor_example.md
+++ b/site/learn/tutorials/camlp4_3.10/static_functor_example.md
@@ -3,6 +3,8 @@
 
 # Static Functor Example
 
+**Deprecation Warning:** this tutorial describes technology that is considered obsolete. It's been replaced by [extensions points and ppx rewriters](http://caml.inria.fr/pub/docs/manual-ocaml-4.02/extn.html#sec243)
+
 static_functor_example.ml:
 
 ```ocaml

--- a/site/learn/tutorials/camlp4_3.10/static_old_syntax.md
+++ b/site/learn/tutorials/camlp4_3.10/static_old_syntax.md
@@ -3,6 +3,8 @@
 
 # Static Old Syntax
 
+**Deprecation Warning:** this tutorial describes technology that is considered obsolete. It's been replaced by [extensions points and ppx rewriters](http://caml.inria.fr/pub/docs/manual-ocaml-4.02/extn.html#sec243)
+
 static_old_syntax.ml:
 
 ```ocaml

--- a/site/learn/tutorials/index.md
+++ b/site/learn/tutorials/index.md
@@ -42,13 +42,11 @@ tracker there to request or offer new tutorials. Thanks!
 * [Performance and Profiling](performance_and_profiling.html)
 * [Calling C libraries](calling_c_libraries.html)
 * [Calling Fortran libraries](calling_fortran_libraries.html)
-* [OCaml and the Web](ocaml_and_the_web.html)
 * [Standard Library Examples](standard_library_examples.html)
 * [Setting up OCaml projects with OASIS](setting_up_with_oasis.html)
 * [Compiling OCaml projects](compiling_ocaml_projects.html)
 * [Command-Line Arguments](command-line_arguments.html)
 * [File manipulation](file_manipulation.html)
-* [Camlp4 3.10](camlp4_3.10/)
 * [Filenames and Extensions](filenames.html)
 * [Streams](streams.html)
 * [Stream Expressions](stream_expressions.html)
@@ -137,3 +135,9 @@ with another language.
 * [Manual](http://caml.inria.fr/pub/docs/manual-ocaml/)
 * [Detecting use cases for GADTs in OCaml](http://mads-hartmann.com/ocaml/2015/01/05/gadt-ocaml.html),
   (by Mads Hartmann), on using generalized algebraic data types in writing interpreters.
+
+###  Archived Tutorials
+These tutorials are either obsolete, or describe obsolete technologies. They're preserved here just in case they're still useful to someone.
+
+* [OCaml and the Web](ocaml_and_the_web.html)
+* [Camlp4 3.10](camlp4_3.10/)

--- a/site/learn/tutorials/ocaml_and_the_web.md
+++ b/site/learn/tutorials/ocaml_and_the_web.md
@@ -3,6 +3,9 @@
 *Table of contents*
 
 # OCaml and the Web
+
+**Deprecation Warning:** this tutorial is outdated and largely irrelevant unless you have an odd fascination with CGI Programming.
+
 ## Advantages and Disadvantages
 Like any other language, OCaml can be used to write CGI programs. The
 advantages of using OCaml for CGI scripting are the same as using OCaml


### PR DESCRIPTION
Adds deprecation warnings to each tutorial page, and an "Archived Tutorials" section on the Tutorials index page.

Fixes #892 