### PR TITLE
typos in doc get_up_and_running.md

### DIFF
--- a/site/learn/tutorials/get_up_and_running.md
+++ b/site/learn/tutorials/get_up_and_running.md
@@ -65,7 +65,7 @@ oasis. The oasis flow basically goes like this: (Be aware that oasis
 is really finicky and its error messages are useless), see the oasis
 minitutorial at the end of this post. 
 
-6. `merlin` is an OCaml program that is simply amazing it drives code
+6. `merlin` is an OCaml program that is simply amazing - it drives code
     completion for plugins available in `emacs` and `vim`. Once you have
     merlin installed with
     
@@ -95,18 +95,18 @@ minitutorial at the end of this post.
     tutorial at the end of this post.
 
 7.  There are no full blown IDEs for OCaml, learn `emacs`, `vim`.
-Also `Sublime Text` has a merlin plugin, if you're already familiar
+Also Sublime Text has a merlin plugin, if you're already familiar
 with Sublime Text then just stick with it, merlin is really what
 matters here.
 
-8. `utop` is an enhanced repl, its better than the plain `ocaml`
+8. `utop` is an enhanced repl, it is better than the plain `ocaml`
 repl. Install it with `opam install utop`
 
 # Library situation
 
-`OCaml` does have a standard library but it is deliberately minimal. It was only created
+OCaml does have a standard library but it is deliberately minimal. It was only created
 to serve the needs of the compiler programmers, ie its not like
-`Python`'s standard library which has everything under the sun + the
+Python's standard library which has everything under the sun + the
 moon. There are a few standard library replacements, one is called
 `Core` and its provided by Jane Street. Its the library used in the
 **Real World OCaml** book/website. Another standard library
@@ -129,7 +129,7 @@ example to talk to the `Stripe` API, see
 
 ## Doing simple tasks (shameless plug)
 
-I try using `OCaml` for literally everything and that includes going
+I try using OCaml for literally everything and that includes going
 to hackathons, to make this less painful I wrote a library called
 `Podge` which helps with simple stuff. I don't claim its a standard
 library replacement, just a library for getting stuff done. These two
@@ -178,11 +178,12 @@ like: (The README has code examples)
 
 Loads, warning shameless plugs ahead.
 
-0.  I wrote an opam package that makes it easy to get an `iOS` OCaml
+0.  I wrote an opam package that makes it easy to get an iOS OCaml
     cross-compiler, see
     [here](https://github.com/fxfactorial/opam-ios).
-1.  Compilers!, lots of compilers/compiler tools are written in OCaml:
-    Facebook uses OCaml for [pfff](https://github.com/facebook/pfff)
+1.  Compilers! Lots of compilers and compiler tools are written in OCaml:
+    Facebook uses OCaml for the [Hack](https://github.com/facebook/hhvm/tree/master/hphp/hack)
+    typechecker, [pfff](https://github.com/facebook/pfff)
     and [flow](https://github.com/facebook/flow) and the first cut of
     Rust was written in OCaml.
 2.  Financial world, [Jane Street](https://www.janestreet.com) uses
@@ -207,13 +208,13 @@ Loads, warning shameless plugs ahead.
 
 # Stick with it!
 
-This style of coding might be new to you or maybe its your first
-programming language, stick with it and continue. `OCaml` offers many
+This style of coding might be new to you or maybe it's your first
+programming language, stick with it and continue. OCaml offers many
 awesome features and has many strengths including a very professional
 and pragmatic community. Also, if you're in the Bay Area then please
 come to [weekly office hours](http://www.meetup.com/sv-ocaml/) hours
-hosted at MixRank in San Francisco. Its open to all levels of
-experience and I still have some Enter the Monad tshirts to give away
+hosted at MixRank in San Francisco. It's open to all levels of
+experience and I still have some Enter the Monad t-shirts to give away,
 courtesy of Jane Street.
 
 ## Oasis mini-tutorial


### PR DESCRIPTION
Typos and nits (a bit too many `)