### PR TITLE
add 4.10.2 release notes

### DIFF
--- a/site/releases/4.10.2.md
+++ b/site/releases/4.10.2.md
@@ -1,4 +1,4 @@
-<!-- ((! set title OCaml 4.10.1 !)) -->
+<!-- ((! set title OCaml 4.10.2 !)) -->
 
 # OCaml 4.10.2
 

--- a/site/releases/4.10.2.md
+++ b/site/releases/4.10.2.md
@@ -1,0 +1,49 @@
+<!-- ((! set title OCaml 4.10.1 !)) -->
+
+# OCaml 4.10.2
+
+This page describes OCaml **4.10.2**, released on Dec 8, 2020.  It is
+an exceptional release making OCaml **4.10** available on macOS/arm64 and
+fixes some compatibility issues for the mingw64 and FreeBSD/amd64 platform.
+
+Note that those fixes were backported from OCaml 4.12: further improvement to the support
+of the macOS/arm64 platform will happen on the 4.12 branch.
+
+![](../img/source.gif "") Source distribution
+---------------------------------------------
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz)
+  (.tar.gz) for compilation under Unix (including Linux and macOS)
+  and Microsoft Windows (including Cygwin).
+- Also available in
+  [.zip](https://github.com/ocaml/ocaml/archive/4.10.2.zip)
+  format.
+- [OPAM](https://opam.ocaml.org/) is a source-based distribution of
+  OCaml and many companion libraries and tools. Compilation and
+  installation are automated by powerful package managers.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+## Changes
+
+- [#9938](https://github.com/ocaml/ocaml/issues/9938), [#9939](https://github.com/ocaml/ocaml/issues/9939): Define `__USE_MINGW_ANSI_STDIO=0` for the mingw-w64 ports to prevent their C99-compliant snprintf conflicting with ours.
+(David Allsopp, report by Michael Soegtrop, review by Xavier Leroy)
+
+### Supported Platforms: 
+
+- [#9699](https://github.com/ocaml/ocaml/issues/9699), [#10026](https://github.com/ocaml/ocaml/issues/10026): Add support for iOS and macOS on ARM 64 bits backported from OCaml 4.12.0.
+(GitHub user @EduardoRFS, review by Xavier Leroy, Nicolás Ojeda Bär
+and Anil Madhavapeddy, additional testing by Michael Schmidt)
+
+### Code generation and optimization: 
+
+- [#9752](https://github.com/ocaml/ocaml/issues/9752), [#10026](https://github.com/ocaml/ocaml/issues/10026):Revised handling of calling conventions for external C functions.
+Provide a more precise description of the types of unboxed arguments,
+so that the ARM64 iOS/macOS calling conventions can be honored.
+Backported from OCaml 4.12.0
+(Xavier Leroy, review by Mark Shinwell and Github user @EduardoRFS)
+
+- [#9699](https://github.com/ocaml/ocaml/issues/9699), [#9981](https://github.com/ocaml/ocaml/issues/9981): Added mergeable flag tqo ELF sections containing mergeable constants. Fixes compatibility with the integrated assembler in clang 11.0.0.
+Backported from OCaml 4.12.0
+(Jacob Young, review by Nicolás Ojeda Bär)

--- a/site/releases/index.fr.md
+++ b/site/releases/index.fr.md
@@ -12,6 +12,7 @@ OPAM et les gestionnaire de paquets spécifiques à une plateforme.
 
 * OCaml [4.11.1](4.11.1.html), publiée le 31 août 2020.
 * OCaml [4.11.0](4.11.0.html), publiée le 19 août 2020.
+* OCaml [4.10.2](4.10.2.html), publiée le 8 décembre 2020.
 * OCaml [4.10.1](4.10.1.html), publiée le 20 août 2020.
 * OCaml [4.10.0](4.10.0.html), publiée le 20 février 2020.
 * OCaml [4.09.1](4.09.1.html), publiée le 18 mars 2020.

--- a/site/releases/index.md
+++ b/site/releases/index.md
@@ -11,6 +11,7 @@ platform specific package managers.
 
 * OCaml [4.11.1](4.11.1.html), released Aug 31, 2020.
 * OCaml [4.11.0](4.11.0.html), released Aug 19, 2020.
+* OCaml [4.10.2](4.10.2.html), released Dec 8, 2020.
 * OCaml [4.10.1](4.10.1.html), released Aug 20, 2020.
 * OCaml [4.10.0](4.10.0.html), released Feb 21, 2020.
 * OCaml [4.09.1](4.09.1.html), released Mar 18, 2020.


### PR DESCRIPTION
This PR: 

 - Adds the 4.10.2 release notes to the "Compiler Releases" page taking the main information from the [discuss post](https://discuss.ocaml.org/t/ann-ocaml-4-10-2/6945) for the same thing. 
 - I also took the liberty of adding the "Source distribution" information for this one as a small step towards fixing #1168. 