### PR TITLE
OCaml 4.10.0 release

### DIFF
--- a/site/releases/4.10.0.md
+++ b/site/releases/4.10.0.md
@@ -1,0 +1,632 @@
+<!-- ((! set title OCaml 4.10.0 !)) -->
+
+# OCaml 4.10.0
+This page describes OCaml version **4.10.0**, released on
+2020-02-21.  Go [here](./) for a list of all releases and
+[here](http://caml.inria.fr/pub/distrib/ocaml-4.09/) for all 4.09.*
+files.
+
+This release is available as multiple
+[OPAM](https://opam.ocaml.org/doc/Usage.html) switches:
+
+- 4.10.0 — Official release 4.10.0
+- 4.10.0+flambda — Official release 4.10.0, with flambda activated
+
+- 4.10.0+afl — Official release 4.10.0, with afl-fuzz instrumentation
+- 4.10.0+spacetime - Official 4.10.0 release with spacetime activated
+
+- 4.10.0+default-unsafe-string — Official release 4.10.0, without
+  safe strings by default
+- 4.10.0+no-flat-float-array - Official release 4.10.0, with
+  --disable-flat-float-array
+- 4.10.0+flambda+no-flat-float-array — Official release 4.10.0, with
+  flambda activated and --disable-flat-float-array
+- 4.10.0+fp — Official release 4.10.0, with frame-pointers
+- 4.10.0+fp+flambda — Official release 4.10.0, with frame-pointers
+  and flambda activated
+- 4.10.0+musl+static+flambda - Official release 4.10.0, compiled with
+  musl-gcc -static and with flambda activated
+
+- 4.10.0+32bit - Official release 4.10.0, compiled in 32-bit mode
+  for 64-bit Linux and OS X hosts
+- 4.10.0+bytecode-only - Official release 4.10.0, without the
+  native-code compiler
+
+
+What's new
+----------
+Some of the highlights in release 4.10 are:
+
+- A new best-fit allocator for the major heap which reducing both GC cost an
+   memory usage.
+- Immutable strings are now enforced at configuration time
+- User-defined indexing operators for multidimensional arrays
+- Coming soon: statmemprof, a new statistical memory profiler. The external API
+  will be release next version.
+- Miscellaneous improvements to the manual
+- A more precise exhaustiveness check for GADTs
+- Many bug fixes
+
+For a comprehensive list of changes and details on all new features,
+bug fixes, optimizations, etc., please consult the
+[changelog](#Changes).
+
+![](../img/source.gif "") Source distribution
+---------------------------------------------
+
+- [Source
+  tarball](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.0.tar.gz)
+  (.tar.gz) for compilation under Unix (including Linux and MacOS X)
+  and Microsoft Windows (including Cygwin).
+- Also available in
+  [.tar.xz](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.0.tar.xz)
+  format.
+- [OPAM](https://opam.ocaml.org/) is a source-based distribution of
+  OCaml and many companion libraries and tools. Compilation and
+  installation are automated by powerful package managers.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+The
+[INSTALL](http://caml.inria.fr/pub/distrib/ocaml-4.10/notes/INSTALL.adoc) file
+of the distribution provides detailed compilation and installation
+instructions — see also the [Windows release
+notes](http://caml.inria.fr/pub/distrib/ocaml-4.10/notes/README.win32.adoc) for
+instructions on how to build under Windows.
+
+Alternative Compilers
+---------------------
+
+Additionally, the following projects allow you to compile OCaml code to
+targets traditionally associated with other languages:
+
+* [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) is a stable OCaml
+  to JavaScript compiler.
+* [Bucklescript](http://bucklescript.github.io/bucklescript/) is a
+  newer OCaml to JavaScript compiler. See its
+  [wiki](https://github.com/bucklescript/bucklescript/wiki/Differences-from-js_of_ocaml) for
+  an explanation of how it differs from `js_of_ocaml`.
+* [OCaml-java](http://www.ocamljava.org/) is a stable OCaml to
+  Java compiler.
+
+![](../img/doc.gif "") User's manual
+------------------------------------
+
+The user's manual for OCaml can be:
+
+- [browsed
+  online](http://caml.inria.fr/pub/docs/manual-ocaml-4.10/index.html),
+- downloaded as a single
+  [PostScript](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10-refman.ps.gz),
+  [PDF](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10-refman.pdf),
+  or [plain
+  text](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10-refman.txt)
+  document,
+- downloaded as a single
+  [TAR](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10-refman-html.tar.gz)
+  or
+  [ZIP](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10-refman-html.zip)
+  archive of HTML files,
+- downloaded as a single
+  [tarball](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10-refman.info.tar.gz)
+  of Emacs info files,
+
+
+
+![](../img/source.gif "") Download directory
+--------------------------------------------
+
+All the files are also available in [this
+directory](http://caml.inria.fr/pub/distrib/ocaml-4.10), along with
+their MD5 and SHA512 checksums.
+
+
+
+
+Changes
+-------
+
+This is the
+[changelog](http://caml.inria.fr/pub/distrib/ocaml-4.10/notes/Changes).
+
+(Changes that can break existing programs are marked with a "*")
+
+### Language features
+
+- [#7757](https://github.com/ocaml/ocaml/issues/7757), [#1726](https://github.com/ocaml/ocaml/issues/1726): multi-indices for extended indexing operators:
+  `a.%{0;1;2}` desugars to `( .%{ ;.. } ) a [|0;1;2|]`
+  (Florian Angeletti, review by Gabriel Radanne)
+
+* [*breaking change*] [#1859](https://github.com/ocaml/ocaml/issues/1859), [#9117](https://github.com/ocaml/ocaml/issues/9117): enforce safe (immutable) strings by removing
+  the -unsafe-string option by default. This can be overridden by
+  a configure-time option (available since 4.04 in 2016):
+  --disable-force-safe-string since 4.08, -no-force-safe-since
+  between 4.07 and 4.04.
+  In the force-safe-string mode (now the default), the return type of the
+  String_val macro in C stubs is `const char*` instead of
+  `char*`. This change may break C FFI code.
+  (Kate Deplaix)
+
+
+- [#6662](https://github.com/ocaml/ocaml/issues/6662), [#8908](https://github.com/ocaml/ocaml/issues/8908): allow writing "module _ = E" to ignore module expressions
+  (Thomas Refis, review by Gabriel Radanne)
+
+### Runtime system:
+
+- [#8809](https://github.com/ocaml/ocaml/issues/8809), [#9292](https://github.com/ocaml/ocaml/issues/9292): Add a best-fit allocator for the major heap; still
+  experimental, it should be much better than current allocation
+  policies (first-fit and next-fit) for programs with large heaps,
+  reducing both GC cost and memory usage.
+  This new best-fit is not (yet) the default; set it explicitly with
+  OCAMLRUNPARAM="a=2" (or Gc.set from the program). You may also want
+  to increase the `space_overhead` parameter of the GC (a percentage,
+  80 by default), for example OCAMLRUNPARAM="o=85", for optimal
+  speed.
+  (Damien Doligez, review by Stephen Dolan, Jacques-Henri Jourdan,
+   Xavier Leroy, Leo White)
+
+* [*breaking change*] [#8713](https://github.com/ocaml/ocaml/issues/8713), [#8940](https://github.com/ocaml/ocaml/issues/8940), [#9115](https://github.com/ocaml/ocaml/issues/9115), [#9143](https://github.com/ocaml/ocaml/issues/9143), [#9202](https://github.com/ocaml/ocaml/issues/9202), [#9251](https://github.com/ocaml/ocaml/issues/9251):
+  Introduce a state table in the runtime to contain the global variables.
+  (The Multicore runtime will have one such state for each domain.)
+
+   This changes the status of some internal variables of the OCaml runtime;
+   in many cases the header file originally defining the internal variable
+   provides a compatibility macro with the old name, but programs
+   re-defining those variables by hand need to be fixed.
+
+   (KC Sivaramakrishnan and Stephen Dolan,
+    compatibility hacking by David Allsopp, Florian Angeletti, Kate Deplaix,
+    Jacques Garrigue, Guillaume Munch-Maccagnoni and Nicolás Ojeda Bär,
+    review by David Allsopp, Alain Frisch, Nicolas Ojeda Bar,
+    Gabriel Scherer, Damien Doligez, and Guillaume Munch-Maccagnoni)
+
+- [#8993](https://github.com/ocaml/ocaml/issues/8993): New C functions caml_process_pending_actions{,_exn} in
+  caml/signals.h, intended for executing all pending actions inside
+  long-running C functions (requested minor and major collections,
+  signal handlers, finalisers, and memprof callbacks). The function
+  caml_process_pending_actions_exn returns any exception arising
+  during their execution, allowing resources to be cleaned-up before
+  re-raising.
+  (Guillaume Munch-Maccagnoni, review by Jacques-Henri Jourdan,
+   Stephen Dolan, and Gabriel Scherer)
+
+* [*breaking change*] [#8691](https://github.com/ocaml/ocaml/issues/8691), [#8897](https://github.com/ocaml/ocaml/issues/8897), [#9027](https://github.com/ocaml/ocaml/issues/9027): Allocation functions are now guaranteed not to
+  trigger any OCaml callback when called from C. In long-running C
+  functions, this can be replaced with calls to
+  caml_process_pending_actions at safe points.
+  Side effect of this change: in bytecode mode, polling for
+  asynchronous callbacks is performed at every minor heap allocation,
+  in addition to function calls and loops as in previous OCaml
+  releases.
+  (Jacques-Henri Jourdan, review by Stephen Dolan, Gabriel Scherer and
+   Guillaume Munch-Maccagnoni)
+
+* [*breaking change*] [#9037](https://github.com/ocaml/ocaml/issues/9037): caml_check_urgent_gc is now guaranteed not to trigger any
+  finaliser. In long-running C functions, this can be replaced
+  with calls to caml_process_pending_actions at safe points.
+  (Guillaume Munch-Maccagnoni, review by Jacques-Henri Jourdan and
+   Stephen Dolan)
+
+
+- [#8619](https://github.com/ocaml/ocaml/issues/8619): Ensure Gc.minor_words remains accurate after a GC.
+  (Stephen Dolan, Xavier Leroy and David Allsopp,
+   review by Xavier Leroy and Gabriel Scherer)
+
+- [#8667](https://github.com/ocaml/ocaml/issues/8667): Limit GC credit to 1.0
+  (Leo White, review by Damien Doligez)
+
+- [#8670](https://github.com/ocaml/ocaml/issues/8670): Fix stack overflow detection with systhreads
+  (Stephen Dolan, review by Xavier Leroy, Anil Madhavapeddy, Gabriel Scherer,
+   Frédéric Bour and Guillaume Munch-Maccagnoni)
+
+* [*breaking change*] [#8711](https://github.com/ocaml/ocaml/issues/8711): The major GC hooks are no longer allowed to interact with the
+   OCaml heap.
+   (Jacques-Henri Jourdan, review by Damien Doligez)
+
+- [#8630](https://github.com/ocaml/ocaml/issues/8630): Use abort() instead of exit(2) in caml_fatal_error, and add
+  the new hook caml_fatal_error_hook.
+  (Jacques-Henri Jourdan, review by Xavier Leroy)
+
+- [#8641](https://github.com/ocaml/ocaml/issues/8641): Better call stacks when a C call is involved in byte code mode
+  (Jacques-Henri Jourdan, review by Xavier Leroy)
+
+- [#8634](https://github.com/ocaml/ocaml/issues/8634), [#8668](https://github.com/ocaml/ocaml/issues/8668), [#8684](https://github.com/ocaml/ocaml/issues/8684), [#9103](https://github.com/ocaml/ocaml/issues/9103) (originally [#847](https://github.com/ocaml/ocaml/issues/847)): Statistical memory profiling.
+  In OCaml 4.10, support for allocations in the minor heap in native
+  mode is not available, and callbacks for promotions and
+  deallocations are not available.
+  Hence, there is not any public API for this feature yet.
+  (Jacques-Henri Jourdan, review by Stephen Dolan, Gabriel Scherer
+   and Damien Doligez)
+
+- [#9268](https://github.com/ocaml/ocaml/issues/9268), [#9271](https://github.com/ocaml/ocaml/issues/9271): Fix bytecode backtrace generation with large integers present.
+  (Stephen Dolan and Mark Shinwell, review by Gabriel Scherer and
+   Jacques-Henri Jourdan)
+
+### Standard library:
+
+- [#8760](https://github.com/ocaml/ocaml/issues/8760): List.concat_map : ('a -> 'b list) -> 'a list -> 'b list
+  (Gabriel Scherer, review by Daniel Bünzli and Thomas Refis)
+
+- [#8832](https://github.com/ocaml/ocaml/issues/8832): List.find_map : ('a -> 'b option) -> 'a list -> 'b option
+  (Gabriel Scherer, review by Jeremy Yallop, Nicolás Ojeda Bär
+   and Daniel Bünzli)
+
+- [#7672](https://github.com/ocaml/ocaml/issues/7672), [#1492](https://github.com/ocaml/ocaml/issues/1492): Add `Filename.quote_command` to produce properly-quoted
+  commands for execution by Sys.command.
+  (Xavier Leroy, review by David Allsopp and Damien Doligez)
+
+- [#8971](https://github.com/ocaml/ocaml/issues/8971): Add `Filename.null`, the conventional name of the "null" device.
+  (Nicolás Ojeda Bär, review by Xavier Leroy and Alain Frisch)
+
+- [#8651](https://github.com/ocaml/ocaml/issues/8651): add '%#F' modifier in printf to output OCaml float constants
+  in hexadecimal
+  (Pierre Roux, review by Gabriel Scherer and Xavier Leroy)
+
+
+- [#8657](https://github.com/ocaml/ocaml/issues/8657): Optimization in [Array.make] when initializing with unboxed
+   or young values.
+   (Jacques-Henri Jourdan, review by Gabriel Scherer and Stephen Dolan)
+
+- [#8716](https://github.com/ocaml/ocaml/issues/8716): Optimize [Array.fill] and [Hashtbl.clear] with a new runtime primitive
+  (Alain Frisch, review by David Allsopp, Stephen Dolan and Damien Doligez)
+
+- [#8530](https://github.com/ocaml/ocaml/issues/8530): List.sort: avoid duplicate work by chop
+  (Guillaume Munch-Maccagnoni, review by David Allsopp, Damien Doligez and
+   Gabriel Scherer)
+
+### Other libraries:
+
+- [#1939](https://github.com/ocaml/ocaml/issues/1939), [#2023](https://github.com/ocaml/ocaml/issues/2023): Implement Unix.truncate and Unix.ftruncate on Windows.
+  (Florent Monnier and Nicolás Ojeda Bär, review by David Allsopp)
+
+### Code generation and optimizations:
+
+- [#8806](https://github.com/ocaml/ocaml/issues/8806): Add an [@@immediate64] attribute for types that are known to
+  be immediate only on 64 bit platforms
+  (Jérémie Dimino, review by Vladimir Keleshev)
+
+- [#9028](https://github.com/ocaml/ocaml/issues/9028), [#9032](https://github.com/ocaml/ocaml/issues/9032): Fix miscompilation by no longer assuming that
+  untag_int (tag_int x) = x in Cmmgen; the compilation of `(n lsl 1) + 1`,
+  for example, would be incorrect if evaluated with a large value for `n`.
+  (Stephen Dolan, review by Vincent Laviron and Xavier Leroy)
+
+- [#8672](https://github.com/ocaml/ocaml/issues/8672): Optimise Switch code generation on booleans.
+  (Stephen Dolan, review by Pierre Chambart)
+
+
+- [#8990](https://github.com/ocaml/ocaml/issues/8990): amd64: Emit 32bit registers for Iconst_int when we can
+  (Xavier Clerc, Tom Kelly and Mark Shinwell, review by Xavier Leroy)
+
+- [#2322](https://github.com/ocaml/ocaml/issues/2322): Add pseudo-instruction `Ladjust_trap_depth` to replace
+  dummy Lpushtrap generated in linearize
+  (Greta Yorsh and Vincent Laviron, review by Xavier Leroy)
+
+- [#8707](https://github.com/ocaml/ocaml/issues/8707): Simplif: more regular treatment of Tupled and Curried functions
+  (Gabriel Scherer, review by Leo White and Alain Frisch)
+
+- [#8526](https://github.com/ocaml/ocaml/issues/8526): Add compile-time option -function-sections in ocamlopt to emit
+  each function in a separate named text section on supported targets.
+  (Greta Yorsh, review by Pierre Chambart)
+
+- [#2321](https://github.com/ocaml/ocaml/issues/2321): Eliminate dead ICatch handlers
+  (Greta Yorsh, review by Pierre Chambart and Vincent Laviron)
+
+- [#8919](https://github.com/ocaml/ocaml/issues/8919): lift mutable lets along with immutable ones
+  (Leo White, review by Pierre Chambart)
+
+- [#8909](https://github.com/ocaml/ocaml/issues/8909): Graph coloring register allocator: the weights put on
+  preference edges should not be divided by 2 in branches of
+  conditional constructs, because it is not good for performance
+  and because it leads to ignoring preference edges with 0 weight.
+  (Eric Stavarache, review by Xavier Leroy)
+
+- [#9006](https://github.com/ocaml/ocaml/issues/9006): int32 code generation improvements
+  (Stephen Dolan, designed with Greta Yorsh, review by Xavier Clerc,
+   Xavier Leroy and Alain Frisch)
+
+- [#9041](https://github.com/ocaml/ocaml/issues/9041): amd64: Avoid stall in sqrtsd by clearing destination.
+  (Stephen Dolan, with thanks to Andrew Hunter, Will Hasenplaugh,
+   Spiros Eliopoulos and Brian Nigito. Review by Xavier Leroy)
+
+- [#2165](https://github.com/ocaml/ocaml/issues/2165): better unboxing heuristics for let-bound identifiers
+  (Alain Frisch, review by Vincent Laviron and Gabriel Scherer)
+
+- [#8735](https://github.com/ocaml/ocaml/issues/8735): unbox across static handlers
+  (Alain Frisch, review by Vincent Laviron and Gabriel Scherer)
+
+### Manual and documentation:
+
+- [#8718](https://github.com/ocaml/ocaml/issues/8718), [#9089](https://github.com/ocaml/ocaml/issues/9089): syntactic highlighting for code examples in the manual
+  (Florian Angeletti, report by Anton Kochkov, review by Gabriel Scherer)
+
+- [#9101](https://github.com/ocaml/ocaml/issues/9101): add links to section anchor before the section title,
+  make the name of those anchor explicits.
+  (Florian Angeletti, review by Daniel Bünzli, Sébastien Hinderer,
+   and Gabriel Scherer)
+
+- [#9257](https://github.com/ocaml/ocaml/issues/9257), cautionary guidelines for using the internal runtime API
+  without too much updating pain.
+  (Florian Angeletti, review by Daniel Bünzli, Guillaume Munch-Maccagnoni
+   and KC Sivaramakrishnan)
+
+
+- [#8950](https://github.com/ocaml/ocaml/issues/8950): move local opens in pattern out of the extension chapter
+  (Florian Angeletti, review and suggestion by Gabriel Scherer)
+
+- [#9088](https://github.com/ocaml/ocaml/issues/9088), [#9097](https://github.com/ocaml/ocaml/issues/9097): fix operator character classes
+  (Florian Angelettion, review by Gabriel Scherer,
+   report by Clément Busschaert)
+
+- [#9169](https://github.com/ocaml/ocaml/issues/9169): better documentation for the best-fit allocation policy
+  (Gabriel Scherer, review by Guillaume Munch-Maccagnoni
+   and Florian Angeletti)
+
+### Compiler user-interface and warnings:
+
+- [#8833](https://github.com/ocaml/ocaml/issues/8833): Hint for (type) redefinitions in toplevel session
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#2127](https://github.com/ocaml/ocaml/issues/2127), [#9185](https://github.com/ocaml/ocaml/issues/9185): Refactor lookup functions
+  Included observable changes:
+    - makes the location of usage warnings and alerts for constructors more
+      precise
+    - don't warn about a constructor never being used to build values when it
+      has been defined as private
+  (Leo White, Hugo Heuzard review by Thomas Refis, Florian Angeletti)
+
+- [#8702](https://github.com/ocaml/ocaml/issues/8702), [#8777](https://github.com/ocaml/ocaml/issues/8777): improved error messages for fixed row polymorphic variants
+  (Florian Angeletti, report by Leo White, review by Thomas Refis)
+
+- [#8844](https://github.com/ocaml/ocaml/issues/8844): Printing faulty constructors, inline records fields and their types
+  during type mismatches. Also slightly changed other type mismatches error
+  output.
+  (Mekhrubon Turaev, review by Florian Angeletti, Leo White)
+
+- [#8885](https://github.com/ocaml/ocaml/issues/8885): Warn about unused local modules
+  (Thomas Refis, review by Alain Frisch)
+
+- [#8872](https://github.com/ocaml/ocaml/issues/8872): Add ocamlc option "-output-complete-exe" to build a self-contained
+  binary for bytecode programs, containing the runtime and C stubs.
+  (Stéphane Glondu, Nicolás Ojeda Bär, review by Jérémie Dimino and Daniel
+  Bünzli)
+
+- [#8874](https://github.com/ocaml/ocaml/issues/8874): add tests for typechecking error messages and pack them into
+  pretty-printing boxes.
+  (Oxana Kostikova, review by Gabriel Scherer)
+
+- [#8891](https://github.com/ocaml/ocaml/issues/8891): Warn about unused functor parameters
+  (Thomas Refis, review by Gabriel Radanne)
+
+- [#8903](https://github.com/ocaml/ocaml/issues/8903): Improve errors for first-class modules
+  (Leo White, review by Jacques Garrigue)
+
+- [#8914](https://github.com/ocaml/ocaml/issues/8914): clarify the warning on unboxable types used in external primitives (61)
+  (Gabriel Scherer, review by Florian Angeletti, report on the Discourse forum)
+
+- [#9046](https://github.com/ocaml/ocaml/issues/9046): disable warning 30 by default
+  This outdated warning complained on label/constructor name conflicts
+  within a mutually-recursive type declarations; there is now no need
+  to complain thanks to type-based disambiguation.
+  (Gabriel Scherer)
+
+### Tools:
+
+* [*breaking change*] [#6792](https://github.com/ocaml/ocaml/issues/6792), [#8654](https://github.com/ocaml/ocaml/issues/8654) ocamldebug now supports programs using Dynlink. This
+  changes ocamldebug messages, which may break compatibility
+  with older emacs modes.
+  (Whitequark and Jacques-Henri Jourdan, review by Gabriel Scherer
+   and Xavier Clerc)
+
+- [#8621](https://github.com/ocaml/ocaml/issues/8621): Make ocamlyacc a Windows Unicode application
+  (David Allsopp, review by Nicolás Ojeda Bär)
+
+* [*breaking change*] [#8834](https://github.com/ocaml/ocaml/issues/8834), `ocaml`: adhere to the XDG base directory specification to
+  locate an `.ocamlinit` file. Reads an `$XDG_CONFIG_HOME/ocaml/init.ml`
+  file before trying to lookup `~/.ocamlinit`. On Windows the behaviour
+  is unchanged.
+  (Daniel C. Bünzli, review by David Allsopp, Armaël Guéneau and
+   Nicolás Ojeda Bär)
+
+- [#9113](https://github.com/ocaml/ocaml/issues/9113): ocamldoc: fix the rendering of multi-line code blocks
+  in the 'man' backend.
+  (Gabriel Scherer, review by Florian Angeletti)
+
+- [#9127](https://github.com/ocaml/ocaml/issues/9127), [#9130](https://github.com/ocaml/ocaml/issues/9130): ocamldoc: fix the formatting of closing brace in record types.
+  (David Allsopp, report by San Vu Ngoc)
+
+- [#9181](https://github.com/ocaml/ocaml/issues/9181): make objinfo work on Cygwin and look for the caml_plugin_header
+  symbol in both the static and the dynamic symbol tables.
+  (Sébastien Hinderer, review by Gabriel Scherer and David Allsopp)
+
+### Build system:
+
+- [#8840](https://github.com/ocaml/ocaml/issues/8840): use ocaml{c,opt}.opt when available to build internal tools
+  On my machine this reduces parallel-build times from 3m30s to 2m50s.
+  (Gabriel Scherer, review by Xavier Leroy and Sébastien Hinderer)
+
+- [#8650](https://github.com/ocaml/ocaml/issues/8650): ensure that "make" variables are defined before use;
+  revise generation of config/util.ml to better quote special characters
+  (Xavier Leroy, review by David Allsopp)
+
+- [#8690](https://github.com/ocaml/ocaml/issues/8690), [#8696](https://github.com/ocaml/ocaml/issues/8696): avoid rebuilding the world when files containing primitives
+  change.
+  (Stephen Dolan, review by Gabriel Scherer, Sébastien Hinderer and
+   Thomas Refis)
+
+- [#8835](https://github.com/ocaml/ocaml/issues/8835): new configure option --disable-stdlib-manpages to disable building
+  and installation of the library manpages.
+  (David Allsopp, review by Florian Angeletti and Gabriel Scherer)
+
+- [#8837](https://github.com/ocaml/ocaml/issues/8837): build manpages using ocamldoc.opt when available
+  cuts the manpages build time from 14s to 4s
+  (Gabriel Scherer, review by David Allsopp and Sébastien Hinderer,
+   report by David Allsopp)
+
+- [#8843](https://github.com/ocaml/ocaml/issues/8843), [#8841](https://github.com/ocaml/ocaml/issues/8841): fix use of off_t on 32-bit systems.
+  (Stephen Dolan, report by Richard Jones, review by Xavier Leroy)
+
+- [#8947](https://github.com/ocaml/ocaml/issues/8947), [#9134](https://github.com/ocaml/ocaml/issues/9134), [#9302](https://github.com/ocaml/ocaml/issues/9302), [#9311](https://github.com/ocaml/ocaml/issues/9311): fix/improve support for the BFD library
+  (Sébastien Hinderer, review by Damien Doligez and David Allsopp)
+
+- [#8951](https://github.com/ocaml/ocaml/issues/8951): let make's default target build the compiler
+  (Sébastien Hinderer, review by David Allsopp)
+
+- [#8995](https://github.com/ocaml/ocaml/issues/8995): allow developers to specify frequently-used configure options in
+  Git (ocaml.configure option) and a directory for host-specific, shareable
+  config.cache files (ocaml.configure-cache option). See HACKING.adoc for
+  further details.
+  (David Allsopp, review by Gabriel Scherer)
+
+- [#9136](https://github.com/ocaml/ocaml/issues/9136): Don't propagate Cygwin-style prefix from configure to
+  Makefile.config on Windows ports.
+  (David Allsopp, review by Sébastien Hinderer)
+
+### Internal/compiler-libs changes:
+
+- [#8828](https://github.com/ocaml/ocaml/issues/8828): Added abstractions for variants, records, constructors, fields and
+  extension constructor types mismatch.
+  (Mekhrubon Turaev, review by Florian Angeletti, Leo White and Gabriel Scherer)
+
+- [#7927](https://github.com/ocaml/ocaml/issues/7927), [#8527](https://github.com/ocaml/ocaml/issues/8527): Replace long tuples into records in typeclass.ml
+  (Ulugbek Abdullaev, review by David Allsopp and Gabriel Scherer)
+
+- [#1963](https://github.com/ocaml/ocaml/issues/1963): split cmmgen into generic Cmm helpers and clambda transformations
+  (Vincent Laviron, review by Mark Shinwell)
+
+- [#1901](https://github.com/ocaml/ocaml/issues/1901): Fix lexing of character literals in comments
+  (Pieter Goetschalckx, review by Damien Doligez)
+
+- [#1932](https://github.com/ocaml/ocaml/issues/1932): Allow octal escape sequences and identifiers containing apostrophes
+  in ocamlyacc actions and comments.
+  (Pieter Goetschalckx, review by Damien Doligez)
+
+- [#2288](https://github.com/ocaml/ocaml/issues/2288): Move middle end code from [Asmgen] to [Clambda_middle_end] and
+  [Flambda_middle_end].  Run [Un_anf] from the middle end, not [Cmmgen].
+  (Mark Shinwell, review by Pierre Chambart)
+
+- [#8692](https://github.com/ocaml/ocaml/issues/8692): Remove Misc.may_map and similar
+  (Leo White, review by Gabriel Scherer and Thomas Refis)
+
+- [#8677](https://github.com/ocaml/ocaml/issues/8677): Use unsigned comparisons in amd64 and i386 emitter of Lcondbranch3.
+  (Greta Yorsh, review by Xavier Leroy)
+
+- [#8766](https://github.com/ocaml/ocaml/issues/8766): Parmatch: introduce a type for simplified pattern heads
+  (Gabriel Scherer and Thomas Refis, review by Stephen Dolan and
+   Florian Angeletti)
+
+- [#8774](https://github.com/ocaml/ocaml/issues/8774): New implementation of Env.make_copy_of_types
+  (Alain Frisch, review by Thomas Refis, Leo White and Jacques Garrigue)
+
+- [#7924](https://github.com/ocaml/ocaml/issues/7924): Use a variant instead of an int in Bad_variance exception
+  (Rian Douglas, review by Gabriel Scherer)
+
+- [#8890](https://github.com/ocaml/ocaml/issues/8890): in -dtimings output, show time spent in C linker clearly
+  (Valentin Gatien-Baron)
+
+- [#8910](https://github.com/ocaml/ocaml/issues/8910), [#8911](https://github.com/ocaml/ocaml/issues/8911): minor improvements to the printing of module types
+  (Gabriel Scherer, review by Florian Angeletti)
+
+- [#8913](https://github.com/ocaml/ocaml/issues/8913): ocamltest: improve 'promote' implementation to take
+  skipped lines/bytes into account
+  (Gabriel Scherer, review by Sébastien Hinderer)
+
+- [#8908](https://github.com/ocaml/ocaml/issues/8908): Use an option instead of a string for module names ("_" becomes None),
+  and a dedicated type for functor parameters: "()" maps to "Unit" (instead of
+  "*").
+  (Thomas Refis, review by Gabriel Radanne)
+
+- [#8928](https://github.com/ocaml/ocaml/issues/8928): Move contains_calls and num_stack_slots from Proc to Mach.fundecl
+  (Greta Yorsh, review by Florian Angeletti and Vincent Laviron)
+
+- [#8959](https://github.com/ocaml/ocaml/issues/8959), [#8960](https://github.com/ocaml/ocaml/issues/8960), [#8968](https://github.com/ocaml/ocaml/issues/8968), [#9023](https://github.com/ocaml/ocaml/issues/9023): minor refactorings in the typing of patterns:
+  + refactor the {let,pat}_bound_idents* functions
+  + minor bugfix in type_pat
+  + refactor the generic pattern-traversal functions
+    in Typecore and Typedtree
+  + restrict the use of Need_backtrack
+  (Gabriel Scherer and Florian Angeletti,
+   review by Thomas Refis and Gabriel Scherer)
+
+- [#9030](https://github.com/ocaml/ocaml/issues/9030): clarify and document the parameter space of type_pat
+  (Gabriel Scherer and Florian Angeletti and Jacques Garrigue,
+   review by Florian Angeletti and Thomas Refis)
+
+- [#8975](https://github.com/ocaml/ocaml/issues/8975): "ocamltests" files are no longer required or used by
+  "ocamltest". Instead, any text file in the testsuite directory containing a
+  valid "TEST" block will be automatically included in the testsuite.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer and Sébastien Hinderer)
+
+- [#8992](https://github.com/ocaml/ocaml/issues/8992): share argument implementations between executables
+  (Florian Angeletti, review by Gabriel Scherer)
+
+- [#9015](https://github.com/ocaml/ocaml/issues/9015): fix fatal error in pprint_ast ([#8789](https://github.com/ocaml/ocaml/issues/8789))
+  (Damien Doligez, review by ...)
+
+### Bug fixes:
+
+- [#5673](https://github.com/ocaml/ocaml/issues/5673), [#7636](https://github.com/ocaml/ocaml/issues/7636): unused type variable causes generalization error
+  (Jacques Garrigue and Leo White, review by Leo White,
+   reports by Jean-Louis Giavitto and Christophe Raffalli)
+
+- [#6922](https://github.com/ocaml/ocaml/issues/6922), [#8955](https://github.com/ocaml/ocaml/issues/8955): Fix regression with -principal type inference for inherited
+  methods, allowing to compile ocamldoc with -principal
+  (Jacques Garrigue, review by Leo White)
+
+- [#7925](https://github.com/ocaml/ocaml/issues/7925), [#8611](https://github.com/ocaml/ocaml/issues/8611): fix error highlighting for exceptionally
+  long toplevel phrases
+  (Kyle Miller, reported by Armaël Guéneau, review by Armaël Guéneau
+   and Nicolás Ojeda Bär)
+
+- [#8622](https://github.com/ocaml/ocaml/issues/8622): Don't generate #! headers over 127 characters.
+  (David Allsopp, review by Xavier Leroy and Stephen Dolan)
+
+- [#8715](https://github.com/ocaml/ocaml/issues/8715): minor bugfixes in CamlinternalFormat; removes the unused
+  and misleading function CamlinternalFormat.string_of_formatting_gen
+  (Gabriel Scherer and Florian Angeletti,
+   review by Florian Angeletti and Gabriel Radanne)
+
+- [#8792](https://github.com/ocaml/ocaml/issues/8792), [#9018](https://github.com/ocaml/ocaml/issues/9018): Possible (latent) bug in Ctype.normalize_type
+  removed incrimined Btype.log_type, replaced by Btype.set_type
+  (Jacques Garrigue, report by Alain Frisch, review by Thomas Refis)
+
+- [#8856](https://github.com/ocaml/ocaml/issues/8856), [#8860](https://github.com/ocaml/ocaml/issues/8860): avoid stackoverflow when printing cyclic type expressions
+  in some error submessages.
+  (Florian Angeletti, report by Mekhrubon Turaev, review by Leo White)
+
+- [#8875](https://github.com/ocaml/ocaml/issues/8875): fix missing newlines in the output from MSVC invocation.
+  (Nicolás Ojeda Bär, review by Gabriel Scherer)
+
+- [#8921](https://github.com/ocaml/ocaml/issues/8921), [#8924](https://github.com/ocaml/ocaml/issues/8924): Fix stack overflow with Flambda
+  (Vincent Laviron, review by Pierre Chambart and Leo White,
+   report by Aleksandr Kuzmenko)
+
+- [#8892](https://github.com/ocaml/ocaml/issues/8892), [#8895](https://github.com/ocaml/ocaml/issues/8895): fix the definition of Is_young when CAML_INTERNALS is not
+  defined.
+  (David Allsopp, review by Xavier Leroy)
+
+- [#8896](https://github.com/ocaml/ocaml/issues/8896): deprecate addr typedef in misc.h
+  (David Allsopp, suggestion by Xavier Leroy)
+
+- [#8981](https://github.com/ocaml/ocaml/issues/8981): Fix check for incompatible -c and -o options.
+  (Greta Yorsh, review by Damien Doligez)
+
+- [#9019](https://github.com/ocaml/ocaml/issues/9019), [#9154](https://github.com/ocaml/ocaml/issues/9154): Unsound exhaustivity of GADTs from incomplete unification
+  Also fixes bug found by Thomas Refis in [#9012](https://github.com/ocaml/ocaml/issues/9012)
+  (Jacques Garrigue, report and review by Leo White, Thomas Refis)
+
+- [#9031](https://github.com/ocaml/ocaml/issues/9031): Unregister Windows stack overflow handler while shutting
+  the runtime down.
+  (Dmitry Bely, review by David Allsopp)
+
+- [#9051](https://github.com/ocaml/ocaml/issues/9051): fix unregistered local root in win32unix/select.c (could result in
+  `select` returning file_descr-like values which weren't in the original sets)
+  and correct initialisation of some blocks allocated with caml_alloc_small.
+  (David Allsopp, review by Xavier Leroy)
+
+- [#9073](https://github.com/ocaml/ocaml/issues/9073), [#9120](https://github.com/ocaml/ocaml/issues/9120): fix incorrect GC ratio multiplier when allocating custom blocks
+  with caml_alloc_custom_mem in runtime/custom.c
+  (Markus Mottl, review by Gabriel Scherer and Damien Doligez)
+
+- [#9209](https://github.com/ocaml/ocaml/issues/9209), [#9212](https://github.com/ocaml/ocaml/issues/9212): fix a development-version regression caused by [#2288](https://github.com/ocaml/ocaml/issues/2288)
+  (Kate Deplaix and David Allsopp, review by Sébastien Hinderer
+   and Gabriel Scherer )

--- a/site/releases/index.fr.md
+++ b/site/releases/index.fr.md
@@ -10,6 +10,7 @@ instructions pour installer OCaml par d'autres moyens que la
 compilation des sources, comme par exemple le gestionnaire de paquets
 OPAM et les gestionnaire de paquets spécifiques à une plateforme.
 
+* OCaml [4.10.0](4.10.0.html), publiée le 20 février 2020.
 * OCaml [4.09.0](4.09.0.html), publiée le 18 septembre 2019.
 * OCaml [4.08.1](4.08.1.html), publiée le 5 août 2019.
 * OCaml [4.08.0](4.08.0.html), publiée le 14 juin 2019.

--- a/site/releases/index.md
+++ b/site/releases/index.md
@@ -9,6 +9,7 @@ See also the [install](/docs/install.html) page for instructions on
 installing OCaml by other means, such as the OPAM package manager and
 platform specific package managers.
 
+* OCaml [4.10.0](4.10.0.html), released Feb 21, 2020.
 * OCaml [4.09.0](4.09.0.html), released Sep 18, 2019.
 * OCaml [4.08.1](4.08.1.html), released Aug 5, 2019.
 * OCaml [4.08.0](4.08.0.html), released Jun 14, 2019.


### PR DESCRIPTION
This PR adds a release file for the upcoming OCaml 4.10 and a link in the release index .