### PR TITLE
Accessibility improvements

### DIFF
--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -472,8 +472,9 @@ let headline_of_post ?(planet=false) ?(img_alt="") ~l9n ~img e =
     else match get_alternate_link e with
          | Some l -> Uri.to_string l
          | None -> "" in
+  let title = string_of_text_construct e.Atom.title in
   let html_icon =
-    [Element("a", ["href", link],
+    [Element("a", ["href", link; "title", title],
              [Element("img", ["src", img ^ ".svg"; "class", "svg";
                               "alt", img_alt], []);
               Element("img", ["src", img ^ ".png"; "class", "png";
@@ -490,7 +491,6 @@ let headline_of_post ?(planet=false) ?(img_alt="") ~l9n ~img e =
          else
            Netdate.format ~fmt:"%e %B %Y" d ~l9n in
        Element("p", [], [Data d]) :: html_icon in
-  let title = string_of_text_construct e.Atom.title in
   let html_title =
     Element("h1", [],
             if link = "" then [Data title]

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -103,7 +103,7 @@ h1 code, h2 code, h3 code, h4 code, h5 code, h5 code { font-size: 80%; }
 .comment, .comment .governing, .comment .keyword, .comment .ocaml-function,
 .comment .string, .ocaml .co, .comment .ocaml-module,
 .comment .ocaml-variable, .planet .Comment {
-  color: #747474;
+  color: #525252;
   font-style: italic;
   font-weight: normal;
 }

--- a/site/learn/index.fr.md
+++ b/site/learn/index.fr.md
@@ -94,6 +94,7 @@ OCaml est un langage générique de programmation, de puissance industrielle, qu
         <section class="span4 condensed">
           <h1 class="ruled"><a href="companies.html">Utilisateurs industriels</a></h1> <p><a href="http://janestreet.com"><img style="float:
           left; margin-right: 10px; margin-bottom: 10px"
+					alt="Logo de Jane Street"
           src="/img/users/jane-street.jpg"></a>Jane Street est une société
 	  d'arbitrage financier qui met l'accent sur la résolution
 	  de problèmes technologiques et collaboratifs. Presque tous
@@ -108,7 +109,7 @@ OCaml est un langage générique de programmation, de puissance industrielle, qu
           <p><a href="https://www.facebook.com"><img style="float:
           left; margin-right: 10px; margin-bottom: 10px"
           src="/img/users/facebook.png"
-						     ></a>Pour gérer
+					alt="Logo de facebook"></a>Pour gérer
             son énorme base de code PHP, Facebook a développé
             <a href="https://github.com/facebook/pfff/wiki/Main"
 			 >pfff</a>,

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -105,7 +105,7 @@
           <h1 class="ruled"><a href="companies.html">Industrial
           Users</a></h1> <p><a href="http://janestreet.com"><img style="float:
           left; margin-right: 10px; margin-bottom: 10px"
-          src="/img/users/jane-street.jpg"></a>Jane Street is a quantitative
+          src="/img/users/jane-street.jpg" alt="Jane Street logo"></a>Jane Street is a quantitative
           proprietary trading firm with a unique focus on technology
           and collaborative problem solving.  Almost all of our
           systems are written in OCaml: from statistical research code
@@ -117,7 +117,7 @@
           <p><a href="https://www.facebook.com"><img style="float:
           left; margin-right: 10px; margin-bottom: 10px"
           src="/img/users/facebook.png"
-						     ></a>To
+          alt="Facebook Logo"></a>To
             handle their huge PHP codebase, Facebook developed
             <a href="https://github.com/facebook/pfff/wiki/Main"
 			 >pfff</a>,

--- a/template/footer.mpp
+++ b/template/footer.mpp
@@ -7,7 +7,6 @@
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/tutorials/" !}}">{{! cmd script/translate ((! get filename !)) "Tutorials" !}}</a></li>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/books.html" !}}" >{{! cmd script/translate ((! get filename !)) "Books" !}}</a></li>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/success.html" !}}">{{! cmd script/translate ((! get filename !)) "Success Stories" !}}</a></li>
-      <li><a href="."></a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
This PR continues with the improvements started in #1199 in particular: 

 - It darkens comments in code sections as the contrast ratio isn't WCAG compliant -- I believe having them in italics is sufficient to distinguish them as a comments rather than code.
 - Quite a few links have no "name" (alt text, title attribute etc.) which [is not compliant with the same set of standards](https://web.dev/link-name/). To fix this I've added title attributes to the image icon for news feed items (and similar). 
 - Alt tags for the Jane Street and Facebook images have also been added (in French too). 
 - The dangling link referenced in https://github.com/ocaml/ocaml.org/pull/1217#issuecomment-730354544 has been removed, I didn't see any changes to layout but a trip to staging would be useful for this PR to double-check :) 

A benefit of this PR is that the homepage and learn page should now score 100 on [Google Lighthouse's](https://developers.google.com/web/tools/lighthouse) accessibility metric 🎉  There is still a lot of improvements in terms of accessibility to be made however.