### PR TITLE
Update the link to the annual course on fun-mooc to the current year.

### DIFF
--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -75,7 +75,7 @@
 
 <iframe frameborder="0" width="380" height="220" src="//www.dailymotion.com/embed/video/x2ymo3x" allowfullscreen></iframe><br /><a href="//www.dailymotion.com/video/x2ymo3x_fun-mooc-introduction-to-functional-programming-in-ocaml_school" target="_blank"> A massive open online course (MOOC) entirely centered around OCaml</a> <i>is now available, and runs once a year!</i>
 	  <p>
-          Learn more, and <a href="https://www.fun-mooc.fr/courses/parisdiderot/56002S02/session02/about">register now on the FUN platform!</a>
+          Learn more, and <a href="https://www.fun-mooc.fr/courses/course-v1:parisdiderot+56002+session03/about">register now on the FUN platform!</a>
 	  </p>
 		  <p class="documentation-video" style="margin-bottom:0">
 <iframe src="//www.slideshare.net/slideshow/embed_code/43836300" width="340" height="290" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>


### PR DESCRIPTION
I thought I've missed the oppurtunity, but it just linked to the last year.