### PR TITLE
Correct OCaml 4.10.0 release date in index.md

### DIFF
--- a/site/index.md
+++ b/site/index.md
@@ -118,7 +118,7 @@
 			  <h1><a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
 			       href="/releases/{{! get LATEST_OCAML_VERSION !}}.html"
 				   >Release of OCaml {{! get LATEST_OCAML_VERSION !}}</a></h1>
-			   <p>June 14, 2019</p>
+			   <p>February 21, 2020</p>
 			   <a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
 			      href="/releases/{{! get LATEST_OCAML_VERSION !}}.html">
 			    <img alt="" src="/img/announcement.svg" class="svg" />


### PR DESCRIPTION
According to [_its individual release page_](https://ocaml.org/releases/4.10.0.html) and [_the main release page_](https://ocaml.org/releases/), OCaml 4.10.0 was released on Feb 21, 2020; not Flag Day, 2019.