### PR TITLE
fix: download link missing from the releases page

### DIFF
--- a/site/releases/index.fr.md
+++ b/site/releases/index.fr.md
@@ -10,33 +10,33 @@ instructions pour installer OCaml par d'autres moyens que la
 compilation des sources, comme par exemple le gestionnaire de paquets
 OPAM et les gestionnaire de paquets spécifiques à une plateforme.
 
-* OCaml [4.12.0](4.12.0.html), publiée le 24 février 2021.
-* OCaml [4.11.2](4.11.2.html), publiée le 24 février 2021.
-* OCaml [4.11.1](4.11.1.html), publiée le 31 août 2020.
-* OCaml [4.11.0](4.11.0.html), publiée le 19 août 2020.
-* OCaml [4.10.2](4.10.2.html), publiée le 8 décembre 2020.
-* OCaml [4.10.1](4.10.1.html), publiée le 20 août 2020.
-* OCaml [4.10.0](4.10.0.html), publiée le 20 février 2020.
-* OCaml [4.09.1](4.09.1.html), publiée le 18 mars 2020.
-* OCaml [4.09.0](4.09.0.html), publiée le 18 septembre 2019.
-* OCaml [4.08.1](4.08.1.html), publiée le 5 août 2019.
-* OCaml [4.08.0](4.08.0.html), publiée le 14 juin 2019.
-* OCaml [4.07.1](4.07.1.html), publiée le 4 octobre 2018.
-* OCaml [4.07.0](4.07.0.html), publiée le 10 juillet 2018.
-* OCaml [4.06.1](4.06.1.html), publiée le 16 février 2018.
-* OCaml [4.06.0](4.06.html), publiée le 3 novembre 2017.
-* OCaml [4.05.0](4.05.html), publiée le 13 juillet 2017.
-* OCaml [4.04.2](4.04.html), publiée le 23 juin 2017.
-* OCaml [4.04.1](4.04.html), publiée le 14 avril 2017.
-* OCaml [4.04.0](4.04.html), publiée le 4 novembre 2016.
-* OCaml [4.03.0](4.03.html), publiée le 25 avril 2016.
-* OCaml [4.02.3](4.02.html), publiée le 27 juillet 2015.
-* OCaml [4.02.2](4.02.html), publiée le 17 juin 2015.
-* OCaml [4.02.1](4.02.html), publiée le 29 octobre 2014.
-* OCaml [4.02.0](4.02.html), publiée le 29 août 2014.
-* OCaml [4.01.0](4.01.0.html), publiée le 12 septembre 2013.
-* OCaml [4.00.1](4.00.1.html), publiée le 5 octobre 2012.
-* OCaml [3.12.1](3.12.1.html), publiée le 4 juillet 2011.
+* OCaml [4.12.0](4.12.0.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.12.0.tar.gz), publiée le 24 février 2021.
+* OCaml [4.11.2](4.11.2.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.11.2.tar.gz), publiée le 24 février 2021.
+* OCaml [4.11.1](4.11.1.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.11.1.tar.gz), publiée le 31 août 2020.
+* OCaml [4.11.0](4.11.0.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.11.0.tar.gz), publiée le 19 août 2020.
+* OCaml [4.10.2](4.10.2.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz), publiée le 8 décembre 2020.
+* OCaml [4.10.1](4.10.1.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.10.1.tar.gz), publiée le 20 août 2020.
+* OCaml [4.10.0](4.10.0.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.10.0.tar.gz), publiée le 20 février 2020.
+* OCaml [4.09.1](4.09.1.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.09.1.tar.gz), publiée le 18 mars 2020.
+* OCaml [4.09.0](4.09.0.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.09.0.tar.gz), publiée le 18 septembre 2019.
+* OCaml [4.08.1](4.08.1.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.08.1.tar.gz), publiée le 5 août 2019.
+* OCaml [4.08.0](4.08.0.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz), publiée le 14 juin 2019.
+* OCaml [4.07.1](4.07.1.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz), publiée le 4 octobre 2018.
+* OCaml [4.07.0](4.07.0.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz), publiée le 10 juillet 2018.
+* OCaml [4.06.1](4.06.1.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz), publiée le 16 février 2018.
+* OCaml [4.06.0](4.06.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz), publiée le 3 novembre 2017.
+* OCaml [4.05.0](4.05.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz), publiée le 13 juillet 2017.
+* OCaml [4.04.2](4.04.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.04.2.tar.gz), publiée le 23 juin 2017.
+* OCaml [4.04.1](4.04.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz), publiée le 14 avril 2017.
+* OCaml [4.04.0](4.04.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz), publiée le 4 novembre 2016.
+* OCaml [4.03.0](4.03.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz), publiée le 25 avril 2016.
+* OCaml [4.02.3](4.02.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.02.3.tar.gz), publiée le 27 juillet 2015.
+* OCaml [4.02.2](4.02.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.02.2.tar.gz), publiée le 17 juin 2015.
+* OCaml [4.02.1](4.02.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.02.1.tar.gz), publiée le 29 octobre 2014.
+* OCaml [4.02.0](4.02.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.02.0.tar.gz), publiée le 29 août 2014.
+* OCaml [4.01.0](4.01.0.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.01.0.tar.gz), publiée le 12 septembre 2013.
+* OCaml [4.00.1](4.00.1.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.00.1.tar.gz), publiée le 5 octobre 2012.
+* OCaml [3.12.1](3.12.1.html), [téléchargé](https://github.com/ocaml/ocaml/archive/3.12.1.tar.gz), publiée le 4 juillet 2011.
 * Les versions plus anciennes sont disponibles 
   [ici](http://caml.inria.fr/pub/distrib/).
 

--- a/site/releases/index.md
+++ b/site/releases/index.md
@@ -9,34 +9,34 @@ See also the [install](/docs/install.html) page for instructions on
 installing OCaml by other means, such as the OPAM package manager and
 platform specific package managers.
 
-* OCaml [4.12.0](4.12.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0.tar.gz), released Feb 24, 2021.
-* OCaml [4.11.2](4.11.2.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.11/ocaml-4.11.2.tar.gz), released Feb 24, 2021.
-* OCaml [4.11.1](4.11.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.11/ocaml-4.11.1.tar.gz), released Aug 31, 2020.
-* OCaml [4.11.0](4.11.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.11/ocaml-4.11.0.tar.gz), released Aug 19, 2020.
-* OCaml [4.10.2](4.10.2.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.2.tar.gz), released Dec 8, 2020.
-* OCaml [4.10.1](4.10.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.1.tar.gz), released Aug 20, 2020.
-* OCaml [4.10.0](4.10.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.0.tar.gz), released Feb 21, 2020.
-* OCaml [4.09.1](4.09.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.09/ocaml-4.09.1.tar.gz), released Mar 18, 2020.
-* OCaml [4.09.0](4.09.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.09/ocaml-4.09.0.tar.gz), released Sep 18, 2019.
-* OCaml [4.08.1](4.08.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.08/ocaml-4.08.1.tar.gz), released Aug 5, 2019.
-* OCaml [4.08.0](4.08.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.08/ocaml-4.08.0.tar.gz), released Jun 14, 2019.
-* OCaml [4.07.1](4.07.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.gz), released Oct 4, 2018.
-* OCaml [4.07.0](4.07.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.0.tar.gz), released Jul 10, 2018.
-* OCaml [4.06.1](4.06.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.1.tar.gz), released Feb 16, 2018.
-* OCaml [4.06.0](4.06.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.gz), released Nov 3, 2017.
-* OCaml [4.05.0](4.05.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.05/ocaml-4.05.0.tar.gz), released July 13, 2017.
-* OCaml [4.04.2](4.04.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.04/ocaml-4.04.2.tar.gz), released Jun 23, 2017.
-* OCaml [4.04.1](4.04.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.04/ocaml-4.04.1.tar.gz), released Apr 14, 2017.
-* OCaml [4.04.0](4.04.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.04/ocaml-4.04.0.tar.gz), released Nov 4, 2016.
-* OCaml [4.03.0](4.03.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.03/ocaml-4.03.0.tar.gz), released Apr 25, 2016.
-* OCaml [4.02.3](4.02.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz), released Jul 27, 2015.
-* OCaml [4.02.2](4.02.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.2.tar.gz), released Jun 17, 2015.
-* OCaml [4.02.1](4.02.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz), released Oct 14, 2014.
-* OCaml [4.02.0](4.02.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz), released Aug 29, 2014.  
+* OCaml [4.12.0](4.12.0.html), [Download](https://github.com/ocaml/ocaml/archive/4.12.0.tar.gz), released Feb 24, 2021.
+* OCaml [4.11.2](4.11.2.html), [Download](https://github.com/ocaml/ocaml/archive/4.11.2.tar.gz), released Feb 24, 2021.
+* OCaml [4.11.1](4.11.1.html), [Download](https://github.com/ocaml/ocaml/archive/4.11.1.tar.gz), released Aug 31, 2020.
+* OCaml [4.11.0](4.11.0.html), [Download](https://github.com/ocaml/ocaml/archive/4.11.0.tar.gz), released Aug 19, 2020.
+* OCaml [4.10.2](4.10.2.html), [Download](https://github.com/ocaml/ocaml/archive/4.10.2.tar.gz), released Dec 8, 2020.
+* OCaml [4.10.1](4.10.1.html), [Download](https://github.com/ocaml/ocaml/archive/4.10.1.tar.gz), released Aug 20, 2020.
+* OCaml [4.10.0](4.10.0.html), [Download](https://github.com/ocaml/ocaml/archive/4.10.0.tar.gz), released Feb 21, 2020.
+* OCaml [4.09.1](4.09.1.html), [Download](https://github.com/ocaml/ocaml/archive/4.09.1.tar.gz), released Mar 18, 2020.
+* OCaml [4.09.0](4.09.0.html), [Download](https://github.com/ocaml/ocaml/archive/4.09.0.tar.gz), released Sep 18, 2019.
+* OCaml [4.08.1](4.08.1.html), [Download](https://github.com/ocaml/ocaml/archive/4.08.1.tar.gz), released Aug 5, 2019.
+* OCaml [4.08.0](4.08.0.html), [Download](https://github.com/ocaml/ocaml/archive/4.08.0.tar.gz), released Jun 14, 2019.
+* OCaml [4.07.1](4.07.1.html), [Download](https://github.com/ocaml/ocaml/archive/4.07.1.tar.gz), released Oct 4, 2018.
+* OCaml [4.07.0](4.07.0.html), [Download](https://github.com/ocaml/ocaml/archive/4.07.0.tar.gz), released Jul 10, 2018.
+* OCaml [4.06.1](4.06.1.html), [Download](https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz), released Feb 16, 2018.
+* OCaml [4.06.0](4.06.html), [Download](https://github.com/ocaml/ocaml/archive/4.06.0.tar.gz), released Nov 3, 2017.
+* OCaml [4.05.0](4.05.html), [Download](https://github.com/ocaml/ocaml/archive/4.05.0.tar.gz), released July 13, 2017.
+* OCaml [4.04.2](4.04.html), [Download](https://github.com/ocaml/ocaml/archive/4.04.2.tar.gz), released Jun 23, 2017.
+* OCaml [4.04.1](4.04.html), [Download](https://github.com/ocaml/ocaml/archive/4.04.1.tar.gz), released Apr 14, 2017.
+* OCaml [4.04.0](4.04.html), [Download](https://github.com/ocaml/ocaml/archive/4.04.0.tar.gz), released Nov 4, 2016.
+* OCaml [4.03.0](4.03.html), [Download](https://github.com/ocaml/ocaml/archive/4.03.0.tar.gz), released Apr 25, 2016.
+* OCaml [4.02.3](4.02.html), [Download](https://github.com/ocaml/ocaml/archive/4.02.3.tar.gz), released Jul 27, 2015.
+* OCaml [4.02.2](4.02.html), [Download](https://github.com/ocaml/ocaml/archive/4.02.2.tar.gz), released Jun 17, 2015.
+* OCaml [4.02.1](4.02.html), [Download](https://github.com/ocaml/ocaml/archive/4.02.1.tar.gz), released Oct 14, 2014.
+* OCaml [4.02.0](4.02.html), [Download](https://github.com/ocaml/ocaml/archive/4.02.0.tar.gz), released Aug 29, 2014.  
       (4.02.0 suffers from one known bug that noticeably increases compilation time, you should use 4.02.1 or later versions instead.)
-* OCaml [4.01.0](4.01.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz), released Sep 12, 2013.
-* OCaml [4.00.1](4.00.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz), released Oct 5, 2012.
-* OCaml [3.12.1](3.12.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz), released July 4, 2011.
+* OCaml [4.01.0](4.01.0.html), [Download](https://github.com/ocaml/ocaml/archive/4.01.0.tar.gz), released Sep 12, 2013.
+* OCaml [4.00.1](4.00.1.html), [Download](https://github.com/ocaml/ocaml/archive/4.00.1.tar.gz), released Oct 5, 2012.
+* OCaml [3.12.1](3.12.1.html), [Download](https://github.com/ocaml/ocaml/archive/3.12.1.tar.gz), released July 4, 2011.
 * Earlier releases are available
   [here](http://caml.inria.fr/pub/distrib/).
 

--- a/site/releases/index.md
+++ b/site/releases/index.md
@@ -9,34 +9,34 @@ See also the [install](/docs/install.html) page for instructions on
 installing OCaml by other means, such as the OPAM package manager and
 platform specific package managers.
 
-* OCaml [4.12.0](4.12.0.html), released Feb 24, 2021.
-* OCaml [4.11.2](4.11.2.html), released Feb 24, 2021.
-* OCaml [4.11.1](4.11.1.html), released Aug 31, 2020.
-* OCaml [4.11.0](4.11.0.html), released Aug 19, 2020.
-* OCaml [4.10.2](4.10.2.html), released Dec 8, 2020.
-* OCaml [4.10.1](4.10.1.html), released Aug 20, 2020.
-* OCaml [4.10.0](4.10.0.html), released Feb 21, 2020.
-* OCaml [4.09.1](4.09.1.html), released Mar 18, 2020.
-* OCaml [4.09.0](4.09.0.html), released Sep 18, 2019.
-* OCaml [4.08.1](4.08.1.html), released Aug 5, 2019.
-* OCaml [4.08.0](4.08.0.html), released Jun 14, 2019.
-* OCaml [4.07.1](4.07.1.html), released Oct 4, 2018.
-* OCaml [4.07.0](4.07.0.html), released Jul 10, 2018.
-* OCaml [4.06.1](4.06.1.html), released Feb 16, 2018.
-* OCaml [4.06.0](4.06.html), released Nov 3, 2017.
-* OCaml [4.05.0](4.05.html), released July 13, 2017.
-* OCaml [4.04.2](4.04.html), released Jun 23, 2017.
-* OCaml [4.04.1](4.04.html), released Apr 14, 2017.
-* OCaml [4.04.0](4.04.html), released Nov 4, 2016.
-* OCaml [4.03.0](4.03.html), released Apr 25, 2016.
-* OCaml [4.02.3](4.02.html), released Jul 27, 2015.
-* OCaml [4.02.2](4.02.html), released Jun 17, 2015.
-* OCaml [4.02.1](4.02.html), released Oct 14, 2014.
-* OCaml [4.02.0](4.02.html), released Aug 29, 2014.  
+* OCaml [4.12.0](4.12.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.12/ocaml-4.12.0.tar.gz), released Feb 24, 2021.
+* OCaml [4.11.2](4.11.2.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.11/ocaml-4.11.2.tar.gz), released Feb 24, 2021.
+* OCaml [4.11.1](4.11.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.11/ocaml-4.11.1.tar.gz), released Aug 31, 2020.
+* OCaml [4.11.0](4.11.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.11/ocaml-4.11.0.tar.gz), released Aug 19, 2020.
+* OCaml [4.10.2](4.10.2.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.2.tar.gz), released Dec 8, 2020.
+* OCaml [4.10.1](4.10.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.1.tar.gz), released Aug 20, 2020.
+* OCaml [4.10.0](4.10.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.10/ocaml-4.10.0.tar.gz), released Feb 21, 2020.
+* OCaml [4.09.1](4.09.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.09/ocaml-4.09.1.tar.gz), released Mar 18, 2020.
+* OCaml [4.09.0](4.09.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.09/ocaml-4.09.0.tar.gz), released Sep 18, 2019.
+* OCaml [4.08.1](4.08.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.08/ocaml-4.08.1.tar.gz), released Aug 5, 2019.
+* OCaml [4.08.0](4.08.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.08/ocaml-4.08.0.tar.gz), released Jun 14, 2019.
+* OCaml [4.07.1](4.07.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.1.tar.gz), released Oct 4, 2018.
+* OCaml [4.07.0](4.07.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.07/ocaml-4.07.0.tar.gz), released Jul 10, 2018.
+* OCaml [4.06.1](4.06.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.1.tar.gz), released Feb 16, 2018.
+* OCaml [4.06.0](4.06.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.gz), released Nov 3, 2017.
+* OCaml [4.05.0](4.05.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.05/ocaml-4.05.0.tar.gz), released July 13, 2017.
+* OCaml [4.04.2](4.04.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.04/ocaml-4.04.2.tar.gz), released Jun 23, 2017.
+* OCaml [4.04.1](4.04.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.04/ocaml-4.04.1.tar.gz), released Apr 14, 2017.
+* OCaml [4.04.0](4.04.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.04/ocaml-4.04.0.tar.gz), released Nov 4, 2016.
+* OCaml [4.03.0](4.03.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.03/ocaml-4.03.0.tar.gz), released Apr 25, 2016.
+* OCaml [4.02.3](4.02.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.3.tar.gz), released Jul 27, 2015.
+* OCaml [4.02.2](4.02.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.2.tar.gz), released Jun 17, 2015.
+* OCaml [4.02.1](4.02.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.1.tar.gz), released Oct 14, 2014.
+* OCaml [4.02.0](4.02.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.02/ocaml-4.02.0.tar.gz), released Aug 29, 2014.  
       (4.02.0 suffers from one known bug that noticeably increases compilation time, you should use 4.02.1 or later versions instead.)
-* OCaml [4.01.0](4.01.0.html), released Sep 12, 2013.
-* OCaml [4.00.1](4.00.1.html), released Oct 5, 2012.
-* OCaml [3.12.1](3.12.1.html), released July 4, 2011.
+* OCaml [4.01.0](4.01.0.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz), released Sep 12, 2013.
+* OCaml [4.00.1](4.00.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-4.00/ocaml-4.00.1.tar.gz), released Oct 5, 2012.
+* OCaml [3.12.1](3.12.1.html), [Download](http://caml.inria.fr/pub/distrib/ocaml-3.12/ocaml-3.12.1.tar.gz), released July 4, 2011.
 * Earlier releases are available
   [here](http://caml.inria.fr/pub/distrib/).
 


### PR DESCRIPTION
fixes #https://github.com/ocaml/ocaml.org/issues/1215

- I have added a download link for each of the releases as requested.