### PR TITLE
Replace deprecated Array.create with Array.make

### DIFF
--- a/site/learn/taste.md
+++ b/site/learn/taste.md
@@ -83,7 +83,7 @@ slots using two successive `for` loops.
 let add_polynom p1 p2 =
   let n1 = Array.length p1
   and n2 = Array.length p2 in
-  let result = Array.create (max n1 n2) 0 in
+  let result = Array.make (max n1 n2) 0 in
   for i = 0 to n1 - 1 do result.(i) <- p1.(i) done;
   for i = 0 to n2 - 1 do result.(i) <- result.(i) + p2.(i) done;
   result;;


### PR DESCRIPTION
The `Array.create` function has been deprecated in favor of `Array.make`. The OCaml interpreter displays a warning that appears in the compiled HTML at http://ocaml.org/learn/taste.html.