### PR TITLE
install: fix a typo

### DIFF
--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -40,7 +40,7 @@ opam switch create 4.06.1
 eval `opam env`
 # check you got what you want
 which ocaml
-ocaml --version
+ocaml -version
 ```
 
 ## Linux


### PR DESCRIPTION
Dear developers.

In my environment, `--version` is unknown option.
Probably, `-version` is valid option for `ocaml` command.