### PR TITLE
add label to search input field

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -436,6 +436,17 @@ ul.translations:after { content: "]"; }
   text-shadow: 0 1px 0 #ffffff;
 }
 
+/* Accessibility Helpers */
+.visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 /* Two columns mode
  ***********************************************************************/
 .begin_two_columns {

--- a/template/main.mpp
+++ b/template/main.mpp
@@ -76,7 +76,8 @@
                   id="searchform" class="navbar-search pull-right"
 		  method="get" action="//www.google.com/search">
               <input type="hidden" name="as_sitesearch" value="ocaml.org" />
-              <input placeholder="{{! cmd script/translate ((! get filename !)) "Search" !}}" class="search-query"
+              <label for="search" class="visually-hidden">Search: </label>
+              <input id="search" placeholder="{{! cmd script/translate ((! get filename !)) "Search" !}}" class="search-query"
 		     name="q" type="text" />
             </form>
             c!}}


### PR DESCRIPTION
This PR adds the search label described in #1202 using the [visually-hidden pattern](https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/). This was tested using the MacOS VoiceOver assistive technology.  