### PR TITLE
Add an FAQ regarding predeclaration of record type

### DIFF
--- a/site/learn/faq.md
+++ b/site/learn/faq.md
@@ -181,12 +181,14 @@ let string_of_color =function
 ```
 
 #### Is it possible to make a record value without declaring its type first?
-No, Before making a record, you must give it's type a name, using the type keyword.
-Otherwise it results in error "Unbound record field"
+No, Before making a record, you must give record's type a name, using the `type` keyword, 
+or the type name for the record should at least be in scope. Ocaml needs to know
+the record type's name and associated field names before making a record value.
+Otherwise it results in error "Unbound record field".
 
 ```ocamltop
-type person = { name: string; age: int };;
-let p1 = { name="John"; age=30 };;
+type person = { name: string; age: int }
+let p1 = { name="John"; age=30 }
 ```
 
 #### How to share a field between two different record types?

--- a/site/learn/faq.md
+++ b/site/learn/faq.md
@@ -180,6 +180,15 @@ let string_of_color =function
   | Red -> "red"
 ```
 
+#### Is it possible to make a record value without declaring its type first?
+No, Before making a record, you must give it's type a name, using the type keyword.
+Otherwise it results in error "Unbound record field"
+
+```ocamltop
+type person = { name: string; age: int };;
+let p1 = { name="John"; age=30 };;
+```
+
 #### How to share a field between two different record types?
 
 When you define two types sharing a field name, the last defined type


### PR DESCRIPTION
It seems it is necessary to pre-declare record types before being able to make record values of that type.
So added a question to the FAQ saying 
"Is it possible to make a record value without declaring its type first?"