### PR TITLE
Remove OCaml 2017 announcement

### DIFF
--- a/site/index.md
+++ b/site/index.md
@@ -104,16 +104,6 @@
 			<ul class="news-feed" style="margin-bottom: 0px">
 
 			<li class="announcement"><article>
-			  <h1><a title="OCaml Users and Developers Workshop"
-			       href="/meetings/ocaml/2017/">OCaml 2017</a></h1>
-			  <p>September 8, 2017</p>
-			  <a title="OCaml Users and Developers Workshop"
-			     href="/meetings/ocaml/2017/">
-			    <img alt="" src="/img/announcement.svg" class="svg" />
-			    <img alt="" src="/img/announcement.png" class="png" />
-			  </a>
-			</article></li>
-			<li class="announcement"><article>
 			  <h1><a title="OCaml Weekly News"
 			       href="/community/cwn/" >OCaml Weekly News</a></h1>
 			   <p>{{! cmd script/weekly_news --date !}}</p>

--- a/site/index.md
+++ b/site/index.md
@@ -103,6 +103,17 @@
             </h1>
 			<ul class="news-feed" style="margin-bottom: 0px">
 
+                        <!-- Commented out until next workshop is announced -->
+			<!-- <li class="announcement"><article>
+			  <h1><a title="OCaml Users and Developers Workshop"
+			       href="/meetings/ocaml/2017/">OCaml 2017</a></h1>
+			  <p>September 8, 2017</p>
+			  <a title="OCaml Users and Developers Workshop"
+			     href="/meetings/ocaml/2017/">
+			    <img alt="" src="/img/announcement.svg" class="svg" />
+			    <img alt="" src="/img/announcement.png" class="png" />
+			  </a>
+			</article></li> -->
 			<li class="announcement"><article>
 			  <h1><a title="OCaml Weekly News"
 			       href="/community/cwn/" >OCaml Weekly News</a></h1>


### PR DESCRIPTION
OCaml 2017 was a long time ago, so this probably doesn't belong on the front page any longer.