### PR TITLE
Update dockerfiles to ocaml/opam and latest opam-repo commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ocurrent/opam:debian-10-ocaml-4.10
-RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 54b0223dcacb6311aa12f5342c34e1be684a79a3 && opam update -u -y
+FROM ocaml/opam:debian-10-ocaml-4.10
+RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout c1952fb63c5a89c8c4230aac0360884518d72d91 && opam update -u -y
 WORKDIR /home/opam/src
 RUN sudo chown opam /home/opam/src
 COPY --chown=opam *.opam /home/opam/src

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,5 +1,5 @@
-FROM ocurrent/opam:debian-10-ocaml-4.10 as build
-RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 54b0223dcacb6311aa12f5342c34e1be684a79a3 && opam update -u -y
+FROM ocaml/opam:debian-10-ocaml-4.10 as build
+RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout c1952fb63c5a89c8c4230aac0360884518d72d91 && opam update -u -y
 WORKDIR /home/opam/src
 RUN sudo chown opam /home/opam/src
 COPY --chown=opam *.opam /home/opam/src

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -1,5 +1,5 @@
-FROM ocurrent/opam:debian-10-ocaml-4.10 as build
-RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 54b0223dcacb6311aa12f5342c34e1be684a79a3 && opam update -u -y
+FROM ocaml/opam:debian-10-ocaml-4.10 as build
+RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout c1952fb63c5a89c8c4230aac0360884518d72d91 && opam update -u -y
 WORKDIR /home/opam/src
 RUN sudo chown opam /home/opam/src
 COPY --chown=opam *.opam /home/opam/src


### PR DESCRIPTION
This PR: 

 - Changes the source of the docker image from the deprecated `ocurrent/opam` to the continuously updated `ocaml/opam` image. This is needed because if the build misses the cache it is using an old `apt-get` package list (see this failing build https://deploy.ocamllabs.io/job/2021-02-25/160625-ocluster-build-8d226d thanks to @Shubham-Vishwakarma for bringing it to my attention in #1237).
 - Bumps the commit of the opam-repository to the latest, because the new base-image is using `4.10.2` which isn't in the old checkout of the repo that is currently being used. 

Seemed to build the docker files locally for me. 

cc @avsm 