### PR TITLE
[Docs] Fix bucklescript links

### DIFF
--- a/site/releases/4.04.md
+++ b/site/releases/4.04.md
@@ -95,9 +95,9 @@ targets traditionally associated with other languages:
 * [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) is a stable OCaml
   to JavaScript compiler.
 
-* [Bucklescript](http://bloomberg.github.io/bucklescript/) is a newer
+* [Bucklescript](http://bucklescript.github.io/bucklescript/) is a newer
   OCaml to JavaScript compiler. See its
-  [wiki](https://github.com/bloomberg/bucklescript/wiki/Differences-from-js_of_ocaml)
+  [wiki](https://github.com/bucklescript/bucklescript/wiki/Differences-from-js_of_ocaml)
   for an explanation of how it differs from js_of_ocaml.
 
 * [OCaml-java](http://www.ocamljava.org/) is a stable OCaml to


### PR DESCRIPTION
The bloomberg one no longer works