### PR TITLE
Fix (and add) FreeBSD install instructions

### DIFF
--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -167,6 +167,7 @@ port install opam
 ```bash
 pkg install ocaml-nox11 # If you don't want X11 support
 pkg install ocaml
+pkg install ocaml-opam
 ```
 
 ## [OpenBSD](https://www.openbsd.org/) [![OpenBSD port](https://repology.org/badge/version-only-for-repo/openbsd/ocaml.svg)](https://repology.org/metapackage/ocaml)

--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -165,8 +165,8 @@ port install opam
 ## [FreeBSD](https://www.freebsd.org/) [![FreeBSD port](https://repology.org/badge/version-only-for-repo/freebsd/ocaml.svg)](https://repology.org/metapackage/ocaml)
 
 ```bash
-pkg_add -r ocaml-nox11 # If you don't want X11 support
-pkg_add -r ocaml
+pkg install ocaml-nox11 # If you don't want X11 support
+pkg install ocaml
 ```
 
 ## [OpenBSD](https://www.openbsd.org/) [![OpenBSD port](https://repology.org/badge/version-only-for-repo/openbsd/ocaml.svg)](https://repology.org/metapackage/ocaml)


### PR DESCRIPTION
This changes the use of `pkg_add` to `pkg` since the latter replaced the former years ago.  No currently supported release of FreeBSD even has `pkg_add` anymore.

This also adds install instructions for getting opam using `pkg`.