### PR TITLE
OCaml 4.11.1

### DIFF
--- a/site/index.md
+++ b/site/index.md
@@ -118,7 +118,7 @@
 			  <h1><a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
 			       href="/releases/{{! get LATEST_OCAML_VERSION !}}.html"
 				   >Release of OCaml {{! get LATEST_OCAML_VERSION !}}</a></h1>
-			   <p>August 19, 2020</p>
+			   <p>August 31, 2020</p>
 			   <a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
 			      href="/releases/{{! get LATEST_OCAML_VERSION !}}.html">
 			    <img alt="" src="/img/announcement.svg" class="svg" />

--- a/site/releases/4.11.0.md
+++ b/site/releases/4.11.0.md
@@ -185,7 +185,7 @@ Called from Foo.bar in file "foo.ml", line 16, characters 42-53
 - [#9426](https://github.com/ocaml/ocaml/issues/9426): build the Mingw ports with higher levels of GCC optimization
   (Xavier Leroy, review by Sébastien Hinderer)
 
-* [*breaking change*] [#9483](https://github.com/ocaml/ocaml/issues/9483): Remove accidental inclusion of <stdio.h> in <caml/misc.h>
+* \[*breaking change*\] [#9483](https://github.com/ocaml/ocaml/issues/9483): Remove accidental inclusion of <stdio.h> in <caml/misc.h>
   The only release with the inclusion of stdio.h has been 4.10.0
   (Christopher Zimmermann, review by Xavier Leroy and David Allsopp)
 
@@ -347,7 +347,7 @@ Called from Foo.bar in file "foo.ml", line 16, characters 42-53
   symbol in both the static and the dynamic symbol tables.
   (Sébastien Hinderer, review by Gabriel Scherer and David Allsopp)
 
-* [*breaking change*] [#9197](https://github.com/ocaml/ocaml/issues/9197): remove compatibility logic from [#244](https://github.com/ocaml/ocaml/issues/244) that was designed to
+* \[*breaking change*\] [#9197](https://github.com/ocaml/ocaml/issues/9197): remove compatibility logic from [#244](https://github.com/ocaml/ocaml/issues/244) that was designed to
   synchronize toplevel printing margins with Format.std_formatter,
   but also resulted in unpredictable/fragile changes to formatter
   margins.
@@ -439,7 +439,7 @@ Called from Foo.bar in file "foo.ml", line 16, characters 42-53
   Doligez)
 
 
-* [*breaking change*] [#7678](https://github.com/ocaml/ocaml/issues/7678), [#8631](https://github.com/ocaml/ocaml/issues/8631): ocamlc -c and ocamlopt -c pass same switches to the C
+* \[*breaking change*\] [#7678](https://github.com/ocaml/ocaml/issues/7678), [#8631](https://github.com/ocaml/ocaml/issues/8631): ocamlc -c and ocamlopt -c pass same switches to the C
   compiler when compiling .c files (in particular, this means ocamlopt
   passes -fPIC on systems requiring it for shared library support).
   (David Allsopp, report by Daniel Bünzli, review by Sébastien Hinderer)
@@ -537,7 +537,7 @@ Called from Foo.bar in file "foo.ml", line 16, characters 42-53
 - [#9402](https://github.com/ocaml/ocaml/issues/9402): Remove `sudo:false` from .travis.yml
   (Hikaru Yoshimura)
 
-* [*breaking change*] [#9411](https://github.com/ocaml/ocaml/issues/9411): forbid optional arguments reordering with -nolabels
+* \[*breaking change*\] [#9411](https://github.com/ocaml/ocaml/issues/9411): forbid optional arguments reordering with -nolabels
   (Thomas Refis, review by Frédéric Bour and Jacques Garrigue)
 
 - [#9414](https://github.com/ocaml/ocaml/issues/9414): testsuite, ocamltest: keep test artifacts only on failure.
@@ -641,7 +641,7 @@ Called from Foo.bar in file "foo.ml", line 16, characters 42-53
 - [#9384](https://github.com/ocaml/ocaml/issues/9384), [#9385](https://github.com/ocaml/ocaml/issues/9385): Fix copy scope bugs in substitutions
   (Leo White, review by Thomas Refis, report by Nick Roberts)
 
-* [*breaking change*] [#9388](https://github.com/ocaml/ocaml/issues/9388): Prohibit signature local types with constraints
+* \[*breaking change*\] [#9388](https://github.com/ocaml/ocaml/issues/9388): Prohibit signature local types with constraints
   (Leo White, review by Jacques Garrigue)
 
 - [#9406](https://github.com/ocaml/ocaml/issues/9406), [#9409](https://github.com/ocaml/ocaml/issues/9409): fix an error with packed module types from missing

--- a/site/releases/4.11.1.md
+++ b/site/releases/4.11.1.md
@@ -1,0 +1,16 @@
+<!-- ((! set title OCaml 4.11.1 !)) -->
+
+# OCaml 4.11.1
+
+This page describe OCaml **4.11.1**, released on Aug 31, 2020.  It is
+a bug-fix release of [OCaml 4.11.0](4.11.0.html).
+
+### Bug fixes:
+
+- [#9856](https://github.com/ocaml/ocaml/issues/9856), [#9857](https://github.com/ocaml/ocaml/issues/9857): Prevent polymorphic type annotations from generalizing
+  weak polymorphic variables.
+  (Leo White, report by Thierry Martinez, review by Jacques Garrigue)
+
+- [#9859](https://github.com/ocaml/ocaml/issues/9859), [#9862](https://github.com/ocaml/ocaml/issues/9862): Remove an erroneous assertion when inferred function types
+  appear in the right hand side of an explicit :> coercion
+  (Florian Angeletti, report by Jerry James, review by Thomas Refis)

--- a/site/releases/index.fr.md
+++ b/site/releases/index.fr.md
@@ -10,6 +10,7 @@ instructions pour installer OCaml par d'autres moyens que la
 compilation des sources, comme par exemple le gestionnaire de paquets
 OPAM et les gestionnaire de paquets spécifiques à une plateforme.
 
+* OCaml [4.11.1](4.11.1.html), publiée le 31 août 2020.
 * OCaml [4.11.0](4.11.0.html), publiée le 19 août 2020.
 * OCaml [4.10.1](4.10.1.html), publiée le 20 août 2020.
 * OCaml [4.10.0](4.10.0.html), publiée le 20 février 2020.

--- a/site/releases/index.md
+++ b/site/releases/index.md
@@ -9,6 +9,7 @@ See also the [install](/docs/install.html) page for instructions on
 installing OCaml by other means, such as the OPAM package manager and
 platform specific package managers.
 
+* OCaml [4.11.1](4.11.1.html), released Aug 31, 2020.
 * OCaml [4.11.0](4.11.0.html), released Aug 19, 2020.
 * OCaml [4.10.1](4.10.1.html), released Aug 20, 2020.
 * OCaml [4.10.0](4.10.0.html), released Feb 21, 2020.


### PR DESCRIPTION
This PR adds a release page for OCaml 4.11.1, adds the new release dates to the various index files, and fix some formatting issues on the 4.11.0 page.