### PR TITLE
Fix documentation page

### DIFF
--- a/site/docs/index.fr.md
+++ b/site/docs/index.fr.md
@@ -4,12 +4,17 @@
   <h1>Documentation</h1>
   <div class="form-group">
     <form name="Versions">
-      <label for="version-selector"
-	     style="display:inline;">Version OCaml:</label>
-      <select class="form-control" id="version-selector" name="selector"
-	      style="width: 10ex;vertical-align: baseline;"
-	      onChange="refresh()">
-	<option>4.10</option>
+      <label for="version-selector" style="display: inline"
+        >Version OCaml:</label
+      >
+      <select
+        class="form-control"
+        id="version-selector"
+        name="selector"
+        style="width: 10ex; vertical-align: baseline"
+        onChange="refresh()"
+      >
+        <option>4.10</option>
       </select>
     </form>
   </div>
@@ -20,147 +25,198 @@
   <div class="row">
     <section class="span6 condensed">
       <h1 class="ruled">Les Tutoriels OCaml</h1>
-      <p>Les
-	<a id="tutref"
-	   href="/manual/index.html#sec6">tutoriels OCaml</a>
-	officiels (chapitres 1 à 6 du manuel), écrits par les
-	inventeurs du langage, sont le meilleur point de
-	départ. Ils constituent une introduction complète à la
-	programmation OCaml, avec le système des modules, les
-	objets, le polymorphisme, etc.
+      <p>
+        Les
+        <a id="tutref" href="/manual/index.html#sec6">tutoriels OCaml</a>
+        officiels (chapitres 1 à 6 du manuel), écrits par les inventeurs du
+        langage, sont le meilleur point de départ. Ils constituent une
+        introduction complète à la programmation OCaml, avec le système des
+        modules, les objets, le polymorphisme, etc.
 
-	<a id="tutref_b" href="/manual/index.html#sec6">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-tut"
-		 value="Lire les tutoriels"></a>
+        <a id="tutref_b" href="/manual/index.html#sec6">
+          <input
+            type="button"
+            class="btn btn-default"
+            style="float: right"
+            name="button-tut"
+            value="Lire les tutoriels"
+        /></a>
       </p>
     </section>
 
     <section class="span6 condensed">
       <h1 class="ruled">L'API OCaml</h1>
-      <p>Incontournable! Contient la documentation pour l'ensemble
-	des modules inclus dans toute distribution OCaml. Ces
-	modules forment ce qu'on appelle la
-	<a id="stdlib" href="/manual/stdlib.html">Standard
-	  Library</a>. En outre, le module spécial
-	<code id="stdlib_name">Stdlib</code> contient
-	la <a id="corref" href="/manual/core.html">"core
-	  library"</a>, et est toujours ouvert.
-
-	<a id="api_b"
-	   href="/api/index.html">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-api"
-		 value="API OCaml"></a>
+      <p>
+        Incontournable! Contient la documentation pour l'ensemble des modules
+        inclus dans toute distribution OCaml. Ces modules forment ce qu'on
+        appelle la
+        <a id="stdlib" href="/manual/stdlib.html">Standard Library</a>. En
+        outre, le module spécial <code id="stdlib_name">Stdlib</code> contient
+        la <a id="corref" href="/manual/core.html">"core library"</a>, et est
+        toujours ouvert.
+      </p>
+      <p style="display: flex; justify-content: flex-end">
+        <a id="api_b" href="/api/index.html">
+          <input
+            type="button"
+            class="btn btn-default"
+            name="button-api"
+            value="OCaml API"
+        /></a>
       </p>
     </section>
 
     <section class="span6 condensed">
       <h1 class="ruled">Les outils</h1>
       <p>
-	De nombreux
-	<a id="toolref"
-	   href="/manual/index.html#sec286">outils</a>
-	sont distribués avec le langage OCaml. Parmi eux,
-	l'interpréteur interactif (REPL ou `toplevel'), le
-	générateur de documentation, le lexer, le débogueur,
-	les outils de profilage, etc.
-
-	<a id="toolref_b"
-	   href="/manual/index.html#sec286">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-api"
-		 value="Outils OCaml"></a>
+        De nombreux
+        <a id="toolref" href="/manual/index.html#sec286">outils</a>
+        sont distribués avec le langage OCaml. Parmi eux, l'interpréteur
+        interactif (REPL ou `toplevel'), le générateur de documentation, le
+        lexer, le débogueur, les outils de profilage, etc.
+      </p>
+      <p style="display: flex; justify-content: flex-end">
+        <a id="toolref_b" href="/manual/index.html#sec286">
+          <input
+            type="button"
+            class="btn btn-default"
+            name="button-api"
+            value="Outils OCaml"
+        /></a>
       </p>
     </section>
 
     <section class="span6 condensed">
       <h1 class="ruled">Les Extensions du langage</h1>
 
-      <p>N'oubliez pas de vérifier régulièrement les
-	<a id="extref"
-	   href="/manual/extn.html">Extensions du langage</a>,
-	afin de rester à jour avec les nouvelles constructions
-	qui vont vous simplifier la vie.
-	<br>
-
-	<a id="extref_b"
-	   href="/manual/extn.html">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-ext"
-		 value="Extensions OCaml"></a>
-
+      <p>
+        N'oubliez pas de vérifier régulièrement les
+        <a id="extref" href="/manual/extn.html">Extensions du langage</a>, afin
+        de rester à jour avec les nouvelles constructions qui vont vous
+        simplifier la vie.
+        <br />
+      </p>
+      <p style="display: flex; justify-content: flex-end">
+        <a id="extref_b" href="/manual/extn.html">
+          <input
+            type="button"
+            class="btn btn-default"
+            name="button-ext"
+            value="Extensions OCaml"
+        /></a>
       </p>
     </section>
 
     <section class="span6 condensed">
       <h1 class="ruled">Le Manuel OCaml</h1>
-      <p>L'ensemble de la documentation est regroupé dans un important
-	<a id="manual" href="/manual/index.html">
-	  Manuel OCaml</a>.  Le manuel est également disponible aux formats
-	<a id="refman-pdf"
-	   href="/releases/4.12/ocaml-4.12-refman.pdf">PDF</a>,
-	<a id="refman-txt"
-	   href="/releases/4.12/ocaml-4.12-refman.txt">texte</a>,
-	comme
-	<a id="refman-html"
-	   href="/releases/4.12/ocaml-4.12-refman-html.tar.gz">archive HTML</a>, et comme
-	<a id="refman-info"
-	   href="/releases/4.12/ocaml-4.12-refman.info.tar.gz">archive de fichiers Emacs Info</a>.
+      <p>
+        L'ensemble de la documentation est regroupé dans un important
+        <a id="manual" href="/manual/index.html"> Manuel OCaml</a>. Le manuel
+        est également disponible aux formats
+        <a id="refman-pdf" href="/releases/4.12/ocaml-4.12-refman.pdf">PDF</a>,
+        <a id="refman-txt" href="/releases/4.12/ocaml-4.12-refman.txt">texte</a
+        >, comme
+        <a id="refman-html" href="/releases/4.12/ocaml-4.12-refman-html.tar.gz"
+          >archive HTML</a
+        >, et comme
+        <a id="refman-info" href="/releases/4.12/ocaml-4.12-refman.info.tar.gz"
+          >archive de fichiers Emacs Info</a
+        >.
       </p>
     </section>
-
 
     <section class="span6 condensed">
       <h1 class="ruled">Autres documents</h1>
       <div class="row">
-	<a href="license.html" class="span3 documentation-highlight">
-	  <img src="/img/license.svg" alt="" class="svg">
-	  <img src="/img/license.png" alt="" class="png">
-	  License OCaml
-	</a>
-	<a href="cheat_sheets.html"
-	   class="span3 documentation-highlight">
-	  <img src="/img/cheat.svg" alt="" class="svg" />
-	  <img src="/img/cheat.png" alt="" class="png" />
-	  Aide-mémoire
-	</a>
+        <a href="license.html" class="span3 documentation-highlight">
+          <img src="/img/license.svg" alt="" class="svg" />
+          <img src="/img/license.png" alt="" class="png" />
+          License OCaml
+        </a>
+        <a href="cheat_sheets.html" class="span3 documentation-highlight">
+          <img src="/img/cheat.svg" alt="" class="svg" />
+          <img src="/img/cheat.png" alt="" class="png" />
+          Aide-mémoire
+        </a>
       </div>
     </section>
+
   </div>
-
-
 
   <div class="row">
     <section class="span6 condensed">
       <h1 class="ruled">Documentation d'OPAM</h1>
-      <p>(<a href="https://opam.ocaml.org">OPAM</a>) permet de gérer l'installation de paquets sources en OCaml. Il permet l'installation de plusieurs versions du compilateur, tolère des contraintes complexes de dépendances entre les paquets et repose sur des mises à jour via un dépôt Github. La documentation sur l'utilisation d'OPAM pour installer des paquets ou créer vos propres paquets, <a href="https://opam.ocaml.org/doc/Install.html">lire ici</a>. Les paquets sont automatiquement testés lors de leur soumission et un rapport est envoyé au mainteneur. Si vous soumettez un paquet, cela vous permettra de recevoir régulièrement les résultats de tests de non-régression sur une multitude de systèmes d'exploitation et de plateformes.</p>
-      <p>OPAM a été créé et est maintenu par OCamlPro, tandis qu'OCaml Labs gère le dépôt de paquets. Les rapports de bugs et suggestions pour l'outil doivent être déposés sur le <a href="https://github.com/OCaml/opam/issues">bug tracker d'OPAM</a>. Les problèmes concernant les paquets doivent être soumis sur le <a href="https://github.com/OCaml/opam-repository/issues">bug tracker du dépôt principal</a>. Les questions générales sur l'outil et les paquets peuvent être envoyées sur <a href="http://lists.ocaml.org/listinfo/platform">la liste de la plateforme OCaml</a> et les détails ou l'évolution d'OPAM peuvent être discutés sur <a href="http://lists.ocaml.org/listinfo/opam-devel">la liste OPAM-devel</a>.</p>
+      <p>
+        (<a href="https://opam.ocaml.org">OPAM</a>) permet de gérer
+        l'installation de paquets sources en OCaml. Il permet l'installation de
+        plusieurs versions du compilateur, tolère des contraintes complexes de
+        dépendances entre les paquets et repose sur des mises à jour via un
+        dépôt Github. La documentation sur l'utilisation d'OPAM pour installer
+        des paquets ou créer vos propres paquets,
+        <a href="https://opam.ocaml.org/doc/Install.html">lire ici</a>. Les
+        paquets sont automatiquement testés lors de leur soumission et un
+        rapport est envoyé au mainteneur. Si vous soumettez un paquet, cela vous
+        permettra de recevoir régulièrement les résultats de tests de
+        non-régression sur une multitude de systèmes d'exploitation et de
+        plateformes.
+      </p>
+      <p>
+        OPAM a été créé et est maintenu par OCamlPro, tandis qu'OCaml Labs gère
+        le dépôt de paquets. Les rapports de bugs et suggestions pour l'outil
+        doivent être déposés sur le
+        <a href="https://github.com/OCaml/opam/issues">bug tracker d'OPAM</a>.
+        Les problèmes concernant les paquets doivent être soumis sur le
+        <a href="https://github.com/OCaml/opam-repository/issues"
+          >bug tracker du dépôt principal</a
+        >. Les questions générales sur l'outil et les paquets peuvent être
+        envoyées sur
+        <a href="http://lists.ocaml.org/listinfo/platform"
+          >la liste de la plateforme OCaml</a
+        >
+        et les détails ou l'évolution d'OPAM peuvent être discutés sur
+        <a href="http://lists.ocaml.org/listinfo/opam-devel"
+          >la liste OPAM-devel</a
+        >.
+      </p>
     </section>
     <section class="span6 condensed">
-      <h1 class="ruled"><a href="/learn/books.html">Livres</a> et <a href="/docs/papers.html">articles</a></h1>
+      <h1 class="ruled">
+        <a href="/learn/books.html">Livres</a> et
+        <a href="/docs/papers.html">articles</a>
+      </h1>
       <div class="row">
-	<div class="span2 documentation-book">
-	  <a href="https://realworldocaml.org">
-	    <img src="/img/real-world-ocaml.jpg" alt="Real Worl OCaml book">
-	  </a>
-	</div>
-	<div class="span2 documentation-book">
-	  <a href="http://ocaml-book.com">
-	    <img src="/img/OCaml_from_beginning.png" alt="OCaml from the very beginning">
-	  </a>
-	</div>
-	<div class="span2 documentation-book">
-	  <a href="http://ocaml-book.com/more-ocaml-algorithms-methods-diversions/">
-	    <img src="/img/more-ocaml-300-376.png" alt="More OCaml: Algorithms, Methods &amp; Diversions">
-	  </a>
-	</div>
+        <div class="span2 documentation-book">
+          <a href="https://realworldocaml.org">
+            <img src="/img/real-world-ocaml.jpg" alt="Real Worl OCaml book" />
+          </a>
+        </div>
+        <div class="span2 documentation-book">
+          <a href="http://ocaml-book.com">
+            <img
+              src="/img/OCaml_from_beginning.png"
+              alt="OCaml from the very beginning"
+            />
+          </a>
+        </div>
+        <div class="span2 documentation-book">
+          <a
+            href="http://ocaml-book.com/more-ocaml-algorithms-methods-diversions/"
+          >
+            <img
+              src="/img/more-ocaml-300-376.png"
+              alt="More OCaml: Algorithms, Methods &amp; Diversions"
+            />
+          </a>
+        </div>
       </div>
       <footer>
-	<p><a href="/learn/books.html">Autres livres</a> / <a href="/docs/papers.html">Articles</a> / <a href="https://realworldocaml.org">Read Real World OCaml online</a></p>
+        <p>
+          <a href="/learn/books.html">Autres livres</a> /
+          <a href="/docs/papers.html">Articles</a> /
+          <a href="https://realworldocaml.org">Read Real World OCaml online</a>
+        </p>
       </footer>
     </section>
-
   </div>
   <div class="row">
     <section class="span12 condensed">
@@ -168,30 +224,69 @@
       <div class="row">
         <div class="span4">
           <p class="documentation-video">
-	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" frameborder="0" allowfullscreen></iframe>
+            <iframe
+              width="310"
+              height="175"
+              src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage"
+              frameborder="0"
+              title="Dans cet exposé, Mark Shinwell explique comment trouver des bugs
+              difficiles dans les programmes OCaml. Cela nécessite l'utilisation
+              du nouveau support de gdb, récemment développé par OCamlPro et
+              d'autres contributeurs"
+              allowfullscreen
+            ></iframe>
           </p>
-          <p>Dans cet exposé, Mark Shinwell explique comment
-	    trouver des bugs difficiles dans les programmes OCaml.
-	    Cela nécessite l'utilisation du nouveau support de gdb,
-	    récemment développé par OCamlPro et d'autres contributeurs.
-	    (<a href="http://oud.ocaml.org/2012/slides/oud2012-paper5-slides.pdf"
-	     >PDF</a>)</p>
+          <p>
+            Dans cet exposé, Mark Shinwell explique comment trouver des bugs
+            difficiles dans les programmes OCaml. Cela nécessite l'utilisation
+            du nouveau support de gdb, récemment développé par OCamlPro et
+            d'autres contributeurs. (<a
+              href="http://oud.ocaml.org/2012/slides/oud2012-paper5-slides.pdf"
+              >PDF</a
+            >)
+          </p>
         </div>
         <div class="span4">
           <p class="documentation-video">
-            <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+            <iframe
+              src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933"
+              width="310"
+              height="233"
+              frameborder="0"
+              title="Exposé de Yaron Minsky à CMU présentant le retour d'expérience de
+              Jane Street sur l'utilisation d'OCaml comme principal langage de
+              développement"
+              webkitallowfullscreen
+              mozallowfullscreen
+              allowfullscreen
+            ></iframe>
           </p>
-          <p>Exposé de Yaron Minsky à CMU présentant
-	    le retour d'expérience de Jane Street sur l'utilisation d'OCaml comme
-	    principal langage de développement.</p>
+          <p>
+            Exposé de Yaron Minsky à CMU présentant le retour d'expérience de
+            Jane Street sur l'utilisation d'OCaml comme principal langage de
+            développement.
+          </p>
         </div>
         <div class="span4">
           <p class="documentation-video">
-            <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+            <iframe
+              src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933"
+              width="310"
+              height="233"
+              frameborder="0"
+              title="Rapport d'expérience: OCaml utilisé pour une plateforme d'analyse
+              statique de niveau industriel, par Pascal Cuoq et Julien Signoles du
+              CEA LIST, à ICFP'2009."
+              webkitallowfullscreen
+              mozallowfullscreen
+              allowfullscreen
+            ></iframe>
           </p>
-          <p>Rapport d'expérience: OCaml utilisé pour une
-	    plateforme d'analyse statique de niveau industriel, par
-            Pascal Cuoq et Julien Signoles du CEA LIST, à ICFP'2009.</p>
+          <p>
+            Rapport d'expérience: OCaml utilisé pour une plateforme d'analyse
+            statique de niveau industriel, par Pascal Cuoq et Julien Signoles du
+            CEA LIST, à ICFP'2009.
+          </p>
         </div>
       </div>
       <footer>

--- a/site/docs/index.fr.md
+++ b/site/docs/index.fr.md
@@ -32,12 +32,12 @@
         langage, sont le meilleur point de départ. Ils constituent une
         introduction complète à la programmation OCaml, avec le système des
         modules, les objets, le polymorphisme, etc.
-
+      </p>
+      <p style="display: flex; justify-content: flex-end">
         <a id="tutref_b" href="/manual/index.html#sec6">
           <input
             type="button"
             class="btn btn-default"
-            style="float: right"
             name="button-tut"
             value="Lire les tutoriels"
         /></a>
@@ -88,7 +88,6 @@
 
     <section class="span6 condensed">
       <h1 class="ruled">Les Extensions du langage</h1>
-
       <p>
         N'oubliez pas de vérifier régulièrement les
         <a id="extref" href="/manual/extn.html">Extensions du langage</a>, afin

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -32,11 +32,12 @@
         language, are the best place to start. They form a complete introduction
         to programming in OCaml, including the module system, objects,
         polymorphism, etc.
+      </p>
+      <p style="display: flex; justify-content: flex-end">
         <a id="tutref_b" href="/manual/index.html#sec6">
           <input
             type="button"
             class="btn btn-default"
-            style="float: right"
             name="button-tut"
             value="Read the tutorials"
         /></a>

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -4,12 +4,17 @@
   <h1>Documentation</h1>
   <div class="form-group">
     <form name="Versions">
-      <label for="version-selector"
-	     style="display:inline;">OCaml version:</label>
-      <select class="form-control" id="version-selector" name="selector"
-	      style="width: 10ex;vertical-align: baseline;"
-	      onChange="refresh()">
-	<option>latest</option>
+      <label for="version-selector" style="display: inline"
+        >OCaml version:</label
+      >
+      <select
+        class="form-control"
+        id="version-selector"
+        name="selector"
+        style="width: 10ex; vertical-align: baseline"
+        onChange="refresh()"
+      >
+        <option>latest</option>
       </select>
     </form>
   </div>
@@ -20,109 +25,112 @@
   <div class="row">
     <section class="span6 condensed">
       <h1 class="ruled">The OCaml Tutorials</h1>
-      <p>The official
-	<a id="tutref"
-	   href="/manual/index.html#sec6">OCaml tutorials</a>
-	(chapters 1 to 6 of the manual), written by the creators of
-	the language, are the best place to start. They form a
-	complete introduction to programming in OCaml, including the
-	module system, objects, polymorphism, etc.
-
-    <a id="tutref_b" href="/manual/index.html#sec6">
-      <input type="button" class="btn btn-default"
-    	 style="float:right;" name="button-tut"
-    	 value="Read the tutorials"></a>
+      <p>
+        The official
+        <a id="tutref" href="/manual/index.html#sec6">OCaml tutorials</a>
+        (chapters 1 to 6 of the manual), written by the creators of the
+        language, are the best place to start. They form a complete introduction
+        to programming in OCaml, including the module system, objects,
+        polymorphism, etc.
+        <a id="tutref_b" href="/manual/index.html#sec6">
+          <input
+            type="button"
+            class="btn btn-default"
+            style="float: right"
+            name="button-tut"
+            value="Read the tutorials"
+        /></a>
       </p>
     </section>
-
     <section class="span6 condensed">
       <h1 class="ruled">The OCaml API</h1>
-      <p>This is the place you'll end up most often!  You'll find the
-    documentation for all modules that ship with any OCaml
-    distribution. These modules form what is called
-    the <a id="stdlib" href="/manual/stdlib.html">Standard
-    Library</a>. In addition, a special
-    module <code id="stdlib_name">Stdlib</code> contains
-    the <a id="corref" href="/manual/core.html">core
-    library</a>, and is always open.
-
-    <a id="api_b"
-       href="/api/index.html">
-      <input type="button" class="btn btn-default"
-    	 style="float:right;" name="button-api"
-    	 value="OCaml API"></a>
+      <p>
+        This is the place you'll end up most often! You'll find the
+        documentation for all modules that ship with any OCaml distribution.
+        These modules form what is called the
+        <a id="stdlib" href="/manual/stdlib.html">Standard Library</a>. In
+        addition, a special module <code id="stdlib_name">Stdlib</code> contains
+        the <a id="corref" href="/manual/core.html">core library</a>, and is
+        always open.
+      </p>
+      <p style="display: flex; justify-content: flex-end">
+        <a id="api_b" href="/api/index.html">
+          <input
+            type="button"
+            class="btn btn-default"
+            name="button-api"
+            value="OCaml API"
+        /></a>
       </p>
     </section>
-
     <section class="span6 condensed">
       <h1 class="ruled">The Tools</h1>
       <p>
-    Many <a id="toolref"
-    	    href="/manual/index.html#sec286">tools</a>
-    are bundled with the OCaml language. Among them, the REPL (or
-    `toplevel'), the documentation generator, lexers, the
-    debugger, profiling tools, etc.
-
-    <a id="toolref_b"
-       href="/manual/index.html#sec286">
-      <input type="button" class="btn btn-default"
-    	 style="float:right;" name="button-api"
-    	 value="OCaml Tools"></a>
+        Many <a id="toolref" href="/manual/index.html#sec286">tools</a>
+        are bundled with the OCaml language. Among them, the REPL (or
+        `toplevel'), the documentation generator, lexers, the debugger,
+        profiling tools, etc.
+      </p>
+      <p style="display: flex; justify-content: flex-end">
+        <a id="toolref_b" href="/manual/index.html#sec286">
+          <input
+            type="button"
+            class="btn btn-default"
+            name="button-api"
+            value="OCaml Tools"
+        /></a>
       </p>
     </section>
-
     <section class="span6 condensed">
       <h1 class="ruled">The Language Extensions</h1>
-
-      <p>Don't forget to regularly check the
-    <a id="extref"
-       href="/manual/extn.html">Language Extensions</a>,
-    they will keep you up-to-date with useful new OCaml idioms
-    and constructions.<br>
-
-    <a id="extref_b"
-       href="/manual/extn.html">
-      <input type="button" class="btn btn-default"
-    	 style="float:right;" name="button-ext"
-    	 value="OCaml Extensions"></a>
-
+      <p>
+        Don't forget to regularly check the
+        <a id="extref" href="/manual/extn.html">Language Extensions</a>, they
+        will keep you up-to-date with useful new OCaml idioms and
+        constructions.<br />
+      </p>
+      <p style="display: flex; justify-content: flex-end">
+        <a id="extref_b" href="/manual/extn.html">
+          <input
+            type="button"
+            class="btn btn-default"
+            name="button-ext"
+            value="OCaml Extensions"
+        /></a>
       </p>
     </section>
-
     <section class="span6 condensed">
       <h1 class="ruled">The OCaml Manual</h1>
-      <p>The complete documentation is bundled as a
-    large <a id="manual" href="/manual/index.html">
-    OCaml Manual</a>.  This manual is also available in
-    <a id="refman-pdf"
-       href="/releases/4.12/ocaml-4.12-refman.pdf">PDF</a>,
-    <a id="refman-txt"
-       href="/releases/4.12/ocaml-4.12-refman.txt">plain text</a>,
-    as a
-    <a id="refman-html"
-       href="/releases/4.12/ocaml-4.12-refman-html.tar.gz">bundle of
-      HTML files</a>, and as a
-    <a id="refman-info"
-       href="/releases/4.12/ocaml-4.12-refman.info.tar.gz">bundle of
-      Emacs Info files</a>.
+      <p>
+        The complete documentation is bundled as a large
+        <a id="manual" href="/manual/index.html"> OCaml Manual</a>. This manual
+        is also available in
+        <a id="refman-pdf" href="/releases/4.12/ocaml-4.12-refman.pdf">PDF</a>,
+        <a id="refman-txt" href="/releases/4.12/ocaml-4.12-refman.txt"
+          >plain text</a
+        >, as a
+        <a id="refman-html" href="/releases/4.12/ocaml-4.12-refman-html.tar.gz"
+          >bundle of HTML files</a
+        >, and as a
+        <a id="refman-info" href="/releases/4.12/ocaml-4.12-refman.info.tar.gz"
+          >bundle of Emacs Info files</a
+        >.
       </p>
     </section>
-
 
     <section class="span6 condensed">
       <h1 class="ruled">Other docs</h1>
       <div class="row">
-    <a href="license.html" class="span3 documentation-highlight">
-      <img src="/img/license.svg" alt="" class="svg">
-      <img src="/img/license.png" alt="" class="png">
-      OCaml License
-    </a>
-    <a href="cheat_sheets.html"
-       class="span3 documentation-highlight">
-      <img src="/img/cheat.svg" alt="" class="svg" />
-      <img src="/img/cheat.png" alt="" class="png" />
-      Cheat Sheets
-    </a>
+        <a href="license.html" class="span3 documentation-highlight">
+          <img src="/img/license.svg" alt="" class="svg" />
+          <img src="/img/license.png" alt="" class="png" />
+          OCaml License
+        </a>
+        <a href="cheat_sheets.html" class="span3 documentation-highlight">
+          <img src="/img/cheat.svg" alt="" class="svg" />
+          <img src="/img/cheat.png" alt="" class="png" />
+          Cheat Sheets
+        </a>
       </div>
     </section>
 
@@ -131,40 +139,56 @@
   <div class="row">
     <section class="span6 condensed">
       <h1 class="ruled">OPAM and package documentation</h1>
-      <p>OPAM is the source-based package manager for OCaml.
-	It allows you to install OCaml and packages.
-	See the <a href="install.html">installation
-	instructions.</a> and the
-	<a href="https://opam.ocaml.org/doc/">OPAM documentation</a>.
+      <p>
+        OPAM is the source-based package manager for OCaml. It allows you to
+        install OCaml and packages. See the
+        <a href="install.html">installation instructions.</a> and the
+        <a href="https://opam.ocaml.org/doc/">OPAM documentation</a>.
       </p>
-      <p>The <a href="https://opam.ocaml.org/packages/">list of
-	OPAM packages</a> has links to their homepage
-	and documentation. The distribution and API documentation
-	of the packages you install locally with OPAM can be accessed
-	via <a href="http://erratique.ch/software/odig">odig</a>.
+      <p>
+        The
+        <a href="https://opam.ocaml.org/packages/">list of OPAM packages</a> has
+        links to their homepage and documentation. The distribution and API
+        documentation of the packages you install locally with OPAM can be
+        accessed via <a href="http://erratique.ch/software/odig">odig</a>.
       </p>
     </section>
     <section class="span6 condensed">
-      <h1 class="ruled"><a href="/learn/books.html">Books</a> and <a href="/docs/papers.html">Papers</a></h1>
+      <h1 class="ruled">
+        <a href="/learn/books.html">Books</a> and
+        <a href="/docs/papers.html">Papers</a>
+      </h1>
       <div class="row">
-	<div class="span2 documentation-book">
-	  <a href="https://realworldocaml.org">
-	    <img src="/img/real-world-ocaml.jpg" alt="Real Worl OCaml book">
-	  </a>
-	</div>
-	<div class="span2 documentation-book">
-	  <a href="http://ocaml-book.com">
-	    <img src="/img/OCaml_from_beginning.png" alt="OCaml from the very beginning">
-	  </a>
-	</div>
-	<div class="span2 documentation-book">
-	  <a href="http://ocaml-book.com/more-ocaml-algorithms-methods-diversions/">
-	    <img src="/img/more-ocaml-300-376.png" alt="More OCaml: Algorithms, Methods &amp; Diversions">
-	  </a>
-	</div>
+        <div class="span2 documentation-book">
+          <a href="https://realworldocaml.org">
+            <img src="/img/real-world-ocaml.jpg" alt="Real Worl OCaml book" />
+          </a>
+        </div>
+        <div class="span2 documentation-book">
+          <a href="http://ocaml-book.com">
+            <img
+              src="/img/OCaml_from_beginning.png"
+              alt="OCaml from the very beginning"
+            />
+          </a>
+        </div>
+        <div class="span2 documentation-book">
+          <a
+            href="http://ocaml-book.com/more-ocaml-algorithms-methods-diversions/"
+          >
+            <img
+              src="/img/more-ocaml-300-376.png"
+              alt="More OCaml: Algorithms, Methods &amp; Diversions"
+            />
+          </a>
+        </div>
       </div>
       <footer>
-	<p><a href="/learn/books.html">See more books</a> / <a href="/docs/papers.html">See more papers</a> / <a href="https://realworldocaml.org">Read Real World OCaml online</a></p>
+        <p>
+          <a href="/learn/books.html">See more books</a> /
+          <a href="/docs/papers.html">See more papers</a> /
+          <a href="https://realworldocaml.org">Read Real World OCaml online</a>
+        </p>
       </footer>
     </section>
   </div>
@@ -172,34 +196,66 @@
     <section class="span12 condensed">
       <h1 class="ruled"><a href="/community/media.html">Videos</a></h1>
       <div class="row">
-	<div class="span4">
-	  <p class="documentation-video">
-	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" title="Mark Shinwell explains how to track down hard-to-find bugs in OCaml programs" frameborder="0" allowfullscreen></iframe>
-	  </p>
-	  <p>In this talk, Mark Shinwell explains how to
-	    track down hard-to-find bugs in OCaml programs.
-	    It involves the new gdb functionality
-	    which OCamlPro and others have worked on recently.
-	    (<a href="http://oud.ocaml.org/2012/slides/oud2012-paper5-slides.pdf"
-	     >PDF slides</a>)</p>
-	</div>
-	<div class="span4">
-	  <p class="documentation-video">
-	    <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" title="Talk at CMU describing the experiences that Jane Street has had using OCaml as its primary development language" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-	  </p>
-	  <p>Talk at CMU describing the experiences that Jane Street has had using OCaml as its primary development language.</p>
-	</div>
-	<div class="span4">
-	  <p class="documentation-video">
-	    <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" title="Experience Report: OCaml for an Industrial-strength Static Analysis Framework" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-	  </p>
-	  <p>Experience Report: OCaml for an Industrial-strength Static Analysis Framework
-	    Pascal Cuoq and Julien Signoles; CEA LIST
-	    International Conference on Functional Programming (ICFP) Edinburgh 2009.</p>
-	</div>
+        <div class="span4">
+          <p class="documentation-video">
+            <iframe
+              width="310"
+              height="175"
+              src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage"
+              title="Mark Shinwell explains how to track down hard-to-find bugs in OCaml programs"
+              frameborder="0"
+              allowfullscreen
+            ></iframe>
+          </p>
+          <p>
+            In this talk, Mark Shinwell explains how to track down hard-to-find
+            bugs in OCaml programs. It involves the new gdb functionality which
+            OCamlPro and others have worked on recently. (<a
+              href="http://oud.ocaml.org/2012/slides/oud2012-paper5-slides.pdf"
+              >PDF slides</a
+            >)
+          </p>
+        </div>
+        <div class="span4">
+          <p class="documentation-video">
+            <iframe
+              src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933"
+              width="310"
+              height="233"
+              frameborder="0"
+              title="Talk at CMU describing the experiences that Jane Street has had using OCaml as its primary development language"
+              webkitallowfullscreen
+              mozallowfullscreen
+              allowfullscreen
+            ></iframe>
+          </p>
+          <p>
+            Talk at CMU describing the experiences that Jane Street has had
+            using OCaml as its primary development language.
+          </p>
+        </div>
+        <div class="span4">
+          <p class="documentation-video">
+            <iframe
+              src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933"
+              width="310"
+              height="233"
+              frameborder="0"
+              title="Experience Report: OCaml for an Industrial-strength Static Analysis Framework"
+              webkitallowfullscreen
+              mozallowfullscreen
+              allowfullscreen
+            ></iframe>
+          </p>
+          <p>
+            Experience Report: OCaml for an Industrial-strength Static Analysis
+            Framework Pascal Cuoq and Julien Signoles; CEA LIST International
+            Conference on Functional Programming (ICFP) Edinburgh 2009.
+          </p>
+        </div>
       </div>
       <footer>
-	<p><a href="/community/media.html">See more videos</a></p>
+        <p><a href="/community/media.html">See more videos</a></p>
       </footer>
     </section>
   </div>

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -28,46 +28,46 @@
 	complete introduction to programming in OCaml, including the
 	module system, objects, polymorphism, etc.
 
-	<a id="tutref_b" href="/manual/index.html#sec6">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-tut"
-		 value="Read the tutorials"></a>
+    <a id="tutref_b" href="/manual/index.html#sec6">
+      <input type="button" class="btn btn-default"
+    	 style="float:right;" name="button-tut"
+    	 value="Read the tutorials"></a>
       </p>
     </section>
 
     <section class="span6 condensed">
       <h1 class="ruled">The OCaml API</h1>
       <p>This is the place you'll end up most often!  You'll find the
-	documentation for all modules that ship with any OCaml
-	distribution. These modules form what is called
-	the <a id="stdlib" href="/manual/stdlib.html">Standard
-	Library</a>. In addition, a special
-	module <code id="stdlib_name">Stdlib</code> contains
-	the <a id="corref" href="/manual/core.html">core
-	library</a>, and is always open.
+    documentation for all modules that ship with any OCaml
+    distribution. These modules form what is called
+    the <a id="stdlib" href="/manual/stdlib.html">Standard
+    Library</a>. In addition, a special
+    module <code id="stdlib_name">Stdlib</code> contains
+    the <a id="corref" href="/manual/core.html">core
+    library</a>, and is always open.
 
-	<a id="api_b"
-	   href="/api/index.html">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-api"
-		 value="OCaml API"></a>
+    <a id="api_b"
+       href="/api/index.html">
+      <input type="button" class="btn btn-default"
+    	 style="float:right;" name="button-api"
+    	 value="OCaml API"></a>
       </p>
     </section>
 
     <section class="span6 condensed">
       <h1 class="ruled">The Tools</h1>
       <p>
-	Many <a id="toolref"
-		    href="/manual/index.html#sec286">tools</a>
-	are bundled with the OCaml language. Among them, the REPL (or
-	`toplevel'), the documentation generator, lexers, the
-	debugger, profiling tools, etc.
+    Many <a id="toolref"
+    	    href="/manual/index.html#sec286">tools</a>
+    are bundled with the OCaml language. Among them, the REPL (or
+    `toplevel'), the documentation generator, lexers, the
+    debugger, profiling tools, etc.
 
-	<a id="toolref_b"
-	   href="/manual/index.html#sec286">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-api"
-		 value="OCaml Tools"></a>
+    <a id="toolref_b"
+       href="/manual/index.html#sec286">
+      <input type="button" class="btn btn-default"
+    	 style="float:right;" name="button-api"
+    	 value="OCaml Tools"></a>
       </p>
     </section>
 
@@ -75,16 +75,16 @@
       <h1 class="ruled">The Language Extensions</h1>
 
       <p>Don't forget to regularly check the
-	<a id="extref"
-	   href="/manual/extn.html">Language Extensions</a>,
-	they will keep you up-to-date with useful new OCaml idioms
-	and constructions.<br>
+    <a id="extref"
+       href="/manual/extn.html">Language Extensions</a>,
+    they will keep you up-to-date with useful new OCaml idioms
+    and constructions.<br>
 
-	<a id="extref_b"
-	   href="/manual/extn.html">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-ext"
-		 value="OCaml Extensions"></a>
+    <a id="extref_b"
+       href="/manual/extn.html">
+      <input type="button" class="btn btn-default"
+    	 style="float:right;" name="button-ext"
+    	 value="OCaml Extensions"></a>
 
       </p>
     </section>
@@ -92,19 +92,19 @@
     <section class="span6 condensed">
       <h1 class="ruled">The OCaml Manual</h1>
       <p>The complete documentation is bundled as a
-	large <a id="manual" href="/manual/index.html">
-	OCaml Manual</a>.  This manual is also available in
-	<a id="refman-pdf"
-	   href="/releases/4.12/ocaml-4.12-refman.pdf">PDF</a>,
-	<a id="refman-txt"
-	   href="/releases/4.12/ocaml-4.12-refman.txt">plain text</a>,
-	as a
-	<a id="refman-html"
-	   href="/releases/4.12/ocaml-4.12-refman-html.tar.gz">bundle of
-	  HTML files</a>, and as a
-	<a id="refman-info"
-	   href="/releases/4.12/ocaml-4.12-refman.info.tar.gz">bundle of
-	  Emacs Info files</a>.
+    large <a id="manual" href="/manual/index.html">
+    OCaml Manual</a>.  This manual is also available in
+    <a id="refman-pdf"
+       href="/releases/4.12/ocaml-4.12-refman.pdf">PDF</a>,
+    <a id="refman-txt"
+       href="/releases/4.12/ocaml-4.12-refman.txt">plain text</a>,
+    as a
+    <a id="refman-html"
+       href="/releases/4.12/ocaml-4.12-refman-html.tar.gz">bundle of
+      HTML files</a>, and as a
+    <a id="refman-info"
+       href="/releases/4.12/ocaml-4.12-refman.info.tar.gz">bundle of
+      Emacs Info files</a>.
       </p>
     </section>
 
@@ -112,21 +112,21 @@
     <section class="span6 condensed">
       <h1 class="ruled">Other docs</h1>
       <div class="row">
-	<a href="license.html" class="span3 documentation-highlight">
-	  <img src="/img/license.svg" alt="" class="svg">
-	  <img src="/img/license.png" alt="" class="png">
-	  OCaml License
-	</a>
-	<a href="cheat_sheets.html"
-	   class="span3 documentation-highlight">
-	  <img src="/img/cheat.svg" alt="" class="svg" />
-	  <img src="/img/cheat.png" alt="" class="png" />
-	  Cheat Sheets
-	</a>
+    <a href="license.html" class="span3 documentation-highlight">
+      <img src="/img/license.svg" alt="" class="svg">
+      <img src="/img/license.png" alt="" class="png">
+      OCaml License
+    </a>
+    <a href="cheat_sheets.html"
+       class="span3 documentation-highlight">
+      <img src="/img/cheat.svg" alt="" class="svg" />
+      <img src="/img/cheat.png" alt="" class="png" />
+      Cheat Sheets
+    </a>
       </div>
     </section>
-  </div>
 
+  </div>
 
   <div class="row">
     <section class="span6 condensed">
@@ -174,7 +174,7 @@
       <div class="row">
 	<div class="span4">
 	  <p class="documentation-video">
-	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" frameborder="0" allowfullscreen></iframe>
+	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" title="Mark Shinwell explains how to track down hard-to-find bugs in OCaml programs" frameborder="0" allowfullscreen></iframe>
 	  </p>
 	  <p>In this talk, Mark Shinwell explains how to
 	    track down hard-to-find bugs in OCaml programs.
@@ -185,13 +185,13 @@
 	</div>
 	<div class="span4">
 	  <p class="documentation-video">
-	    <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+	    <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" title="Talk at CMU describing the experiences that Jane Street has had using OCaml as its primary development language" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 	  </p>
 	  <p>Talk at CMU describing the experiences that Jane Street has had using OCaml as its primary development language.</p>
 	</div>
 	<div class="span4">
 	  <p class="documentation-video">
-	    <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+	    <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" title="Experience Report: OCaml for an Industrial-strength Static Analysis Framework" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 	  </p>
 	  <p>Experience Report: OCaml for an Industrial-strength Static Analysis Framework
 	    Pascal Cuoq and Julien Signoles; CEA LIST


### PR DESCRIPTION
# Description

This pull request makes the [documentation](https://ocaml.org/docs/) page more accessible and fixes the misalignment and overlap of the green buttons with the heading text on mobile view. The misalignment in mobile view was as a result of using `float:right` on the `input` element. This was fixed by wrapping the `a` tag in its own `p` element and then applying `display: flex` on the `p` tag.  The page has been made more accessible by adding  descriptive titles  to the `iframe` elements.

# Issue

Closes #1236.

# Before

**Alignment**

- Desktop view
![image](https://user-images.githubusercontent.com/52580190/109412956-0040ee80-79bc-11eb-9b5d-eec7076cae97.png)
- Mobile view
![image](https://user-images.githubusercontent.com/52580190/109413015-5dd53b00-79bc-11eb-9493-252f0d9b3004.png)

**Accessibility**
Google chrome's light house accessibility report.
![image](https://user-images.githubusercontent.com/52580190/109413543-0e443e80-79bf-11eb-9715-744a1d047d1c.png)


# After

**Alignment**
- Desktop view
![image](https://user-images.githubusercontent.com/52580190/109413065-a3920380-79bc-11eb-831b-0cf49680e017.png)
- Mobile view
![image](https://user-images.githubusercontent.com/52580190/109413167-19966a80-79bd-11eb-8954-e24c05f6f18b.png)

**Accessibility**
Google chrome's light house accessibility report.
![image](https://user-images.githubusercontent.com/52580190/109413602-5cf1d880-79bf-11eb-8978-39921b1d5dbe.png)


