### PR TITLE
add dune to automated build systems links

### DIFF
--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -141,6 +141,7 @@ necessary. See next section.
 
 ## Automated build systems
 
+- [dune](https://dune.readthedocs.io/en/latest/quick-start.html)
 - [OCamlbuild](ocamlbuild/)
 - [GNU make](compiling_with_gnu_make.html)
 - [OMake](compiling_with_omake.html)


### PR DESCRIPTION
we should have a link to the dune documentation in the automated build systems