### PR TITLE
Fix HTML validation errors

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -145,7 +145,7 @@ h1 img.rss {
 .documentation-video iframe{
   border: 0;
 }
-.documentation-form{
+.doc-link-wrapper{
   display: flex;
   justify-content: flex-end;
 }

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -142,7 +142,13 @@ li p {
 h1 img.rss {
   height: 1.3ex;
 }
-
+.documentation-video iframe{
+  border: 0;
+}
+.documentation-form{
+  display: flex;
+  justify-content: flex-end;
+}
 .syndication img {
   height: 1.5ex;
   margin-left: 0.3ex;

--- a/site/docs/index.fr.md
+++ b/site/docs/index.fr.md
@@ -29,11 +29,10 @@
 	programmation OCaml, avec le système des modules, les
 	objets, le polymorphisme, etc.
     </p>
-	  <form id="tutref_b" action="/manual/index.html#sec6" class="documentation-form">
-	    <input type="submit" class="btn btn-default"
-		  name="button-tut"
-		  value="Lire les tutoriels">
-	</form>
+	<p class="doc-link-wrapper">
+        <a id="tutref_b" href="/manual/index.html#sec6" class="btn btn-default">
+			Lire les tutoriels</a>
+	  </p>
     </section>
 
     <section class="span6 condensed">
@@ -47,11 +46,11 @@
 	la <a id="corref" href="/manual/core.html">"core
 	  library"</a>, et est toujours ouvert.
       </p>
-	  <form id="api_b" action="/api/index.html" class="documentation-form">
-	    <input type="submit" class="btn btn-default"
-		name="button-api"
-		value="API OCaml">
-	 </form>
+	  <p class="doc-link-wrapper">
+		<a id="api_b"
+		href="/api/index.html" class="btn btn-default">
+		API OCaml</a>
+	  </p>
     </section>
 
     <section class="span6 condensed">
@@ -65,11 +64,11 @@
 	générateur de documentation, le lexer, le débogueur,
 	les outils de profilage, etc.
       </p>
-	  <form id="toolref_b" action="/manual/index.html#sec286" class="documentation-form">
-	    <input type="submit" class="btn btn-default"
-		name="button-api"
-		value="Outils OCaml">
-	 </form>
+	  <p class="doc-link-wrapper">
+		<a id="toolref_b"
+		href="/manual/index.html#sec286" class="btn btn-default">
+		Outils OCaml</a>
+	  </p>
     </section>
 
     <section class="span6 condensed">
@@ -83,11 +82,11 @@
 	<br>
     </p>
 	  
-	<form id="extref_b" action="/manual/extn.html" class="documentation-form">
-	    <input type="submit" class="btn btn-default"
-		name="button-ext"
-		value="Extensions OCaml">
-	 </form>
+	<p class="doc-link-wrapper">
+		<a id="extref_b"
+		href="/manual/extn.html" class="btn btn-default" >
+		Extensions OCaml</a>
+	  </p>
     </section>
 
     <section class="span6 condensed">

--- a/site/docs/index.fr.md
+++ b/site/docs/index.fr.md
@@ -19,7 +19,7 @@
 
   <div class="row">
     <section class="span6 condensed">
-      <h1 class="ruled">Les Tutoriels OCaml</h1>
+      <h2 class="ruled">Les Tutoriels OCaml</h2>
       <p>Les
 	<a id="tutref"
 	   href="/manual/index.html#sec6">tutoriels OCaml</a>
@@ -28,16 +28,16 @@
 	départ. Ils constituent une introduction complète à la
 	programmation OCaml, avec le système des modules, les
 	objets, le polymorphisme, etc.
-
-	<a id="tutref_b" href="/manual/index.html#sec6">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-tut"
-		 value="Lire les tutoriels"></a>
-      </p>
+    </p>
+	  <form id="tutref_b" action="/manual/index.html#sec6" class="documentation-form">
+	    <input type="submit" class="btn btn-default"
+		  name="button-tut"
+		  value="Lire les tutoriels">
+	</form>
     </section>
 
     <section class="span6 condensed">
-      <h1 class="ruled">L'API OCaml</h1>
+      <h2 class="ruled">L'API OCaml</h2>
       <p>Incontournable! Contient la documentation pour l'ensemble
 	des modules inclus dans toute distribution OCaml. Ces
 	modules forment ce qu'on appelle la
@@ -46,17 +46,16 @@
 	<code id="stdlib_name">Stdlib</code> contient
 	la <a id="corref" href="/manual/core.html">"core
 	  library"</a>, et est toujours ouvert.
-
-	<a id="api_b"
-	   href="/api/index.html">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-api"
-		 value="API OCaml"></a>
       </p>
+	  <form id="api_b" action="/api/index.html" class="documentation-form">
+	    <input type="submit" class="btn btn-default"
+		name="button-api"
+		value="API OCaml">
+	 </form>
     </section>
 
     <section class="span6 condensed">
-      <h1 class="ruled">Les outils</h1>
+      <h2 class="ruled">Les outils</h2>
       <p>
 	De nombreux
 	<a id="toolref"
@@ -65,17 +64,16 @@
 	l'interpréteur interactif (REPL ou `toplevel'), le
 	générateur de documentation, le lexer, le débogueur,
 	les outils de profilage, etc.
-
-	<a id="toolref_b"
-	   href="/manual/index.html#sec286">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-api"
-		 value="Outils OCaml"></a>
       </p>
+	  <form id="toolref_b" action="/manual/index.html#sec286" class="documentation-form">
+	    <input type="submit" class="btn btn-default"
+		name="button-api"
+		value="Outils OCaml">
+	 </form>
     </section>
 
     <section class="span6 condensed">
-      <h1 class="ruled">Les Extensions du langage</h1>
+      <h2 class="ruled">Les Extensions du langage</h2>
 
       <p>N'oubliez pas de vérifier régulièrement les
 	<a id="extref"
@@ -83,18 +81,17 @@
 	afin de rester à jour avec les nouvelles constructions
 	qui vont vous simplifier la vie.
 	<br>
-
-	<a id="extref_b"
-	   href="/manual/extn.html">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-ext"
-		 value="Extensions OCaml"></a>
-
-      </p>
+    </p>
+	  
+	<form id="extref_b" action="/manual/extn.html" class="documentation-form">
+	    <input type="submit" class="btn btn-default"
+		name="button-ext"
+		value="Extensions OCaml">
+	 </form>
     </section>
 
     <section class="span6 condensed">
-      <h1 class="ruled">Le Manuel OCaml</h1>
+      <h2 class="ruled">Le Manuel OCaml</h2>
       <p>L'ensemble de la documentation est regroupé dans un important
 	<a id="manual" href="/manual/index.html">
 	  Manuel OCaml</a>.  Le manuel est également disponible aux formats
@@ -112,7 +109,7 @@
 
 
     <section class="span6 condensed">
-      <h1 class="ruled">Autres documents</h1>
+      <h2 class="ruled">Autres documents</h2>
       <div class="row">
 	<a href="license.html" class="span3 documentation-highlight">
 	  <img src="/img/license.svg" alt="" class="svg">
@@ -133,12 +130,12 @@
 
   <div class="row">
     <section class="span6 condensed">
-      <h1 class="ruled">Documentation d'OPAM</h1>
+      <h2 class="ruled">Documentation d'OPAM</h2>
       <p>(<a href="https://opam.ocaml.org">OPAM</a>) permet de gérer l'installation de paquets sources en OCaml. Il permet l'installation de plusieurs versions du compilateur, tolère des contraintes complexes de dépendances entre les paquets et repose sur des mises à jour via un dépôt Github. La documentation sur l'utilisation d'OPAM pour installer des paquets ou créer vos propres paquets, <a href="https://opam.ocaml.org/doc/Install.html">lire ici</a>. Les paquets sont automatiquement testés lors de leur soumission et un rapport est envoyé au mainteneur. Si vous soumettez un paquet, cela vous permettra de recevoir régulièrement les résultats de tests de non-régression sur une multitude de systèmes d'exploitation et de plateformes.</p>
       <p>OPAM a été créé et est maintenu par OCamlPro, tandis qu'OCaml Labs gère le dépôt de paquets. Les rapports de bugs et suggestions pour l'outil doivent être déposés sur le <a href="https://github.com/OCaml/opam/issues">bug tracker d'OPAM</a>. Les problèmes concernant les paquets doivent être soumis sur le <a href="https://github.com/OCaml/opam-repository/issues">bug tracker du dépôt principal</a>. Les questions générales sur l'outil et les paquets peuvent être envoyées sur <a href="http://lists.ocaml.org/listinfo/platform">la liste de la plateforme OCaml</a> et les détails ou l'évolution d'OPAM peuvent être discutés sur <a href="http://lists.ocaml.org/listinfo/opam-devel">la liste OPAM-devel</a>.</p>
     </section>
     <section class="span6 condensed">
-      <h1 class="ruled"><a href="/learn/books.html">Livres</a> et <a href="/docs/papers.html">articles</a></h1>
+      <h2 class="ruled"><a href="/learn/books.html">Livres</a> et <a href="/docs/papers.html">articles</a></h2>
       <div class="row">
 	<div class="span2 documentation-book">
 	  <a href="https://realworldocaml.org">
@@ -164,11 +161,11 @@
   </div>
   <div class="row">
     <section class="span12 condensed">
-      <h1 class="ruled"><a href="/community/media.html">Vidéos</a></h1>
+      <h2 class="ruled"><a href="/community/media.html">Vidéos</a></h2>
       <div class="row">
         <div class="span4">
           <p class="documentation-video">
-	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" frameborder="0" allowfullscreen></iframe>
+	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" allowfullscreen></iframe>
           </p>
           <p>Dans cet exposé, Mark Shinwell explique comment
 	    trouver des bugs difficiles dans les programmes OCaml.
@@ -179,7 +176,7 @@
         </div>
         <div class="span4">
           <p class="documentation-video">
-            <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+            <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" allowfullscreen></iframe>
           </p>
           <p>Exposé de Yaron Minsky à CMU présentant
 	    le retour d'expérience de Jane Street sur l'utilisation d'OCaml comme
@@ -187,7 +184,7 @@
         </div>
         <div class="span4">
           <p class="documentation-video">
-            <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+            <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" allowfullscreen></iframe>
           </p>
           <p>Rapport d'expérience: OCaml utilisé pour une
 	    plateforme d'analyse statique de niveau industriel, par

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -29,11 +29,10 @@
 	module system, objects, polymorphism, etc.
       
    </p>
-   <form id="tutref_b" action="/manual/index.html#sec6" class="documentation-form">
-	    <input type="submit" class="btn btn-default"
-		  name="button-tut"
-		 value="Read the tutorials">
-	</form>
+   <p class="doc-link-wrapper">
+	<a id="tutref_b" href="/manual/index.html#sec6" class="btn btn-default">
+		Read the tutorials</a>
+  </p>
     </section>
 
     <section class="span6 condensed">
@@ -47,11 +46,11 @@
 	the <a id="corref" href="/manual/core.html">core
 	library</a>, and is always open.
    </p>
-    <form id="api_b" action="/api/index.html" class="documentation-form">
-	    <input type="submit" class="btn btn-default"
-		name="button-api"
-		value="OCaml API">
-	 </form>
+   <p class="doc-link-wrapper">
+	<a id="api_b"
+	href="/api/index.html" class="btn btn-default">
+	OCaml API</a>
+  </p>
     </section>
 
     <section class="span6 condensed">
@@ -63,11 +62,11 @@
 	`toplevel'), the documentation generator, lexers, the
 	debugger, profiling tools, etc.
     </p>
-	  <form id="toolref_b" action="/manual/index.html#sec286" class="documentation-form">
-	    <input type="submit" class="btn btn-default"
-		name="button-api"
-		value="OCaml Tools">
-	 </form>
+	<p class="doc-link-wrapper">
+		<a id="toolref_b"
+		href="/manual/index.html#sec286" class="btn btn-default">
+	   OCaml Tools</a>
+	  </p>
     </section>
 
     <section class="span6 condensed">
@@ -79,11 +78,11 @@
 	they will keep you up-to-date with useful new OCaml idioms
 	and constructions.<br>
       </p>
-	  <form id="extref_b" action="/manual/extn.html" class="documentation-form">
-	    <input type="submit" class="btn btn-default"
-		name="button-ext"
-		value="OCaml Extensions">
-	 </form>
+	  <p class="doc-link-wrapper">
+		<a id="extref_b"
+		href="/manual/extn.html" class="btn btn-default" >
+	   OCaml Extensions</a>
+	  </p>
     </section>
 
     <section class="span6 condensed">

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -19,7 +19,7 @@
 
   <div class="row">
     <section class="span6 condensed">
-      <h1 class="ruled">The OCaml Tutorials</h1>
+      <h2 class="ruled">The OCaml Tutorials</h2>
       <p>The official
 	<a id="tutref"
 	   href="/manual/index.html#sec6">OCaml tutorials</a>
@@ -27,16 +27,17 @@
 	the language, are the best place to start. They form a
 	complete introduction to programming in OCaml, including the
 	module system, objects, polymorphism, etc.
-
-	<a id="tutref_b" href="/manual/index.html#sec6">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-tut"
-		 value="Read the tutorials"></a>
-      </p>
+      
+   </p>
+   <form id="tutref_b" action="/manual/index.html#sec6" class="documentation-form">
+	    <input type="submit" class="btn btn-default"
+		  name="button-tut"
+		 value="Read the tutorials">
+	</form>
     </section>
 
     <section class="span6 condensed">
-      <h1 class="ruled">The OCaml API</h1>
+      <h2 class="ruled">The OCaml API</h2>
       <p>This is the place you'll end up most often!  You'll find the
 	documentation for all modules that ship with any OCaml
 	distribution. These modules form what is called
@@ -45,52 +46,48 @@
 	module <code id="stdlib_name">Stdlib</code> contains
 	the <a id="corref" href="/manual/core.html">core
 	library</a>, and is always open.
-
-	<a id="api_b"
-	   href="/api/index.html">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-api"
-		 value="OCaml API"></a>
-      </p>
+   </p>
+    <form id="api_b" action="/api/index.html" class="documentation-form">
+	    <input type="submit" class="btn btn-default"
+		name="button-api"
+		value="OCaml API">
+	 </form>
     </section>
 
     <section class="span6 condensed">
-      <h1 class="ruled">The Tools</h1>
+      <h2 class="ruled">The Tools</h2>
       <p>
 	Many <a id="toolref"
 		    href="/manual/index.html#sec286">tools</a>
 	are bundled with the OCaml language. Among them, the REPL (or
 	`toplevel'), the documentation generator, lexers, the
 	debugger, profiling tools, etc.
-
-	<a id="toolref_b"
-	   href="/manual/index.html#sec286">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-api"
-		 value="OCaml Tools"></a>
-      </p>
+    </p>
+	  <form id="toolref_b" action="/manual/index.html#sec286" class="documentation-form">
+	    <input type="submit" class="btn btn-default"
+		name="button-api"
+		value="OCaml Tools">
+	 </form>
     </section>
 
     <section class="span6 condensed">
-      <h1 class="ruled">The Language Extensions</h1>
+      <h2 class="ruled">The Language Extensions</h2>
 
       <p>Don't forget to regularly check the
 	<a id="extref"
 	   href="/manual/extn.html">Language Extensions</a>,
 	they will keep you up-to-date with useful new OCaml idioms
 	and constructions.<br>
-
-	<a id="extref_b"
-	   href="/manual/extn.html">
-	  <input type="button" class="btn btn-default"
-		 style="float:right;" name="button-ext"
-		 value="OCaml Extensions"></a>
-
       </p>
+	  <form id="extref_b" action="/manual/extn.html" class="documentation-form">
+	    <input type="submit" class="btn btn-default"
+		name="button-ext"
+		value="OCaml Extensions">
+	 </form>
     </section>
 
     <section class="span6 condensed">
-      <h1 class="ruled">The OCaml Manual</h1>
+      <h2 class="ruled">The OCaml Manual</h2>
       <p>The complete documentation is bundled as a
 	large <a id="manual" href="/manual/index.html">
 	OCaml Manual</a>.  This manual is also available in
@@ -110,7 +107,7 @@
 
 
     <section class="span6 condensed">
-      <h1 class="ruled">Other docs</h1>
+      <h2 class="ruled">Other docs</h2>
       <div class="row">
 	<a href="license.html" class="span3 documentation-highlight">
 	  <img src="/img/license.svg" alt="" class="svg">
@@ -130,7 +127,7 @@
 
   <div class="row">
     <section class="span6 condensed">
-      <h1 class="ruled">OPAM and package documentation</h1>
+      <h2 class="ruled">OPAM and package documentation</h2>
       <p>OPAM is the source-based package manager for OCaml.
 	It allows you to install OCaml and packages.
 	See the <a href="install.html">installation
@@ -145,7 +142,7 @@
       </p>
     </section>
     <section class="span6 condensed">
-      <h1 class="ruled"><a href="/learn/books.html">Books</a> and <a href="/docs/papers.html">Papers</a></h1>
+      <h2 class="ruled"><a href="/learn/books.html">Books</a> and <a href="/docs/papers.html">Papers</a></h2>
       <div class="row">
 	<div class="span2 documentation-book">
 	  <a href="https://realworldocaml.org">
@@ -170,11 +167,11 @@
   </div>
   <div class="row">
     <section class="span12 condensed">
-      <h1 class="ruled"><a href="/community/media.html">Videos</a></h1>
+      <h2 class="ruled"><a href="/community/media.html">Videos</a></h2>
       <div class="row">
 	<div class="span4">
 	  <p class="documentation-video">
-	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" frameborder="0" allowfullscreen></iframe>
+	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" allowfullscreen></iframe>
 	  </p>
 	  <p>In this talk, Mark Shinwell explains how to
 	    track down hard-to-find bugs in OCaml programs.
@@ -185,13 +182,13 @@
 	</div>
 	<div class="span4">
 	  <p class="documentation-video">
-	    <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+	    <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" allowfullscreen></iframe>
 	  </p>
 	  <p>Talk at CMU describing the experiences that Jane Street has had using OCaml as its primary development language.</p>
 	</div>
 	<div class="span4">
 	  <p class="documentation-video">
-	    <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+	    <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" allowfullscreen></iframe>
 	  </p>
 	  <p>Experience Report: OCaml for an Industrial-strength Static Analysis Framework
 	    Pascal Cuoq and Julien Signoles; CEA LIST

--- a/template/main.mpp
+++ b/template/main.mpp
@@ -26,7 +26,7 @@
     <link href="/css/bootstrap.css" rel="stylesheet" media="screen" />
     <link href="/css/bootstrap_mod.css" rel="stylesheet" media="screen" />
     <link href="/css/ocamlorg.css" rel="stylesheet" media="screen" />
-    <script src="/js/collapsed-menu.js" type="text/javascript"></script>
+    <script src="/js/collapsed-menu.js"></script>
     {{! ifdef advertise_rss
     <link rel="alternate" type="application/atom+xml" title="Atom feed"
 	  href="/feed.xml" />
@@ -63,7 +63,7 @@
 	       class="edit-this-page pull-right"
 	       ><!-- Image in CSS
 	      --><span>{{!t cmd script/translate ((! get filename !)) "Edit this page" t!}}</span></a>
-	    <script language="JavaScript">
+	    <script>
 	      // Preload the hover image
 	      Image1= new Image(33,33);
 	      Image1.src = '/img/edit-hover.svg';
@@ -96,10 +96,10 @@
     </footer>
     {{!j ifdef extra-js {{!i input ((! get extra-js !)) i!}} j!}}
     <!-- Load javascript from CDN -->
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.1/js/bootstrap.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.1/js/bootstrap.min.js"></script>
 
     {{!S ifndef staging
-    <script type="text/javascript">
+    <script>
 
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', 'UA-37808023-1']);
@@ -107,14 +107,14 @@
     _gaq.push(['_trackPageview']);
 
     (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        var ga = document.createElement('script'); ga.async = true;
         ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
     })();
 
     </script>
     <!-- Piwik -->
-    <script type="text/javascript">
+    <script>
       var _paq = _paq || [];
       _paq.push(['setCookieDomain', '*.ocaml.org']);
       _paq.push(['setDocumentTitle', '((! tryget title !))']);
@@ -129,7 +129,7 @@
         var u=(('https:' == document.location.protocol) ? 'https' : 'http') + '://ocaml.org/piwik/';
         _paq.push(['setTrackerUrl', u+'piwik.php']);
         _paq.push(['setSiteId', '1']);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript';
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.defer=true; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
       })();
     </script>


### PR DESCRIPTION
This PR fixes HTML validation errors emitted when the [documentation page](https://ocaml.org/docs/) is run through the [HTML validator](https://validator.w3.org/).

Running `make` generates the `ocaml.org` directory but doesn't "relativise" the value of `action` attribute of the `form` elements which have been added. Having an `input` element of type `button` nested within an  `a` tag is not valid. As a result, I have modified  such `input`s  to be nested inside `form` elements.   I suspect a script which generates the HTML files from markdown needs to be worked on to fix this. @patricoferris 