### PR TITLE
Add Ahrefs's tech blog to planet

### DIFF
--- a/planet_feeds.txt
+++ b/planet_feeds.txt
@@ -75,3 +75,4 @@ Cryptosense|https://cryptosense.com/tag/ocaml/feed/
 Gabriel Radanne|http://drup.github.io/feed-ocaml.xml
 The BAP Blog|https://binaryanalysisplatform.github.io/feed.xml
 Tarides|https://tarides.com/feed.xml
+Ahrefs|https://tech.ahrefs.com/feed

--- a/planet_feeds.txt
+++ b/planet_feeds.txt
@@ -75,4 +75,4 @@ Cryptosense|https://cryptosense.com/tag/ocaml/feed/
 Gabriel Radanne|http://drup.github.io/feed-ocaml.xml
 The BAP Blog|https://binaryanalysisplatform.github.io/feed.xml
 Tarides|https://tarides.com/feed.xml
-Ahrefs|https://tech.ahrefs.com/feed
+Ahrefs|https://medium.com/feed/ahrefs/tagged/ocaml


### PR DESCRIPTION
name for the feed: Ahrefs
url: https://tech.ahrefs.com/feed

The tech blog is focused on articles related to technologies we are using: ocaml, reasonml, bucklescript.