### PR TITLE
Remove broken tutorial link to Utretch publication about OCaml.

### DIFF
--- a/site/learn/tutorials/index.md
+++ b/site/learn/tutorials/index.md
@@ -148,8 +148,6 @@ tools and libraries.
 These tutorials help learn OCaml from the perspective of being familiar
 with another language.
 
-* [Beyond functional programming in Haskell: an introduction to
- OCaml](http://www.cs.uu.nl/wiki/pub/Stc/BeyondFunctionalProgrammingInHaskell:AnIntroductionToOCaml/ocaml.pdf)
 * [OCaml for Haskellers](http://blog.ezyang.com/2010/10/ocaml-for-haskellers/)
 
 ###  Advanced Tutorials & Articles


### PR DESCRIPTION
This is a broken link.  I can't find the Utretch university wiki available anymore or this publication itself.