### PR TITLE
add a deployment Dockerfile

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -8,7 +8,9 @@ RUN opam depext ocamlorg
 RUN opam install -y --deps-only ocamlorg
 COPY --chown=opam . /home/opam/src
 RUN opam exec -- make production
-FROM ocurrent/opam:alpine
+FROM ocurrent/opam:debian-10-ocaml-4.10
+RUN sudo apt-get install -y dumb-init
 RUN opam depext -i cohttp-lwt-unix
 COPY --from=build /home/opam/src/ocaml.org/* /home/opam/src/
-RUN opam exec -- cohttp-server-lwt -p 8080 /home/opam/src -v
+WORKDIR /home/opam/src
+ENTRYPOINT ["dumb-init", "/home/opam/.opam/4.10/bin/cohttp-server-lwt"]

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,0 +1,14 @@
+FROM ocurrent/opam:debian-10-ocaml-4.10 as build
+RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 54b0223dcacb6311aa12f5342c34e1be684a79a3 && opam update -u -y
+WORKDIR /home/opam/src
+RUN sudo chown opam /home/opam/src
+COPY --chown=opam *.opam /home/opam/src
+RUN opam pin add -n -k path ocamlorg /home/opam/src/
+RUN opam depext ocamlorg
+RUN opam install -y --deps-only ocamlorg
+COPY --chown=opam . /home/opam/src
+RUN opam exec -- make production
+FROM ocurrent/opam:alpine
+RUN opam depext -i cohttp-lwt-unix
+COPY --from=build /home/opam/src/ocaml.org/* /home/opam/src/
+RUN opam exec -- cohttp-server-lwt -p 8080 /home/opam/src -v


### PR DESCRIPTION
This is the same as the base Dockerfile, but adds in a webserver
so that the resuting site is an executable container.

Using this to test out the new deployment mechanism for #1178