### PR TITLE
Don't classify discuss.ocaml.org as a mailing list.

### DIFF
--- a/site/community/index.md
+++ b/site/community/index.md
@@ -8,7 +8,7 @@
             <img src="/img/community-large.png" alt="Community" class="png" />
         </div>
         <section id="community-leader" class="span6">
-            <p>OCaml has a diverse, worldwide community and one of the main benefits is the ability to easily reach each other.  <a href="mailing_lists.html">Mailing lists</a> are the most common way people interact although you will always find users on IRC, around the web and at any of the <a href="/meetings/">meetings</a>.  OCaml also has a committed group of <a href="../learn/companies.html">industrial users</a> who regularly contribute to the community.</p>
+            <p>OCaml has a diverse, worldwide community and one of the main benefits is the ability to easily reach each other.  <a href="mailing_lists.html">Mailing lists and web forums</a> are the most common way people interact although you will always find users on IRC, around the web and at any of the <a href="/meetings/">meetings</a>.  OCaml also has a committed group of <a href="../learn/companies.html">industrial users</a> who regularly contribute to the community.</p>
         </section>
         <div class="span2">
             <img src="/img/colour-transparent-icon.svg" alt="OCaml"
@@ -25,7 +25,7 @@
     </div>
     <div class="row">
         <section class="span12 condensed">
-            <h1 class="ruled"><a href="mailing_lists.html">Mailing Lists</a></h1>
+            <h1 class="ruled"><a href="mailing_lists.html">Mailing Lists and Web Forums</a></h1>
             <div class="row">
             <section class="span4 condensed">
                 <p><strong><a href="https://discuss.ocaml.org/">discuss.ocaml.org</a></strong><br />
@@ -71,7 +71,7 @@
     <div class="row">
         <section class="span4 condensed">
             <h1 class="ruled">Support</h1>
-            <p>See the <a href="/community/mailing_lists.html">mailing lists</a> page for a complete list of support channels. <a href="support.html">Commercial support</a> is also available.</p>
+            <p>See the <a href="/community/mailing_lists.html">mailing lists and web forums</a> page for a complete list of support channels. <a href="support.html">Commercial support</a> is also available.</p>
 
             <p>If you would like to give support to OCaml, you can join the Consortium or support the work of OCaml Labs. <a href="/community/support.html#GivingSupport">Find out more</a>.</p>
 
@@ -164,7 +164,7 @@
                 <ul class="inline">
                     <li><a href="/community/mailing_lists.html"><img src="/img/mail.png" title="OCaml Mailing Lists"></a></li>
                     <li><a href="https://github.com/trending?l=ocaml&since=monthly"><img src="/img/github-mark.png" title="OCaml repos on Github"></a></li>
-                    <li><a href="https://bitbucket.org/repo/all?name=ocaml"><img src="/img/bitbucket-logo.png" title="OCaml repos on BitBucket"></a></li>                
+                    <li><a href="https://bitbucket.org/repo/all?name=ocaml"><img src="/img/bitbucket-logo.png" title="OCaml repos on BitBucket"></a></li>
                     <li><a href="http://stackoverflow.com/questions/tagged/ocaml"><img src="/img/stackoverflow-logo.jpg" title="OCaml tag on StackOverflow"></a></li>
                     <li><a href="https://plus.google.com/u/0/communities/100872177392545601885"><img src="/img/googleplus.jpg" title="OCaml on Google+"></a></li>
                     <li><a href="http://www.reddit.com/r/ocaml/"><img src="/img/reddit-alien.png" title="OCaml subreddit on Reddit"></a></li>

--- a/site/community/mailing_lists.md
+++ b/site/community/mailing_lists.md
@@ -2,7 +2,7 @@
 
 *Table of contents*
 
-# Mailing Lists and Forums
+# Mailing Lists and Web Forums
 
 Mailing lists and other forums used to discuss OCaml in general are
 listed below. There are thousands of other forums related to
@@ -11,10 +11,10 @@ individual projects. Several mailing lists are hosted on the
 [GitHub](https://github.com/trending?l=ocaml&since=monthly) actively
 use GitHub's Issue system for discussions.
 
-## Mailing Lists
+## Web Forums
 
 ### Discuss at OCaml.org
-[discuss.ocaml.org](https://discuss.ocaml.org/)  
+[discuss.ocaml.org](https://discuss.ocaml.org/)
 This is the most active forum about OCaml. Topics are grouped into
 a variety of categories, which can be followed independently.
 This forum welcomes people at all levels of proficiency, including
@@ -25,8 +25,10 @@ all messages.
 Most categories are in English but categories in other languages are
 welcome.
 
+## Mailing Lists
+
 ### Official OCaml List
-*caml-list AT inria.fr*  
+*caml-list AT inria.fr*
 The OCaml mailing list is intended for all users of the OCaml
 implementations developed at Inria. The purpose of this list is to share
 experience, exchange ideas and code, and report on applications of the
@@ -46,7 +48,7 @@ a curated summary of caml-list discussions.
 
 
 ### OCaml Jobs and Internships
-*ocaml-jobs AT inria.fr*  
+*ocaml-jobs AT inria.fr*
 This list is for exchanges between people looking for a job or an
 internship requiring skills in OCaml and people, corporations,
 universities, ..., offering such jobs or internships.
@@ -54,7 +56,7 @@ universities, ..., offering such jobs or internships.
 [(Un)subscribe](https://sympa.inria.fr/sympa/info/ocaml-jobs)
 
 ### OCaml Announcements
-*caml-announce AT inria.fr*  
+*caml-announce AT inria.fr*
 This is a low-traffic, moderated list for announcements of OCaml
 releases and new OCaml-related software, libraries, documents, etc.
 
@@ -64,7 +66,7 @@ releases and new OCaml-related software, libraries, documents, etc.
 ## Discussion Groups
 
 ### IRC Channel - English
-*irc.freenode.net #ocaml*  
+*irc.freenode.net #ocaml*
 This is a real-time communication channel, where you can ask for help.
 There are about a hundred users hanging around; don't ask if you can
 ask, just ask, and be patient: not everyone is in the same timezone. The
@@ -80,11 +82,11 @@ interface, you may try
 requires registration but is otherwise free.
 
 ### IRC Channel - French
-*irc.freenode.net #ocaml-fr*  
+*irc.freenode.net #ocaml-fr*
 As above, but for French speakers.
 
 ### About ML
-*comp.lang.ml*  
+*comp.lang.ml*
 This is a moderated Usenet newsgroup about all variants of ML.
 Discussions generally concern Standard ML implementations (such as
 SML-NJ), but some threads concern the OCaml branch.
@@ -94,7 +96,7 @@ Groups](http://groups.google.com/groups?group=comp.lang.ml) |
 [FAQ](http://www.faqs.org/faqs/meta-lang-faq/)
 
 ### About Functional Languages
-*comp.lang.functional*  
+*comp.lang.functional*
 This is an unmoderated usenet newsgroup for the discussion of all
 aspects of functional programming languages, including their design,
 application, theoretical foundation, and implementation. Discussions


### PR DESCRIPTION
This renames "Mailing Lists" in a couple of places to "Mailing Lists and Web Forums", and separates out `discuss.ocaml.org` on the mailing lists page as a web forum.

Also a couple of other small changes to differentiate web forums from mailing lists, and kill some spurious trailing whitespace.