### PR TITLE
-debug is not a valid option for ocamlbuild

### DIFF
--- a/site/learn/tutorials/error_handling.md
+++ b/site/learn/tutorials/error_handling.md
@@ -79,7 +79,7 @@ val foo : a -> b
 
 To get a stacktrace when a unhandled exception makes your program crash, you
 need to compile the program in "debug" mode (with `-g` when calling
-`ocamlc`, or `-debug` when calling `ocamlbuild`).
+`ocamlc`, or `-tag 'debug'` when calling `ocamlbuild`).
 Then:
 
     OCAMLRUNPARAM=b ./myprogram [args]


### PR DESCRIPTION
The way to enable debugging information is to set the 'debug' tag, as described in the ocamlbuild manual.