### PR TITLE
basics ja: Modify to more suitable link

### DIFF
--- a/site/learn/tutorials/basics.ja.md
+++ b/site/learn/tutorials/basics.ja.md
@@ -60,7 +60,7 @@ $ ./my_prog.native
 Hello, World!
 ```
 
-詳細に付いては、[Compiling OCaml projects](compiling_ocaml_projects.html)を参照して下さい。
+詳細に付いては、[OCamlプログラムをコンパイルする](compiling_ocaml_projects.ja.html)を参照して下さい。
 
 コメント
 --------


### PR DESCRIPTION
Currently, this link moves us from the page of Japanese to the page of English.

I think suitable that the language of the page is the same source of link and destination.