### PR TITLE
Paragraph linking to the new Discourse-based forum discuss.ocaml.org.

### DIFF
--- a/site/community/mailing_lists.fr.md
+++ b/site/community/mailing_lists.fr.md
@@ -6,6 +6,18 @@
 
 ## Les listes de discussion par mail
 
+### discuss.ocaml.org
+[discuss.ocaml.org](https://discuss.ocaml.org/)  
+C'est le forum le plus actif au sein de la communauté OCaml.
+Il touche à tous les aspects du langage et toutes les audiences sont
+bienvenues. Les conversations y sont groupées en catégories,
+auxquelles il est possible de s'abonner separément.
+Il offre également un mode liste de diffusion, pour ceux qui désireraient
+recevoir tous les messages.
+
+La plupart des catégories sont en anglais mais certaines catégories
+peuvent etre créées en français ou dans d'autres langues.
+
 ### caml-list AT inria.fr
 
 La liste de diffusion OCaml s'adresse à tous les utilisateurs des

--- a/site/community/mailing_lists.fr.md
+++ b/site/community/mailing_lists.fr.md
@@ -10,8 +10,8 @@
 [discuss.ocaml.org](https://discuss.ocaml.org/)  
 C'est le forum le plus actif au sein de la communauté OCaml.
 Il touche à tous les aspects du langage et toutes les audiences sont
-bienvenues. Les conversations y sont groupées en catégories,
-auxquelles il est possible de s'abonner separément.
+bienvenues. Les conversations y sont regroupées en catégories,
+auxquelles il est possible de s'abonner séparément.
 Il offre également un mode liste de diffusion, pour ceux qui désireraient
 recevoir tous les messages.
 

--- a/site/community/mailing_lists.md
+++ b/site/community/mailing_lists.md
@@ -13,6 +13,16 @@ use GitHub's Issue system for discussions.
 
 ## Mailing Lists
 
+### Discuss at OCaml.org
+[discuss.ocaml.org](https://discuss.ocaml.org/)  
+This is the most active forum about OCaml. Topics are grouped into
+a variety of categories, which can be followed independently.
+A mailing-list mode is also available for those who wish to receive
+all messages.
+
+Most categories are in English but categories in other languages are
+welcome.
+
 ### Official OCaml List
 *caml-list AT inria.fr*  
 The OCaml mailing list is intended for all users of the OCaml


### PR DESCRIPTION
English + about the same in French.
Note that I'm mentioning it's ok to create categories in other languages than English.

The goal of this edit is to drive new users to the new forum. Feel free to rewrite the whole thing.
