### PR TITLE
Change the order of the suggested Ubuntu packages.

### DIFF
--- a/site/docs/install.fr.md
+++ b/site/docs/install.fr.md
@@ -78,8 +78,9 @@ Ils sont disponibles selon
 ### [Ubuntu](https://www.ubuntu.com/)
 
 ```bash
-apt install ocaml-nox # Si vous ne voulez pas le support de X11 
-apt install ocaml
+apt install ocaml # Avec le support de X11 (donc le module Graphics)
+
+apt install ocaml-nox # Plus léger, si vous ne voulez pas le support de X11 
 ```
 
 Les autres paquets Unbuntu liés à OCaml sont


### PR DESCRIPTION
It seems that students looking to install OCaml on Ubuntu will find this page, not know what X11 means and proceed to install using the first suggested command. By swapping the two suggested commands, we ensure that people who don't know what they are doing are getting X11 support and the Graphics package.