### PR TITLE
Update feed URLs based on permanent redirects

### DIFF
--- a/planet_feeds.txt
+++ b/planet_feeds.txt
@@ -51,7 +51,6 @@ OCamlPro|https://www.ocamlpro.com/feed/
 ODNS project|http://odns.tuxfamily.org/feed/
 Ocaml XMPP project|http://ox.tuxfamily.org/feed/
 Ocsigen project|https://ocsigen.org/feed.xml
-Ocsigen blog|https://ocsigen.org/feed.xml
 Opa|http://www.blogger.com/feeds/2073503406800427577/posts/default
 Orbitz|http://functional-orbitz.blogspot.com/feeds/posts/default/-/planetocaml?alt=rss
 Paolo Donadeo|http://www.donadeo.net/facets/programming-languages/objective-caml/feed/

--- a/planet_feeds.txt
+++ b/planet_feeds.txt
@@ -34,7 +34,7 @@ Jane Street|https://blog.janestreet.com/feed.xml
 KC Sivaramakrishnan|https://kcsrk.info/atom-ocaml.xml
 Leo White|http://lpw25.net/rss.xml
 Magnus Skjegstad|http://www.skjegstad.com/feeds/ocaml.tag.atom.xml
-Marc Simpson|http://newblog.0branch.com/rss.xml
+Marc Simpson|https://blog.0branch.com/rss.xml
 Matthias Puech|https://syntaxexclamation.wordpress.com/tag/ocaml/feed/
 Matías Giovannini|http://www.blogger.com/feeds/5888658295182480819/posts/default
 Mindy Preston|https://www.somerandomidiot.com/blog/categories/ocaml/atom.xml

--- a/planet_feeds.txt
+++ b/planet_feeds.txt
@@ -1,5 +1,5 @@
 Amir Chaudhry|http://amirchaudhry.com/tags/ocaml-atom.xml
-Andrej Bauer|http://math.andrej.com/feed/
+Andrej Bauer|http://math.andrej.com/feed.xml
 Andy Ray|http://www.ujamjar.com/ocaml.xml
 Anil Madhavapeddy|http://anil.recoil.org/feeds/atom.xml
 Ashish Agarwal|http://ashishagarwal.org/tag/ocaml/feed/
@@ -7,63 +7,63 @@ CUFP|http://cufp.org/blog/all.rss.xml
 Cameleon news|http://www.blogger.com/feeds/7617521785419311079/posts/default
 Caml INRIA|http://caml.inria.fr/news.en.rss
 Caml Spotting|http://camlspotter.blogspot.com/feeds/posts/default?alt=rss
-Coherent Graphics|http://coherentpdf.com/blog/?tag=ocaml&feed=rss2
-Coq|http://coq.inria.fr/news/feed
+Coherent Graphics|https://coherentpdf.com/blog/?tag=ocaml&feed=rss2
+Coq|https://coq.inria.fr/rss.xml
 Cranial Burnout|http://www.blogger.com/feeds/9108979482982930820/posts/default/-/OCaml
-Daniel Bünzli|http://erratique.ch/feeds/news.atom
-Daniel Bünzli (log)|http://erratique.ch/log/feed.atom
+Daniel Bünzli|https://erratique.ch/feeds/news.atom
+Daniel Bünzli (log)|https://erratique.ch/log/feed.atom
 Dario Teixeira|http://nleyten.com/feed/tag/ocaml/atom
 David Baelde|http://www.blogger.com/feeds/17133288/posts/default/-/ocaml
 David Mentré|http://blog.bentobako.org/index.php?feed/tag/ocaml/atom
-David Teller|http://dutherenverseauborddelatable.wordpress.com/category/ocaml/feed/
+David Teller|https://dutherenverseauborddelatable.wordpress.com/category/ocaml/feed/
 Eray Özkural|https://examachine.net/blog/category/ocaml/feed/
 Erik de Castro Lopo|http://www.mega-nerd.com/erikd/Blog/index.rss20
 Etienne Millon|http://blog.emillon.org/feeds/ocaml.xml
 Frama-C|http://frama-c.com/rss.xml
 Functional Jobs|http://functionaljobs.com/jobs/search/?q=ocaml&format=rss
 GaGallium|http://gallium.inria.fr/blog/index.rss
-Gaius Hammond|http://gaiustech.wordpress.com/category/ocaml/feed/
+Gaius Hammond|https://gaius.tech/category/ocaml/feed/
 Gemma Gordon (OCaml Labs)|http://reynard.io/feed.xml
 Gerd Stolpmann|http://blog.camlcity.org/blog/rss
 GitHub Jobs|https://jobs.github.com/positions.atom?description=ocaml
-Grant Rettke|http://www.wisdomandwonder.com/tag/OCaml/feed
+Grant Rettke|https://www.wisdomandwonder.com/tag/OCaml/feed
 Hannes Mehnert|https://hannes.nqsb.io/atom
-Hong bo Zhang|http://hongboz.wordpress.com/feed/
+Hong bo Zhang|https://hongboz.wordpress.com/feed/
 Jake Donham|http://ambassadortothecomputers.blogspot.com/feeds/posts/default?alt=rss
 Jane Street|https://blog.janestreet.com/feed.xml
-KC Sivaramakrishnan|http://kcsrk.info/atom-ocaml.xml
+KC Sivaramakrishnan|https://kcsrk.info/atom-ocaml.xml
 Leo White|http://lpw25.net/rss.xml
 Magnus Skjegstad|http://www.skjegstad.com/feeds/ocaml.tag.atom.xml
 Marc Simpson|http://newblog.0branch.com/rss.xml
-Matthias Puech|http://syntaxexclamation.wordpress.com/tag/ocaml/feed/
+Matthias Puech|https://syntaxexclamation.wordpress.com/tag/ocaml/feed/
 Matías Giovannini|http://www.blogger.com/feeds/5888658295182480819/posts/default
-Mindy Preston|http://www.somerandomidiot.com/blog/categories/ocaml/atom.xml
+Mindy Preston|https://www.somerandomidiot.com/blog/categories/ocaml/atom.xml
 Mike Lin|http://www.blogger.com/feeds/3693082774051755513/posts/default/-/OCaml
-Mike McClurg|http://mcclurmc.wordpress.com/feed/
+Mike McClurg|https://mcclurmc.wordpress.com/feed/
 MirageOS|https://mirage.io/blog/atom.xml
 OCaml Book|http://ocaml-book.com/blog?format=rss
 OCaml Labs|http://ocamllabs.io/feed.xml
-OCaml Labs compiler hacking|http://ocamllabs.github.com/compiler-hacking/rss.xml
+OCaml Labs compiler hacking|http://ocamllabs.io/compiler-hacking/rss.xml
 OCamlCore Forge News|http://forge.ocamlcore.org/export/rss20_news.php
 OCamlCore Forge Projects|http://forge.ocamlcore.org/export/rss20_projects.php
 OCamlCore.com|http://www.ocamlcore.com/wp/feed/?amp;language=en&language=en
-OCamlPro|http://www.ocamlpro.com/feed/
+OCamlPro|https://www.ocamlpro.com/feed/
 ODNS project|http://odns.tuxfamily.org/feed/
 Ocaml XMPP project|http://ox.tuxfamily.org/feed/
-Ocsigen project|http://ocsigen.org/feed.xml
-Ocsigen blog|https://ocsigen.github.io/feed.xml
+Ocsigen project|https://ocsigen.org/feed.xml
+Ocsigen blog|https://ocsigen.org/feed.xml
 Opa|http://www.blogger.com/feeds/2073503406800427577/posts/default
 Orbitz|http://functional-orbitz.blogspot.com/feeds/posts/default/-/planetocaml?alt=rss
 Paolo Donadeo|http://www.donadeo.net/facets/programming-languages/objective-caml/feed/
 Perpetually Curious|http://lambdafoo.com/blog/categories/ocaml/atom.xml
-Peter Zotov|http://whitequark.org/blog/categories/ocaml/atom.xml
+Peter Zotov|https://whitequark.org/blog/categories/ocaml/atom.xml
 Psellos|http://psellos.com/atom.xml
-Richard Jones|http://rwmj.wordpress.com/tag/ocaml/feed/
+Richard Jones|https://rwmj.wordpress.com/tag/ocaml/feed/
 Rudenoise|http://rudenoise.uk/ocaml.rss
 Rudi Grinberg|http://rgrinberg.com/blog/atom.xml
 Sebastien Mondet|https://seb.mondet.org/b/OCaml.rss
 Shayne Fletcher|http://blog.shaynefletcher.org/feeds/posts/default/-/OCaml
-Stefano Zacchiroli|http://upsilon.cc/~zack/tags/ocaml/index.rss
+Stefano Zacchiroli|https://upsilon.cc/~zack/tags/ocaml/index.rss
 Sylvain Le Gall|http://le-gall.net/sylvain+violaine/blog/index.php?feed/tag/ocaml/atom
 Thomas Leonard|http://roscidus.com/blog/blog/categories/ocaml/atom.xml
 Till Varoquaux|http://www.blogger.com/feeds/6115529230232389198/posts/default
@@ -71,10 +71,10 @@ Yan Shvartzshnaider|http://yansnotes.blogspot.com/feeds/posts/default/-/ocaml
 OCaml-Java|http://www.ocamljava.org/feed.xml
 OCaml Platform|http://opam.ocaml.org/blog/feed.xml
 Xinuo Chen|http://typeocaml.com/rss/
-Cryptosense|https://cryptosense.com/tag/ocaml/feed/
+Cryptosense|https://cryptosense.com/blog/tag/ocaml/feed/
 Gabriel Radanne|http://drup.github.io/feed-ocaml.xml
 The BAP Blog|https://binaryanalysisplatform.github.io/feed.xml
 Tarides|https://tarides.com/feed.xml
 Ahrefs|https://medium.com/feed/ahrefs/tagged/ocaml
-Reason Documentation Blog|https://reasonml.org/blog/feed.xml
+Reason Documentation Blog|https://rescript-lang.org/blog/feed.xml
 Daniil Baturin|https://baturin.org/blog/atom-ocaml.xml


### PR DESCRIPTION
Following discussion in #1151, this PR updates feeds that return permanent redirects. There are two interesting cases:
- after following redirects, two entries point to the ocsigen website. This removes one.
- there's a case where the listed url temporarily redirects to a second url, which permanently redirects to a third one. With the logic implemented in #1151, this displays a warning prompting to update the URL, which technically can't do because the first one is a temporary one... but I'm sure if we do it nothing bad will happen :see_no_evil: 