### PR TITLE
Add "What's new" sections for releases 4.04, 4.05 and 4.06

### DIFF
--- a/site/releases/4.04.md
+++ b/site/releases/4.04.md
@@ -63,6 +63,25 @@ AV:L/AC:L/Au:S/C:C/I:C/A:N/E:F/RL:OF/RC:C/CDP:H/TD:L/CR:H/IR:H/AR:L
 CWE ID: 114
 ```
 
+## What's new
+
+Some of the highlights in release 4.04 are:
+
+- Exceptions can be declared locally within an expression, with syntax
+  `let exception ... in ...`
+
+- Optimized memory representation for immutable records with a single
+  field, and concrete types with a single constructor with a single
+  argument. This is triggered with a `@@unboxed` attribute on the type
+  definition.
+
+- Support for the Spacetime memory profiler was added.
+
+For a comprehensive list of changes and details on all new features,
+bug fixes, optimizations, etc., please consult the
+[changelog](http://caml.inria.fr/pub/distrib/ocaml-4.04/notes/Changes).
+
+
 ## ![](../img/source.gif "") Source distribution
 
 - [Source

--- a/site/releases/4.05.md
+++ b/site/releases/4.05.md
@@ -15,6 +15,10 @@ This release is availabe as multiple [OPAM](https://opam.ocaml.org/doc/Usage.htm
 - 4.05.0+spacetime - Official 4.05.0 release with [`-spacetime` profiling](http://caml.inria.fr/pub/docs/manual-ocaml/spacetime.html) enabled
 - 4.05.0+afl — Official 4.05.0 release with support for afl-fuzz instrumentation
 
+## What's new
+
+OCaml 4.05 comprises mainly bug fixes, with some improvements in
+performance and usability.
 For a comprehensive list of changes and details on all new features,
 bug fixes, optimizations, etc., please consult the
 [changelog](http://caml.inria.fr/pub/distrib/ocaml-4.05/notes/Changes). There

--- a/site/releases/4.06.md
+++ b/site/releases/4.06.md
@@ -19,6 +19,41 @@ This release is availabe as multiple
 - 4.06.0+fp+flambda — Official 4.06.0 release with frame-pointers and
   flambda activated
 
+What's new
+----------
+
+Some of the highlights in release 4.06 are:
+
+- Strings (type `string`) are now immutable by default. In-place
+  modification must use the type `bytes` of byte sequences, which is
+  distinct from `string`.  This corresponds to the `-safe-string`
+  compile-time option, which was introduced in OCaml 4.02 in 2014, and
+  which is now the default.
+
+- Object types can now extend a previously-defined object type, as in
+  `<t; a: int>`.
+
+- Destructive substitution over module signatures can now express more
+  substitutions, such as `S with type M.t := type-expr`
+  and `S with module M.N := path`.
+
+- Users can now define operators that look like array indexing, e.g.
+  `let ( .%() ) = List.nth in [0; 1; 2].%(1)`
+
+- New escape `\u{XXXX}` in string literals, denoting the UTF-8
+  encoding of the Unicode code point `XXXX`.
+
+- Full Unicode support was added to the Windows runtime system.  In
+  particular, file names can now contain Unicode characters.
+
+- An alternate register allocator based on linear scan can be selected
+  with `ocamlopt -linscan`.  It reduces compilation time compared with
+  the default register allocator.
+
+- The Num library for arbitrary-precision integer and rational
+  arithmetic is no longer part of the core distribution and can be
+  found as a separate OPAM package.
+
 
 For a comprehensive list of changes and details on all new features,
 bug fixes, optimizations, etc., please consult the


### PR DESCRIPTION
As currently discussed in the core OCaml dev team, change logs for new releases are getting larger and larger and harder and harder to read, so it's good to highlight the most important changes for each release.

On ocaml.org this highlighting was done until release 4.03, but is missing since 4.04.

This PR adds "What's new" sections to summarize important changes in 4.04, 4.05, and 4.06.  The summaries are taken from the corresponding pages on caml.inria.fr.