### PR TITLE
Fix broken caml light link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ opam.ocaml.org_template:
 
 # List of files to build, sorted according to their source format
 MD_FILES = $(patsubst site/%, ocaml.org/%, $(patsubst %.md, %.html, \
-  $(shell find site -type f -name '*.md' -print)))
+  $(shell find site \( -type f -o -type l \) -name '*.md' -print)))
 
 HTML_FILES = $(patsubst site/%, ocaml.org/%, \
   $(shell find site -type d -wholename '$(MANUAL_DIRS)' -prune \

--- a/site/caml-light/faq.md
+++ b/site/caml-light/faq.md
@@ -1,3 +1,5 @@
+<!-- ((! set title Caml Light - FAQ !)) -->
+
 # Caml Light — FAQ
 
 #### Is it possible to get error message in my own language?

--- a/site/caml-light/index.md
+++ b/site/caml-light/index.md
@@ -1,3 +1,5 @@
+<!-- ((! set title Caml Light !)) -->
+
 # Caml Light
 
 ## Overview

--- a/site/caml-light/license.md
+++ b/site/caml-light/license.md
@@ -1,3 +1,4 @@
+<!-- ((! set title Caml Light's License !)) -->
 
 # Caml Light's License
 

--- a/site/caml-light/releases/0.75.md
+++ b/site/caml-light/releases/0.75.md
@@ -1,3 +1,4 @@
+<!-- ((! set title Caml Light 0.75 !)) -->
 
 # Caml Light 0.75
 


### PR DESCRIPTION
This PR fixes #939 

It would be good to double-check it in staging (to make sure the augmented `find` statement works as intended) but I tried it locally in the container and on my Mac.

I also took the opportunity to fix the bread-crumbs on the `caml-light` version of the files. As noted in #608 there is duplication here and that should be fixed, but perhaps not in this PR. 