### PR TITLE
Remove embarassingly-old dates

### DIFF
--- a/site/community/mailing_lists.fr.md
+++ b/site/community/mailing_lists.fr.md
@@ -26,9 +26,7 @@ implémentations OCaml de l'Inria. Le but de cette tribune est de mettre
 en commun les expériences, échanger idées et morceaux de code, et
 discuter des applications du langage OCaml. Il faut être inscrit à la
 liste avant de pouvoir y poster des messages. Les messages y sont écrits
-principalement en anglais, mais parfois aussi en français. En 2010, la
-liste compte environ 1500 abonnées, qui échangent de l'ordre de 300
-messages par mois.
+principalement en anglais, mais parfois aussi en français.
 
 [Abonnement](https://sympa.inria.fr/sympa/subscribe/caml-list) |
 [Archives OCaml](https://inbox.ocaml.org/caml-list) |

--- a/site/community/mailing_lists.md
+++ b/site/community/mailing_lists.md
@@ -34,8 +34,7 @@ implementations developed at Inria. The purpose of this list is to share
 experience, exchange ideas and code, and report on applications of the
 OCaml language. This list is not moderated, but posting is restricted to
 the subscribers of the list. Messages are generally in English but
-sometimes also in French. In 2010, the list has about 1500 subscribers,
-who exchange about 300 messages per month.
+sometimes also in French.
 
 [Subscribe](https://sympa.inria.fr/sympa/subscribe/caml-list)
 |

--- a/site/docs/index.fr.md
+++ b/site/docs/index.fr.md
@@ -57,7 +57,7 @@
                     </a>
                 </div>
                 <div class="span2">                    
-                    <p>Il y a plusieurs excellents livres sur OCaml, dont deux nouveaux titres publiés en 2013. Ainsi, Real World OCaml est disponible <a href="https://realworldocaml.org">online</a> en anglais.</p>
+                    <p>Il y a plusieurs excellents livres sur OCaml, dont deux nouveaux titres publiés récemment. Ainsi, Real World OCaml est disponible <a href="https://realworldocaml.org">online</a> en anglais.</p>
                 </div>
             </div>
             <footer>

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -82,7 +82,7 @@
                 </div>
             </div>
             <footer>
-            <p>There are a number of excellent books available, with the most recent title published in 2014.</p>
+            <p>There are a number of excellent books available, with two new titles published recently.</p>
             <p><a href="/learn/books.html">See more books</a> / <a href="/docs/papers.html">See more papers</a> / <a href="https://realworldocaml.org">Read Real World OCaml online</a></p>
             </footer>
         </section>

--- a/site/learn/index.fr.md
+++ b/site/learn/index.fr.md
@@ -56,7 +56,7 @@ OCaml est un langage générique de programmation, de puissance industrielle, qu
                 src="/img/OCaml_from_beginning.png" width="48%"
 				alt="OCaml from the very beginning"></a>
 				<p style="clear:both"
->De nombreux livres sont disponibles sur OCaml, dont deux publiés en 2013.
+>De nombreux livres sont disponibles sur OCaml, dont deux publiés récemment.
 		</p>
 		<footer>
                   <p><a href="books.html">Voir la liste complète des livres sur OCaml</a></p>

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -62,7 +62,7 @@
                 src="/img/OCaml_from_beginning.png" width="48%"
 				alt="OCaml from the very beginning"></a>
 				<p style="clear:both">There are a number of excellent
-				books, with two new titles published in 2013.
+				books, with two new titles published in recent years.
 		</p>
 		<footer>
                   <p><a href="books.html">See full list</a></p>


### PR DESCRIPTION
The most recently-published books being from 2013, and the subscriber stats for 2010 caml-list might lead the casual reader of ocaml.org to believe the language is out-dated. We fix them.