### PR TITLE
corrected graphics code

### DIFF
--- a/site/learn/tutorials/null_pointers_asserts_and_warnings.md
+++ b/site/learn/tutorials/null_pointers_asserts_and_warnings.md
@@ -125,7 +125,7 @@ let () =
     set_color (if i mod 2 = 0 then red else yellow);
     fill_circle 320 240 radius
   done;
-  read_line ()
+  print_endline ""
 ```
 
 If you prefer C-style `printf`'s then try using OCaml's `Printf` module
@@ -143,5 +143,5 @@ let () =
     set_color (if i mod 2 = 0 then red else yellow);
     fill_circle 320 240 radius
   done;
-  read_line ()
+  print_endline ""
 ```


### PR DESCRIPTION
The graphics code was not correct and it is not compilable. According to ocaml (I tried with v>=4.05) `let ()` must return with a value of type `unit`, but the code provided here was using `read_line ()` which is of type `string -> unit`. So I used `print_endline ""` which is of type `unit` to correct the code.