### PR TITLE
update links for downloading opam_install.sh on french documentation

### DIFF
--- a/site/docs/install.fr.md
+++ b/site/docs/install.fr.md
@@ -39,7 +39,7 @@ OPAM](http://opam.ocaml.org/) et suivez les instructions.
 Pour les plus impatients, il existe un installeur binaire :
 
 ```bash
-$ wget http://www.ocamlpro.com/pub/opam_installer.sh
+$ wget https://raw.github.com/ocaml/opam/master/shell/opam_installer.sh
 $ sh ./opam_installer.sh /usr/local/bin  # Vous pouvez changer le chemin pour l'installer ailleurs
 ```
 Ou depuis les sources:


### PR DESCRIPTION
Hello,

I updated the french documentation for the installation of ocaml w/ opam available on [this link](https://ocaml.org/docs/install.fr.html), because when we execute the script, we receive this error:

`opam_installer.sh: Couldn't download http://www.ocamlpro.com/pub/opam-1.1.0-x86_64-Linux`

So changing the download link available on the [english document](https://opam.ocaml.org/doc/Install.html) fix the problem.