### PR TITLE
Fixing common typos (throughout the site)

### DIFF
--- a/script/code.ml
+++ b/script/code.ml
@@ -1,4 +1,4 @@
-(* Syntax hightlight code and eval ocaml toplevel phrases *)
+(* Syntax highlight code and eval ocaml toplevel phrases *)
 
 open Printf
 open Scanf
@@ -221,7 +221,7 @@ let add_prompt =
   let nl_re = Str.regexp "[\n\r]" in
   let indent_string s = Str.global_replace nl_re "\n  " s in
   fun phrase ->
-  (* Due to the prompt, one must add 2 spaces at the beginnig of each line *)
+  (* Due to the prompt, one must add 2 spaces at the beginning of each line *)
   let phrase = omd_map_string indent_string phrase in
   let open Omd in
   [Html_block("span", ["class", Some "ocaml-prompt"], [Raw "# "]);

--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -11,7 +11,7 @@
   /*
       This is a blank LESS mixin that can be added to LESS files that
       should not be included in the final build. This mixin
-      will break their standalone build. exluding them from
+      will break their standalone build. excluding them from
       output while not bloating the compiled file size, since blank
       declarations are stripped out by most compressors.
   */
@@ -95,7 +95,7 @@ img {
   /* Responsive images (ensure images don't scale beyond their parents) */
 
   max-width: 100%;
-  /* Part 1: Set a maxium relative to the parent */
+  /* Part 1: Set a maximum relative to the parent */
 
   width: auto\9;
   /* IE7-8 need help adjusting responsive images */
@@ -4849,7 +4849,7 @@ a.thumbnail:focus {
   /*
       This is a blank LESS mixin that can be added to LESS files that
       should not be included in the final build. This mixin
-      will break their standalone build. exluding them from
+      will break their standalone build. excluding them from
       output while not bloating the compiled file size, since blank
       declarations are stripped out by most compressors.
   */
@@ -5325,7 +5325,7 @@ a.badge:focus {
   /*
       This is a blank LESS mixin that can be added to LESS files that
       should not be included in the final build. This mixin
-      will break their standalone build. exluding them from
+      will break their standalone build. excluding them from
       output while not bloating the compiled file size, since blank
       declarations are stripped out by most compressors.
   */
@@ -5375,7 +5375,7 @@ body {
   /*
       This is a blank LESS mixin that can be added to LESS files that
       should not be included in the final build. This mixin
-      will break their standalone build. exluding them from
+      will break their standalone build. excluding them from
       output while not bloating the compiled file size, since blank
       declarations are stripped out by most compressors.
   */
@@ -5928,7 +5928,7 @@ body {
   /*
       This is a blank LESS mixin that can be added to LESS files that
       should not be included in the final build. This mixin
-      will break their standalone build. exluding them from
+      will break their standalone build. excluding them from
       output while not bloating the compiled file size, since blank
       declarations are stripped out by most compressors.
   */
@@ -6005,7 +6005,7 @@ body {
   /*
       This is a blank LESS mixin that can be added to LESS files that
       should not be included in the final build. This mixin
-      will break their standalone build. exluding them from
+      will break their standalone build. excluding them from
       output while not bloating the compiled file size, since blank
       declarations are stripped out by most compressors.
   */
@@ -7009,7 +7009,7 @@ body {
   /*
       This is a blank LESS mixin that can be added to LESS files that
       should not be included in the final build. This mixin
-      will break their standalone build. exluding them from
+      will break their standalone build. excluding them from
       output while not bloating the compiled file size, since blank
       declarations are stripped out by most compressors.
   */

--- a/site/learn/companies.md
+++ b/site/learn/companies.md
@@ -48,7 +48,7 @@
         <h2><a href="http://www.citrix.com">Citrix</a>, United Kingdom</h2>
         <p>Citrix uses OCaml in XenServer, a world-class
         server virtualization system. Most components of XenServer are
-        realeased as open source. The open-source XenServer toolstack
+        released as open source. The open-source XenServer toolstack
         components implemented in OCaml are bundled in the <a
         href="https://github.com/xapi-project/xs-opam">XS-Opam</a>
         repository on GitHub.</p>

--- a/site/learn/faq.md
+++ b/site/learn/faq.md
@@ -71,7 +71,7 @@ bug reports and features request, and submit new ones.
 * * *
 
 ###  Basic types
-#### Is it possible to do computations with arbritrary precision arithmetics?
+#### Is it possible to do computations with arbitrary precision arithmetic?
 
 OCaml provides a library called `Num` that handles exact arithmetic computation
 for rational numbers.
@@ -563,7 +563,7 @@ This message appears when the OCaml compiler tries to compile a function
 or a value which is monomorphic, but for which some types have not been
 completely inferred. Some types variables are left in the type, which
 are are called “weak” (and are displayed by an underscore: `'_a`); they
-will disappear thanks to type inference as soon as enough informations
+will disappear thanks to type inference as soon as enough information
 will be given.
 
 ```ocamltop

--- a/site/learn/tutorials/99problems.md
+++ b/site/learn/tutorials/99problems.md
@@ -715,7 +715,7 @@ SOLUTION
 > 
 > (* Sorting according to length frequency : prepend frequency, sort,
 >    remove frequency. Frequencies are extracted by sorting lengths
->    and applying RLE to count occurences of each length (see problem
+>    and applying RLE to count occurrences of each length (see problem
 >    "Run-length encoding of a list.") *)
 > let rle list =
 >   let rec aux count acc = function
@@ -3101,7 +3101,7 @@ SOLUTION
 > ```
 > You may want to look at
 > [more efficient algorithms](http://link.springer.com/article/10.1007%2Fs10489-009-0200-0)
-> and implement them so you can solve the following within resonable time:
+> and implement them so you can solve the following within reasonable time:
 >
 > ```ocaml
 > solve [[14]; [1;1]; [7;1]; [3;3]; [2;3;2];

--- a/site/learn/tutorials/calling_c_libraries.md
+++ b/site/learn/tutorials/calling_c_libraries.md
@@ -166,7 +166,7 @@ method show_all = gtk_widget_show_all obj
 Notice that we pass the underlying `GtkObject` to both C library calls.
 This makes sense because these functions are prototyped as
 `void gtk_widget_show (GtkWidget *);` in C (`GtkWidget` and `GtkObject`
-are safely used interchangably in this context).
+are safely used interchangeably in this context).
 
 I want to describe the `label` class (the real one this time!), but in
 between `widget` and `label` is `misc`, a generic class which describes

--- a/site/learn/tutorials/debug.md
+++ b/site/learn/tutorials/debug.md
@@ -93,7 +93,7 @@ define and understand. Let me say that we use the notion of *runtime
 events* that happen for instance when a parameter is passed to a
 function or when entering a pattern matching, or selecting a clause in a
 pttern matching. Computation progress is taken into account by these
-events, independantly of the instructions executed on the hardware.
+events, independently of the instructions executed on the hardware.
 
 Although this is difficult to implement, there exists such a debugger
 for OCaml under Unix: `ocamldebug` (there also exists one for Caml
@@ -163,7 +163,7 @@ Program end.
 Uncaught exception: Not_found
 (ocd)
 ```
-Self explanatory, is'nt it? So, you want to step backward to set the
+Self explanatory, isn't it? So, you want to step backward to set the
 program counter before the time the exception is raised; hence type in
 `b` as *backstep*, and you get
 

--- a/site/learn/tutorials/error_handling.md
+++ b/site/learn/tutorials/error_handling.md
@@ -156,7 +156,7 @@ are:
   if printing is required.
 - some polymorphic variant, with one case per
   possible error. This is very accurate (each error can be dealt with
-  explicitely and occurs in the type) but the use of polymorphic variants
+  explicitly and occurs in the type) but the use of polymorphic variants
   sometimes make error messages hard to read.
 
 

--- a/site/learn/tutorials/guidelines.md
+++ b/site/learn/tutorials/guidelines.md
@@ -350,7 +350,7 @@ else if cond3 ...
 ```
 > 
 > **Justification**: `elsif` is a keyword in many languages, so use
-> indentation and `else if` to bring it to mind. Morever, you do not
+> indentation and `else if` to bring it to mind. Moreover, you do not
 > have to look to the end of line to know whether the condition is
 > continued or another test is performed.
 > 

--- a/site/learn/tutorials/if_statements_loops_and_recursion.md
+++ b/site/learn/tutorials/if_statements_loops_and_recursion.md
@@ -407,7 +407,7 @@ except over the characters of the string.
 Now we come to a hard topic - recursion. Functional programmers are
 defined by their love of recursive functions, and in many ways recursive
 functions in f.p. are the equivalent of loops in imperative programming.
-In functional languages loops are second-class citizens, whilest
+In functional languages loops are second-class citizens, whilst
 recursive functions get all the best support.
 
 Writing recursive functions requires a change in mindset from writing

--- a/site/learn/tutorials/map.md
+++ b/site/learn/tutorials/map.md
@@ -54,7 +54,7 @@ simple print function.
 let print_users key password =
   print_string(key ^ " " ^ password ^ "\n");;
 ```
-We have here a function that will take two strings, a key and a pasword,
+We have here a function that will take two strings, a key and a password,
 and print them out nicely, including a new line character at the end.
 All we need to do is to have this function applied to our mapping. Here
 is what that would look like.

--- a/site/learn/tutorials/modules.md
+++ b/site/learn/tutorials/modules.md
@@ -85,7 +85,7 @@ submodules, ...) to the rest of the program that is using it. If nothing
 special is done, everything which is defined in a module will be
 accessible from outside. That's often fine in small personal programs,
 but there are many situations where it is better that a module only
-provides what it is meant to provide, not any of the auxilliary
+provides what it is meant to provide, not any of the auxiliary
 functions and types that are used internally.
 
 For this we have to define a module interface, which will act as a mask

--- a/site/learn/tutorials/objects.md
+++ b/site/learn/tutorials/objects.md
@@ -496,7 +496,7 @@ necessarily using classes.
 
 ###  Immediate objects and object types
 Objects can be used instead of records, and have some nice properties
-that can make them preferrable to records in some cases. We saw that the
+that can make them preferable to records in some cases. We saw that the
 canonical way of creating objects is to first define a class, and use
 this class to create individual objects. This can be cumbersome in some
 situations since class definitions are more than a type definition and
@@ -549,7 +549,7 @@ but each solution has its own advantages:
  data structure where only their common methods are visible (see next
  section)
 * **type definitions**: there is no need to define an object type in
- advance, so it lightens the dependency contraints between modules
+ advance, so it lightens the dependency constraints between modules
 
 ###  Class types vs. just types
 Beware of the confusion between *class types* and object *types*. A

--- a/site/learn/tutorials/ocamlbuild/CrossCompiler.md
+++ b/site/learn/tutorials/ocamlbuild/CrossCompiler.md
@@ -159,7 +159,7 @@ Linux cross-compiler, based on a C cross-toolchain obtained from
 crosstool.
 
 In order to improve the patch, as well as this page, I would like to
-hear about both sucessful and unsucessful uses of them. Please send a
+hear about both successful and unsuccessful uses of them. Please send a
 mail to [xavier.clerc@inria.fr](mailto:xavier.clerc@inria.fr) to report.
 
 ## Related resources

--- a/site/learn/tutorials/ocamlbuild/Making_plugins.md
+++ b/site/learn/tutorials/ocamlbuild/Making_plugins.md
@@ -87,7 +87,7 @@ plugins are plugged into OCamlbuild.
 ### Change options
 You can use a plugin to set the value of an OCamlbuild option such as
 `-no-hygiene` or `-ocamlc`. This way you won't have to write the option
-everytime on the command line.
+every time on the command line.
 
 To set an option, simply set the option reference. All these references
 are defined in the
@@ -95,7 +95,7 @@ are defined in the
 module of the API.
 
 Remember that if you change the reference `Before_options`, the value set
-in your plugin can still be overriden by the command line. If you want
+in your plugin can still be overridden by the command line. If you want
 to force the value of an option you have to do it `After_options`. See
 the example in the previous section.
 

--- a/site/learn/tutorials/ocamlbuild/Ocamlbuild_and_module_packs.md
+++ b/site/learn/tutorials/ocamlbuild/Ocamlbuild_and_module_packs.md
@@ -41,7 +41,7 @@ namespace with modules `Bli`, `Blo` and `Blu` (which will be reached using
 
 The previous approach doesn't work if the files `bli.ml`, `blo.ml` and
 `blu.ml` depend on each other and are in different directories. Let's
-assume that `blo.ml` depends on `bli.ml`. If they are in the same direcory,
+assume that `blo.ml` depends on `bli.ml`. If they are in the same directory,
 there is no problem because `Blo` sees the whole content of its directory.
 But if `otherdir1` and `otherdir2` are different, then you get an error
 because `Bli` is unbound in `Blo`.

--- a/site/learn/tutorials/ocamlbuild/Using_an_ocamlfind_installation_of_sexplib.md
+++ b/site/learn/tutorials/ocamlbuild/Using_an_ocamlfind_installation_of_sexplib.md
@@ -1,4 +1,4 @@
-<!-- ((! set title Using an ocamlfind installtion of sexplib !)) ((! set learn !)) -->
+<!-- ((! set title Using an ocamlfind installation of sexplib !)) ((! set learn !)) -->
 
 # Using an ocamlfind installation of sexplib
 Install type-conv and sexplib according to the instructions given at

--- a/site/learn/tutorials/performance_and_profiling.md
+++ b/site/learn/tutorials/performance_and_profiling.md
@@ -70,7 +70,7 @@ foo:
 ```
 This declares a global symbol called `foo`. It means the address of the
 next thing to come can be named `foo`. Writing just `foo:` without the
-preceeding `.globl` directive declares a local symbol (local to just the
+preceding `.globl` directive declares a local symbol (local to just the
 current file).
 
 ```assembly
@@ -895,7 +895,7 @@ perf report
 ```
 
 The first command launches `foo.native` with arguments `a b c d` and
-records profiling informations in `perf.data`; the second command
+records profiling information in `perf.data`; the second command
 starts an interactive program to explore the call graph. The option
 `--call-graph=dwarf` makes perf aware of the calling convention of
 OCaml (with old versions of `perf`, enabling frame pointers in OCaml

--- a/site/learn/tutorials/pointers.md
+++ b/site/learn/tutorials/pointers.md
@@ -96,8 +96,8 @@ We thus see that fields of list cells in the C program have to be
 mutable, otherwise initialization is impossible. By contrast in OCaml,
 allocation and initialization are merged into a single basic operation:
 constructor application. This way, immutable data structures are
-definable (those data types are often refered to as “pure” or
-“functionnal” data structures). If physical modifications are necessary
+definable (those data types are often referred to as “pure” or
+“functional” data structures). If physical modifications are necessary
 for other reasons than mere initialization, OCaml provides records with
 mutable fields. For instance, a list type defining lists whose elements
 can be in place modified could be written:
@@ -116,7 +116,7 @@ and cell = {mutable hd : int; mutable tl : list};;
 ```
 Physical assignments are still useless to allocate mutable data: you
 write `Cons {hd = 1; tl = l}` to add `1` to the list `l`. Physical
-assigments that remain in OCaml programs should be just those
+assignments that remain in OCaml programs should be just those
 assignments that are mandatory to implement the algorithm at hand.
 
 ###  Pointers and mutable fields or vectors
@@ -126,7 +126,7 @@ in records. For this kind of use of pointers, the Pascal's instruction:
 `x^.label := val` (where `x` is a value of a record having a `label`
 field) corresponds to the OCaml construct `x.label <- val` (where `x` is
 a value of a record having a `label` mutable field). The Pascal's `^`
-symbol simply disapears, since dereferencing is automatically handled by
+symbol simply disappears, since dereferencing is automatically handled by
 the OCaml compiler.
 
 **In conclusion:** You can use explicit pointers in OCaml, exactly as in
@@ -145,7 +145,7 @@ type 'a pointer = Null | Pointer of 'a ref
 Explicit dereferencing (or reading the pointer's designated value) and
 pointer assignment (or writing to the pointer's designated memory
 location) are easily defined. We define dereferencing as a prefix
-operator named `!^`, and assigment as the infix `^:=`.
+operator named `!^`, and assignment as the infix `^:=`.
 
 ```ocamltop
 let ( !^ ) = function

--- a/site/learn/tutorials/streams.md
+++ b/site/learn/tutorials/streams.md
@@ -496,7 +496,7 @@ let hash_of_stream stream =
     stream;
   result
 ```
-What if you want to convert arbitary data types to streams? Well, if the
+What if you want to convert arbitrary data types to streams? Well, if the
 data type defines an `iter` function, and you don't mind using threads,
 you can use a producer-consumer arrangement to invert control:
 

--- a/site/meetings/ocaml/2008/index.md
+++ b/site/meetings/ocaml/2008/index.md
@@ -99,8 +99,8 @@ packages, and what's generally happening behind the user interface.
 
 ### ocamlbuild, by Nicolas Pouillard
 
-Nicolas Pouillard is an OCaml developper, working for Gallium since
-two years, he has made a renovation of Camlp4 and also developped
+Nicolas Pouillard is an OCaml developer, working for Gallium since
+two years, he has made a renovation of Camlp4 and also developed
 ocamlbuild with Berke Durak.
 
 This talk presents ocamlbuild, a compilation manager that was added to
@@ -118,7 +118,7 @@ be extended through plug-ins written in OCaml itself.
 
 ### OCaml in Debian, by Sylvain Le Gall
 
-Sylvain Le Gall is a Debian Developper working on OCaml packages since
+Sylvain Le Gall is a Debian Developer working on OCaml packages since
 2003 and OCaml programmer since 2000.
 
 This talk is about how OCaml is integrated into the Debian GNU/Linux

--- a/site/meetings/ocaml/2009/index.md
+++ b/site/meetings/ocaml/2009/index.md
@@ -84,7 +84,7 @@ OCaml. It is based on the building of STSort, a fast sorting GNU sort
 like utilities. It will try to show how to go from specification of a
 full project to achieving a high level of performance for it.
 
-It will show how mixing functionnal and imperative style in an
+It will show how mixing functional and imperative style in an
 application is one of the important feature of OCaml.
 
 [Slides](http://forge.ocamlcore.org/docman/view.php/77/37/OCaml%20as%20fast%20as%20C.pdf)
@@ -134,7 +134,7 @@ subscription will be closed on 25th January 2009.
 
 As of 27th January 2009, the subscription is closed.
 
-People, who whish to join at the restaurant, should add (R) just after
+People, who wish to join at the restaurant, should add (R) just after
 their name in the list. Organization team will use this list to book
 the restaurant on Ferburay 3rd. You can update your entry until
 February 2nd.

--- a/site/meetings/ocaml/2011/index.md
+++ b/site/meetings/ocaml/2011/index.md
@@ -92,7 +92,7 @@ a Web browser. Its key features are the following:
 - The whole language, and most of the standard library are supported.
 - The generated code runs very fast
 - The compiler is easy to install: it only depends on Findlib and Lwt.
-- The generated code is independant of Eliom and the Ocsigen server. You can use it with any Web server.
+- The generated code is independent of Eliom and the Ocsigen server. You can use it with any Web server.
 - You can use a standard installation of OCaml to compile your programs. In particular, you do not have to recompile a library to use it with Js_of_ocaml. You just have to link your program with a specific library to interface with the browser APIs.
 - Binding Javascript libraries is very easy
 

--- a/site/releases/4.03.md
+++ b/site/releases/4.03.md
@@ -6,7 +6,7 @@ This page describes OCaml version **4.03.0**, released on
 [here](http://caml.inria.fr/pub/distrib/ocaml-4.03/) for all 4.03.*
 files.
 
-This release is availabe as multiple OPAM switches:
+This release is available as multiple OPAM switches:
 
 - 4.03.0 — Official 4.03.0 release
 - 4.03.0+flambda — Official 4.03.0 release with flambda enabled

--- a/site/releases/4.04.md
+++ b/site/releases/4.04.md
@@ -6,7 +6,7 @@ This page describes OCaml version **4.04.2**, released on
 [here](http://caml.inria.fr/pub/distrib/ocaml-4.04/) for all 4.04.*
 files.
 
-This release is availabe as multiple OPAM switches:
+This release is available as multiple OPAM switches:
 
 - 4.04.2 — Official 4.04.2 release
 - 4.04.2+flambda — Official 4.04.2 release with flambda enabled

--- a/site/releases/4.05.md
+++ b/site/releases/4.05.md
@@ -6,7 +6,7 @@ This page describes OCaml version **4.05.0**, released on
 [here](http://caml.inria.fr/pub/distrib/ocaml-4.05/) for all 4.05.*
 files.
 
-This release is availabe as multiple [OPAM](https://opam.ocaml.org/doc/Usage.html) switches:
+This release is available as multiple [OPAM](https://opam.ocaml.org/doc/Usage.html) switches:
 
 - 4.05.0 — Official 4.05.0 release
 - 4.05.0+flambda — Official 4.05.0 release with flambda enabled

--- a/site/releases/4.06.md
+++ b/site/releases/4.06.md
@@ -6,7 +6,7 @@ This page describes OCaml version **4.06.0**, released on
 [here](http://caml.inria.fr/pub/distrib/ocaml-4.06/) for all 4.06.*
 files.
 
-This release is availabe as multiple
+This release is available as multiple
 [OPAM](https://opam.ocaml.org/doc/Usage.html) switches:
 
 - 4.06.0 — Official 4.06.0 release
@@ -578,7 +578,7 @@ This is the
 
 * [MPR#7478](https://caml.inria.fr/mantis/view.php?id=7478), [GPR#1037](https://github.com/ocaml/ocaml/pull/1037): ocamldoc, do not use as a module preamble documentation
   comments that occur after the first module element. This change may break
-  existing documenation. In particular, module preambles must now come before
+  existing documentation. In particular, module preambles must now come before
   any `open` statement.  
   (Florian Angeletti, review by David Allsopp and report by Daniel Bünzli)
 

--- a/site/releases/4.07.0.md
+++ b/site/releases/4.07.0.md
@@ -347,12 +347,12 @@ This is the
   (Fuyong Quah, Leo White, review by Xavier Clerc)
 
 - [GPR#1665](https://github.com/ocaml/ocaml/pull/1665):
-  reduce the size of cmx files in classic mode by droping the
+  reduce the size of cmx files in classic mode by dropping the
   bodies of functions that will not be inlined
   (Fuyong Quah, review by Leo White and Pierre Chambart)
 
 - [GPR#1666](https://github.com/ocaml/ocaml/pull/1666):
-  reduce the size of cmx files in classic mode by droping the
+  reduce the size of cmx files in classic mode by dropping the
   bodies of functions that cannot be reached from the module block
   (Fuyong Quah, review by Leo White and Pierre Chambart)
 


### PR DESCRIPTION
**Note:**
Typos found with codespell https://github.com/codespell-project/codespell

using this "magic" command:

$ codespell -q 2 -S "*it.md,*fr.md,*de.md,*books.md" -L amin,cmo,millon,que,cas,cristal,iff,nd,ot,adresse,softwares,openin,ith,ue,nott
