### PR TITLE
4.11.2 release page

### DIFF
--- a/site/releases/4.11.2.md
+++ b/site/releases/4.11.2.md
@@ -1,0 +1,102 @@
+<!-- ((! set title OCaml 4.11.2 !)) -->
+
+# OCaml 4.11.2
+
+This page describes OCaml **4.11.2**, released on Feb 24, 2021.
+This is a bug-fix release of [OCaml 4.11.0](4.11.0.html).
+
+
+Opam switches
+-------------
+
+This release is available as multiple
+[OPAM](https://opam.ocaml.org/doc/Usage.html) switches:
+
+- 4.11.2 — Official release 4.11.2
+- 4.11.2+flambda — Official release 4.11.2, with flambda activated
+
+- 4.11.2+afl — Official release 4.11.2, with afl-fuzz instrumentation
+- 4.11.2+no-flat-float-array - Official release 4.11.2, with
+  --disable-flat-float-array
+- 4.11.2+flambda+no-flat-float-array — Official release 4.11.2, with
+  flambda activated and --disable-flat-float-array
+- 4.11.2+fp — Official release 4.11.2, with frame-pointers
+- 4.11.2+fp+flambda — Official release 4.11.2, with frame-pointers
+  and flambda activated
+- 4.11.2+musl+static+flambda - Official release 4.11.2, compiled with
+  musl-gcc -static and with flambda activated
+
+- 4.11.2+32bit - Official release 4.11.2, compiled in 32-bit mode
+  for 64-bit Linux and OS X hosts
+- 4.11.2+bytecode-only - Official release 4.11.2, without the
+  native-code compiler
+
+- 4.11.2+spacetime - Official 4.11.2 release with spacetime activated
+- 4.11.2+default-unsafe-string — Official release 4.11.2, without
+  safe strings by default
+
+
+
+![](../img/source.gif "") Source distribution
+---------------------------------------------
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/4.11.2.tar.gz)
+  (.tar.gz) for compilation under Unix (including Linux and macOS)
+  and Microsoft Windows (including Cygwin).
+- Also available in
+  [.zip](https://github.com/ocaml/ocaml/archive/4.11.2.zip)
+  format.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+Changes
+-------
+
+### Build system:
+
+- [9938](https://github.com/ocaml/ocaml/issues/9938), [9939](https://github.com/ocaml/ocaml/issues/9939): Define __USE_MINGW_ANSI_STDIO=0 for the mingw-w64 ports to
+  prevent their C99-compliant snprintf conflicting with ours.
+  (David Allsopp, report by Michael Soegtrop, review by Xavier Leroy)
+
+### Runtime system:
+
+- [10056](https://github.com/ocaml/ocaml/issues/10056): Memprof: ensure young_trigger is within the bounds of the minor
+  heap in caml_memprof_renew_minor_sample (regression from [8684](https://github.com/ocaml/ocaml/issues/8684))
+  (David Allsopp, review by Guillaume Munch-Maccagnoni and
+  Jacques-Henri Jourdan)
+
+- [9654](https://github.com/ocaml/ocaml/issues/9654): More efficient management of code fragments.
+  (Xavier Leroy, review by Jacques-Henri Jourdan, Damien Doligez, and
+  Stephen Dolan)
+
+### Tools:
+
+- [9606](https://github.com/ocaml/ocaml/issues/9606), [9635](https://github.com/ocaml/ocaml/issues/9635), [9637](https://github.com/ocaml/ocaml/issues/9637): fix performance regression in the debugger
+  (behaviors quadratic in the size of the debugged program)
+  (Xavier Leroy, report by Jacques Garrigue and Virgile Prevosto,
+  review by David Allsopp and Jacques-Henri Jourdan)
+
+### Code generation and optimizations:
+
+- [9969](https://github.com/ocaml/ocaml/issues/9969), [9981](https://github.com/ocaml/ocaml/issues/9981): Added mergeable flag to ELF sections containing mergeable
+  constants.  Fixes compatibility with the integrated assembler in clang 11.0.0.
+  (Jacob Young, review by Nicolás Ojeda Bär)
+
+### Bug fixes:
+
+- [9970](https://github.com/ocaml/ocaml/issues/9970), [10010](https://github.com/ocaml/ocaml/issues/10010): fix the declaration scope of extensible-datatype constructors.
+  A regression that dates back to 4.08 makes extensible-datatype constructors
+  with inline records very fragile, for example:
+    type 'a t += X of {x : 'a}
+  (Gabriel Scherer, review by Thomas Refis and Leo White,
+   report by Nicolás Ojeda Bär)
+
+- [9096](https://github.com/ocaml/ocaml/issues/9096), [10096](https://github.com/ocaml/ocaml/issues/10096): fix a 4.11.0 performance regression in classes/objects
+  declared within a function
+  (Gabriel Scherer, review by Leo White, report by Sacha Ayoun)
+
+- [9326](https://github.com/ocaml/ocaml/issues/9326), [10125](https://github.com/ocaml/ocaml/issues/10125): Gc.set incorrectly handles the three `custom_*` fields,
+  causing a performance regression
+  (report by Emilio Jesús Gallego Arias, analysis and fix by Stephen Dolan,
+   code by Xavier Leroy, review by Hugo Heuzard and Gabriel Scherer)

--- a/site/releases/4.11.2.md
+++ b/site/releases/4.11.2.md
@@ -10,7 +10,7 @@ Opam switches
 -------------
 
 This release is available as multiple
-[OPAM](https://opam.ocaml.org/doc/Usage.html) switches:
+[opam](https://opam.ocaml.org/doc/Usage.html) switches:
 
 - 4.11.2 — Official release 4.11.2
 - 4.11.2+flambda — Official release 4.11.2, with flambda activated

--- a/site/releases/4.11/notes/Changes
+++ b/site/releases/4.11/notes/Changes
@@ -1,5 +1,73 @@
+OCaml 4.11 maintenance branch
+-----------------------------
+
+
+OCaml 4.11.2 (24 February 2021)
+-------------------------------
+
+### Build system:
+
+- #9938, #9939: Define __USE_MINGW_ANSI_STDIO=0 for the mingw-w64 ports to
+  prevent their C99-compliant snprintf conflicting with ours.
+  (David Allsopp, report by Michael Soegtrop, review by Xavier Leroy)
+
+### Runtime system:
+
+- #10056: Memprof: ensure young_trigger is within the bounds of the minor
+  heap in caml_memprof_renew_minor_sample (regression from #8684)
+  (David Allsopp, review by Guillaume Munch-Maccagnoni and
+  Jacques-Henri Jourdan)
+
+- #9654: More efficient management of code fragments.
+  (Xavier Leroy, review by Jacques-Henri Jourdan, Damien Doligez, and
+  Stephen Dolan)
+
+### Tools:
+
+- #9606, #9635, #9637: fix performance regression in the debugger
+  (behaviors quadratic in the size of the debugged program)
+  (Xavier Leroy, report by Jacques Garrigue and Virgile Prevosto,
+  review by David Allsopp and Jacques-Henri Jourdan)
+
+### Code generation and optimizations:
+
+- #9969, #9981: Added mergeable flag to ELF sections containing mergeable
+  constants.  Fixes compatibility with the integrated assembler in clang 11.0.0.
+  (Jacob Young, review by Nicolás Ojeda Bär)
+
+### Bug fixes:
+
+- #9970, #10010: fix the declaration scope of extensible-datatype constructors.
+  A regression that dates back to 4.08 makes extensible-datatype constructors
+  with inline records very fragile, for example:
+    type 'a t += X of {x : 'a}
+  (Gabriel Scherer, review by Thomas Refis and Leo White,
+   report by Nicolás Ojeda Bär)
+
+- #9096, #10096: fix a 4.11.0 performance regression in classes/objects
+  declared within a function
+  (Gabriel Scherer, review by Leo White, report by Sacha Ayoun)
+
+- #9326, #10125: Gc.set incorrectly handles the three `custom_*` fields,
+  causing a performance regression
+  (report by Emilio Jesús Gallego Arias, analysis and fix by Stephen Dolan,
+   code by Xavier Leroy, review by Hugo Heuzard and Gabriel Scherer)
+
+OCaml 4.11.1 (31 August 2020)
+-----------------------------
+
+### Bug fixes:
+
+- #9856, #9857: Prevent polymorphic type annotations from generalizing
+  weak polymorphic variables.
+  (Leo White, review by Jacques Garrigue)
+
+- #9859, #9862: Remove an erroneous assertion when inferred function types
+  appear in the right hand side of an explicit :> coercion
+  (Florian Angeletti, review by Thomas Refis)
+
 OCaml 4.11.0 (19 August 2020)
----------------------------
+-----------------------------
 
 (Changes that can break existing programs are marked with a "*")
 
@@ -1435,6 +1503,16 @@ OCaml 4.09.0 (19 September 2019)
 
 - #8944: Fix "open struct .. end" on clambda backend
   (Thomas Refis, review by Leo White, report by Damon Wang and Mark Shinwell)
+
+OCaml 4.08 maintenance branch
+-----------------------------
+
+### Bug fixes:
+
+- #9326, #10125: Gc.set incorrectly handles the three `custom_*` fields,
+  causing a performance regression
+  (report by Emilio Jesús Gallego Arias, analysis and fix by Stephen Dolan,
+   code by Xavier Leroy, review by Hugo Heuzard and Gabriel Scherer)
 
 OCaml 4.08.1 (5 August 2019)
 ----------------------------

--- a/site/releases/index.fr.md
+++ b/site/releases/index.fr.md
@@ -11,6 +11,7 @@ compilation des sources, comme par exemple le gestionnaire de paquets
 OPAM et les gestionnaire de paquets spécifiques à une plateforme.
 
 * OCaml [4.12.0](4.12.0.html), publiée le 24 février 2021.
+* OCaml [4.11.2](4.11.2.html), publiée le 24 février 2021.
 * OCaml [4.11.1](4.11.1.html), publiée le 31 août 2020.
 * OCaml [4.11.0](4.11.0.html), publiée le 19 août 2020.
 * OCaml [4.10.2](4.10.2.html), publiée le 8 décembre 2020.

--- a/site/releases/index.md
+++ b/site/releases/index.md
@@ -10,6 +10,7 @@ installing OCaml by other means, such as the OPAM package manager and
 platform specific package managers.
 
 * OCaml [4.12.0](4.12.0.html), released Feb 24, 2021.
+* OCaml [4.11.2](4.11.2.html), released Feb 24, 2021.
 * OCaml [4.11.1](4.11.1.html), released Aug 31, 2020.
 * OCaml [4.11.0](4.11.0.html), released Aug 19, 2020.
 * OCaml [4.10.2](4.10.2.html), released Dec 8, 2020.


### PR DESCRIPTION
This adds the release page for 4.11.2 (and the links in the indexes).
I have updated the template for bugfix release to add back the installation information (opam switches + fixes) #1168 .
If this is new template seems good enough, I propose to backtrack those changes on all bugfix releases. 