### PR TITLE
Use #require instead of #load to load graphics module in tutorial

### DIFF
--- a/site/learn/tutorials/structure_of_ocaml_programs.md
+++ b/site/learn/tutorials/structure_of_ocaml_programs.md
@@ -262,7 +262,7 @@ first load the
 library with
 
 ```ocaml
-#load "graphics.cma";;
+#require "graphics";;
 ```
 Windows users: For this example to work interactively on Windows, you
 will need to create a custom toplevel. Issue the command `ocamlmktop


### PR DESCRIPTION
I am learning ocaml by following the ocaml.org tutorial. I have found it excellent so far but got very stuck at the point:

> To use Graphics in the interactive toplevel, you must first load the library with
> ```
> #load "graphics.cma";;
> ```

It took me some time to discover I needed to run `#require "graphics";;` before `#load` so I think it is worth documenting this. Should we also mention running `#use "topfind";;` first? In my case I didn't need to do this but I'm not sure if that will be the same for everyone.