### PR TITLE
update the ocaml.org Dockerfile and fix opam name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM ocaml/opam
-RUN git -C /home/opam/opam-repository pull && opam update -u -y
-COPY . /home/opam/src
-RUN sudo chown -R opam /home/opam/src
-RUN opam pin add -n ocaml.org /home/opam/src
-RUN opam depext -u ocaml.org
-RUN opam install -j 4 -y -v --deps-only ocaml.org
-RUN opam install -y -v ocaml.org
+FROM ocurrent/opam:debian-10-ocaml-4.10
+RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 54b0223dcacb6311aa12f5342c34e1be684a79a3 && opam update -u -y
+WORKDIR /home/opam/src
+RUN sudo chown opam /home/opam/src
+COPY --chown=opam *.opam /home/opam/src
+RUN opam pin add -n -k path ocamlorg /home/opam/src/
+RUN opam depext ocamlorg
+RUN opam install -y --deps-only ocamlorg
+COPY --chown=opam . /home/opam/src
+RUN opam exec -- make production

--- a/ocamlorg.opam
+++ b/ocamlorg.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "ocaml-org"
+name: "ocamlorg"
 maintainer: "The OCaml.org team"
 authors: "The OCaml.org team"
 license: "See LICENSE.md file."


### PR DESCRIPTION
This allows a Docker build to construct the website without
requiring a specific host setup. Files are left in the
/home/opam/src/ocaml.org build directory to be picked up by
deployment scripts.