### PR TITLE
add git clone for ocaml logos

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -8,6 +8,7 @@ RUN opam depext ocamlorg
 RUN opam install -y --deps-only ocamlorg
 COPY --chown=opam . /home/opam/src
 RUN opam exec -- make -j production
+RUN git clone https://github.com/ocaml/ocaml-logo /home/opam/src/ocaml.org/logo
 FROM caddy:2-alpine
 COPY --from=build /home/opam/src/ocaml.org /usr/share/caddy
 ENTRYPOINT ["caddy", "file-server"]

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -8,7 +8,7 @@ RUN opam depext ocamlorg
 RUN opam install -y --deps-only ocamlorg
 COPY --chown=opam . /home/opam/src
 RUN opam exec -- make -j production
-RUN git clone https://github.com/ocaml/ocaml-logo /home/opam/src/ocaml.org/logo
+RUN git clone --depth=1 https://github.com/ocaml/ocaml-logo /home/opam/src/ocaml.org/logo
 FROM caddy:2-alpine
 COPY --from=build /home/opam/src/ocaml.org /usr/share/caddy
 ENTRYPOINT ["caddy", "file-server"]

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -8,6 +8,7 @@ RUN opam depext ocamlorg
 RUN opam install -y --deps-only ocamlorg
 COPY --chown=opam . /home/opam/src
 RUN opam exec -- make -j local
+RUN git clone https://github.com/ocaml/ocaml-logo /home/opam/src/ocaml.org/logo
 FROM caddy:2-alpine
 COPY --from=build /home/opam/src/ocaml.org /usr/share/caddy
 ENTRYPOINT ["caddy", "file-server"]

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -8,7 +8,7 @@ RUN opam depext ocamlorg
 RUN opam install -y --deps-only ocamlorg
 COPY --chown=opam . /home/opam/src
 RUN opam exec -- make -j local
-RUN git clone https://github.com/ocaml/ocaml-logo /home/opam/src/ocaml.org/logo
+RUN git clone --depth=1 https://github.com/ocaml/ocaml-logo /home/opam/src/ocaml.org/logo
 FROM caddy:2-alpine
 COPY --from=build /home/opam/src/ocaml.org /usr/share/caddy
 ENTRYPOINT ["caddy", "file-server"]


### PR DESCRIPTION
A potential solution for #1229 -- vendors in the [ocaml-logo](https://github.com/ocaml/ocaml-logo) repository in the OCurrent deploy and staging dockerfiles. 