### PR TITLE
Fixes contrast of broken news links #1244

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -222,7 +222,6 @@ div.subscribers {
 }
 
 .subscribers .broken {
-  color: #dcc8c4;
   text-decoration: line-through;
 }
 


### PR DESCRIPTION
Updated ocamlog.css  in order to fix the contrast of broken news links. Solves #1244 

Before:
![syndications_before](https://user-images.githubusercontent.com/73695161/110220355-1afaf200-7eeb-11eb-9868-fcf221dc9cf4.png)
After:
![syndications_after](https://user-images.githubusercontent.com/73695161/110220359-23ebc380-7eeb-11eb-8a1c-7d1bca793534.png)

