### PR TITLE
Sorted out the Contributors list alphabetically and Optimize the command to display the same

### DIFF
--- a/site/contributors.fr.md
+++ b/site/contributors.fr.md
@@ -5,7 +5,7 @@ Contributeurs
 
 Les contributeurs à ce site :
 <ul>
-((! cmd git log --format="%aN" | sort -k 2 | uniq | sed -e "/^[^ ]*$/ d" -e "s|\(.*\)|<li>\1</li>|" !))
+((! cmd git log --format="%aN" | sort | uniq | awk '{print "<li>"$1,$2,$3"</li>"} !))
 </ul>
 
 Cette liste est obtenue depuis [le log GIT](https://github.com/ocaml/ocaml.org/commits/master), pensez à vérifier que votre

--- a/site/contributors.fr.md
+++ b/site/contributors.fr.md
@@ -5,7 +5,7 @@ Contributeurs
 
 Les contributeurs à ce site :
 <ul>
-((! cmd git log --format="%aN" | sort | uniq | awk '{print "<li>"$1,$2,$3"</li>"} !))
+((! cmd git log --format="%aN" | sort | uniq | awk '{print "<li>"$1,$2,$3"</li>"}' !))
 </ul>
 
 Cette liste est obtenue depuis [le log GIT](https://github.com/ocaml/ocaml.org/commits/master), pensez à vérifier que votre

--- a/site/contributors.md
+++ b/site/contributors.md
@@ -44,7 +44,7 @@ The contributors to this site, extracted from the
 [Git log](https://github.com/ocaml/ocaml.org/commits/master), are:
 
 <ul>
-((! cmd git log --format="%aN" | sort | uniq | awk '{print "<li>"$1,$2,$3"</li>"} !))
+((! cmd git log --format="%aN" | sort | uniq | awk '{print "<li>"$1,$2,$3"</li>"}' !))
 </ul>
 
 

--- a/site/contributors.md
+++ b/site/contributors.md
@@ -44,7 +44,7 @@ The contributors to this site, extracted from the
 [Git log](https://github.com/ocaml/ocaml.org/commits/master), are:
 
 <ul>
-((! cmd git log --format="%aN" | sort -k 2 | uniq | sed -e "/^[^ ]*$/ d" -e "s|\(.*\)|<li>\1</li>|" !))
+((! cmd git log --format="%aN" | sort | uniq | awk '{print "<li>"$1,$2,$3"</li>"} !))
 </ul>
 
 


### PR DESCRIPTION
## Issues 
1. The ***Contributors List*** is not displaying the names of the contributors in alphabetical order.
2. The ```sort``` command used to sort in ASCII order is not resulting in the expected output.
3.  The ```sed``` command used to print the same is not the flexible one and complicated too.
4. The following is the screenshot of the above discussed points:
![Screenshot from 2021-03-07 10-50-55](https://user-images.githubusercontent.com/65283880/110230893-33dec400-7f3a-11eb-92a1-d0a0b1198baf.png)

5. The overall command is not the optimized one.
*(In Continuation with the issue #1247 )*
## Changes Incorporated
- [x] Made necessary corrections to the ```sort``` command in order to get the desired output.
- [x] Used ```awk``` instead of ```sed``` command to decrease complexity and to achieve optimization.
- [x] Used ```sort -u``` in place of ```sort | uniq``` . Thanks to @pw374 for pointing me about this.

## Resultant Output as expected
![contributors](https://user-images.githubusercontent.com/65283880/110230987-e1ea6e00-7f3a-11eb-9e31-3eb1bfe59bf9.png)

## Additional Changes
- [x] Appropriate changes  made to ***french version*** of the same. 