### PR TITLE
Bringing tutorials up to date - round one

### DIFF
--- a/site/learn/tutorials/basics.md
+++ b/site/learn/tutorials/basics.md
@@ -378,7 +378,7 @@ int_of_char : char -> int
 ```
 If a function returns nothing (`void` for C and Java programmers), then
 we write that it returns the `unit` type. Here, for instance, is the
-OCaml equivalent of C's `fputc`:
+OCaml equivalent of C's _[fputc(3)](https://pubs.opengroup.org/onlinepubs/009695399/functions/fputc.html)_:
 
 ```ocaml
 output_char : out_channel -> char -> unit

--- a/site/learn/tutorials/basics.md
+++ b/site/learn/tutorials/basics.md
@@ -239,8 +239,7 @@ floating point numbers.
 
 OCaml provides a `char` type which is used for characters, written `'x'`
 for example. Unfortunately the `char` type does not support Unicode or
-UTF-8, There are [comprehensive Unicode
-libraries](https://github.com/yoriyuki/Camomile "https://github.com/yoriyuki/Camomile")
+UTF-8, There are [comprehensive Unicode libraries](https://github.com/yoriyuki/Camomile)
 which provide this functionality.
 
 Strings are not just lists of characters. They have their own, more

--- a/site/learn/tutorials/basics.md
+++ b/site/learn/tutorials/basics.md
@@ -14,28 +14,28 @@ To install OCaml on your computer, see the [Install](/docs/install.html) documen
 To quickly try small OCaml expressions, you can use an interactive
 toplevel, or REPL (Read–Eval–Print Loop). The `ocaml` command provides
 a very basic toplevel (you should install `rlwrap` through your system
-package manager and run `rlwrap ocaml` to get history navigation). If
-you can install it through [OPAM](/docs/install.html#OPAM) or your
-system package manager, we recommend the use of
-the [utop](https://github.com/diml/utop) toplevel instead, which has
-the same basic interface but is much more convenient to use (history
-navigation, auto-completion, etc.).
+package manager and run `rlwrap ocaml` to get history navigation).
 
-Use `;;` to indicate that you've finished entering each statement. Here is what is looks like running `ocaml`:
+The recommended alternative REPL [utop](https://github.com/diml/utop) may be
+installed through [OPAM](/docs/install.html#OPAM) or your system package
+manager. It has the same basic interface but is much more convenient to use
+(history navigation, auto-completion, etc.).
+
+Use `;;` to indicate that you've finished entering each expression and prompt OCaml to evaluate it. Here is what running `ocaml` looks like:
 ```console
 $ ocaml
         OCaml version {{! get LATEST_OCAML_VERSION !}}
 
-# 1+1;;
+# 1 + 1;;
 - : int = 2
 ```
 
-This is how running the same code looks like when using `utop`:
+This is how running the same code looks when using `utop`:
 
 ```console
-───────┬────────────────────────────────────────────────────────────┬─────
-       │ Welcome to utop version 1.18 (using OCaml version 4.02.3)! │     
-       └────────────────────────────────────────────────────────────┘     
+───────┬─────────────────────────────────────────────────────────────┬────
+       │ Welcome to utop version 2.7.0 (using OCaml version 4.12.0)! │     
+       └─────────────────────────────────────────────────────────────┘     
 
 Type #utop_help for help about using utop.
 
@@ -44,20 +44,6 @@ utop # 1 + 1;;
 - : int = 2
 ```
 
-To compile an OCaml program named `my_prog.ml` to a native executable, use `ocamlbuild my_prog.native`:
-
-```shell
-$ mkdir my_project
-$ cd my_project
-$ echo 'let () = print_endline "Hello, World!"' > my_prog.ml
-$ ocamlbuild my_prog.native
-Finished, 4 targets (0 cached) in 00:00:00.
-$ ./my_prog.native
-Hello, World!
-```
-
-See [Compiling OCaml projects](compiling_ocaml_projects.html) for more information.
-
 ## Comments
 OCaml comments are delimited by `(*` and `*)`, like this:
 
@@ -65,13 +51,13 @@ OCaml comments are delimited by `(*` and `*)`, like this:
 (* This is a single-line comment. *)
 
 (* This is a
- * multi-line
- * comment.
- *)
+   multi-line
+   comment.
+*)
 ```
 In other words, the commenting convention is very similar to original C
-(`/* ... */`). There is currently no single-line comment syntax (like
-`# ...` in Perl or `// ...` in C99/C++/Java).
+(`/* ... */`). There is no single-line comment syntax (like
+`# ...` in Perl/Python or `// ...` in C99/C++/Java).
 
 OCaml counts nested `(* ... *)` blocks, and this allows you to comment
 out regions of code very easily:
@@ -145,7 +131,7 @@ f (g 3 4)            (* f has one argument, g has two arguments *)
 <div media:type="text/omd" style="display: none">
 
 ```ocamltop
-let repeated (s: string) (i: int) =
+let repeated (s : string) (i : int) =
   failwith "implementation not given"
 ```
 
@@ -156,7 +142,7 @@ repeated ("hello", 3)     (* OCaml will spot the mistake *)
 ```
 
 ## Defining a function
-We all know how to define a function (or static method, for Java-heads)
+We all know how to define a function (or static method, in Java)
 in our existing languages. How do we do it in OCaml?
 
 The OCaml syntax is pleasantly concise. Here's a function which takes
@@ -164,7 +150,7 @@ two floating point numbers and calculates the average:
 
 ```ocaml
 let average a b =
-  (a +. b) /. 2.0;;
+  (a +. b) /. 2.0
 ```
 Type this into the OCaml interactive toplevel (on Unix, type the command `ocaml`
 from the shell) and you'll see this:
@@ -176,8 +162,8 @@ let average a b =
 If you look at the function definition closely, and also at what OCaml
 prints back at you, you'll have a number of questions:
 
-* What're all those extra periods doing there in the code?
-* What does all that stuff about `float -> float -> float` mean?
+* What are those periods in `+.` and `/.` for?
+* What does `float -> float -> float` mean?
 
 I'll answer those questions in the next sections, but first I want to go
 and define the same function in C (the Java definition would be fairly
@@ -232,7 +218,7 @@ OCaml type  Range
 int         31-bit signed int (roughly +/- 1 billion) on 32-bit
             processors, or 63-bit signed int on 64-bit processors
 float       IEEE double-precision floating point, equivalent to C's double
-bool        A boolean, written either true or false
+bool        A boolean, written either 'true' or 'false'
 char        An 8-bit character
 string      A string
 unit        Written as ()
@@ -243,27 +229,23 @@ automatically manage the memory use (garbage collection). This is why
 the basic `int` is 31 bits, not 32 bits (63 bits if you're using a 64
 bit platform). In practice this isn't an issue except in a few
 specialised cases. For example if you're counting things in a loop, then
-OCaml limits you to counting up to 1 billion instead of 2 billion. This
-isn't going to be a problem because if you're counting things close to
-this limit in any language, then you ought to be using bignums (the
-`Nat` and `Big_int` modules in OCaml). However if you need to do things
+OCaml limits you to counting up to 1 billion instead of 2 billion. However if you need to do things
 such as processing 32 bit types (eg. you're writing crypto code or a
 network stack), OCaml provides a `nativeint` type which matches the
 native integer type for your platform.
 
 OCaml doesn't have a basic unsigned integer type, but you can get the
-same effect using `nativeint`. OCaml doesn't have builtin single-precision 
+same effect using `nativeint`. OCaml doesn't have built-in single-precision 
 floating point numbers.
 
 OCaml provides a `char` type which is used for characters, written `'x'`
 for example. Unfortunately the `char` type does not support Unicode or
-UTF-8. This is a serious flaw in OCaml which should be fixed, but for
-the time being there are [comprehensive Unicode
-libraries](http://camomile.sourceforge.net/ "http://camomile.sourceforge.net/")
-which work around it.
+UTF-8, There are [comprehensive Unicode
+libraries](https://github.com/yoriyuki/Camomile "https://github.com/yoriyuki/Camomile")
+which provide this functionality.
 
 Strings are not just lists of characters. They have their own, more
-efficient internal representation.
+efficient internal representation. Strings are immutable.
 
 The `unit` type is sort of like `void` in C, but we'll talk about it
 more below.
@@ -282,9 +264,6 @@ here we're giving it an int and a float, so it reports this error:
 ```ocamltop
 1 + 2.5;;
 ```
-(In the "translated from the French" language of OCaml error messages
-this means "you put a float here, but I was expecting an int").
-
 To add two floats together you need to use a different operator, `+.`
 (note the trailing period).
 
@@ -301,7 +280,7 @@ together? (Say they are stored as `i` and `f`). In OCaml you need to
 explicitly cast:
 
 ```ocaml
-(float_of_int i) +. f
+float_of_int i +. f
 ```
 `float_of_int` is a function which takes an `int` and returns a `float`.
 There are a whole load of these functions, called such things as
@@ -315,7 +294,7 @@ example could simply have been written
 ```ocaml
 float i +. f
 ```
-(Note that unlike C, it is perfectly valid in OCaml for a type and a
+(Note that it is perfectly valid in OCaml for a type and a
 function to have the same name.)
 
 ###  Is implicit or explicit casting better?
@@ -340,7 +319,7 @@ example of a recursive function:
 ```ocamltop
 let rec range a b =
   if a > b then []
-  else a :: range (a+1) b
+  else a :: range (a + 1) b
 ```
 Notice that `range` calls itself.
 
@@ -355,7 +334,7 @@ to re-define a value in terms of the previous definition. For example:
 let positive_sum a b = 
   let a = max a 0
   and b = max b 0 in
-  a + b
+    a + b
 ```
 This redefinition hides the previous "bindings" of `a` and `b` from the
 function definition. In some situations coders prefer this pattern to
@@ -400,7 +379,7 @@ int_of_char : char -> int
 ```
 If a function returns nothing (`void` for C and Java programmers), then
 we write that it returns the `unit` type. Here, for instance, is the
-OCaml equivalent of `fputc`:
+OCaml equivalent of C's `fputc`:
 
 ```ocaml
 output_char : out_channel -> char -> unit
@@ -421,13 +400,13 @@ a letter. The type of the above function would normally be written:
 ```ocaml
 give_me_a_three : 'a -> int
 ```
-where `'a` really does mean any type. You can, for example, call this
+where `'a` (pronounced alpha) really does mean any type. You can, for example, call this
 function as `give_me_a_three "foo"` or `give_me_a_three 2.0` and both
 are quite valid expressions in OCaml.
 
 It won't be clear yet why polymorphic functions are useful, but they are
 very useful and very common, and so we'll discuss them later on. (Hint:
-polymorphism is kind of like templates in C++ or generics in Java 1.5).
+polymorphism is kind of like templates in C++ or generics in Java).
 
 ## Type inference
 So the theme of this tutorial is that functional languages have many
@@ -458,8 +437,8 @@ interactive toplevel:
 let average a b =
   (a +. b) /. 2.0
 ```
-[Mirabile dictu!](http://en.wiktionary.org/wiki/mirabile_dictu) OCaml worked out all on its own that the function takes
-two `float` arguments and returns a `float`.
+OCaml worked out all on its own that the function takes
+two `float` arguments and returns a `float`!
 
 How did it do this? Firstly it looks at where `a` and `b` are used,
 namely in the expression `(a +. b)`. Now, `+.` is itself a function

--- a/site/learn/tutorials/basics.md
+++ b/site/learn/tutorials/basics.md
@@ -57,7 +57,7 @@ OCaml comments are delimited by `(*` and `*)`, like this:
 ```
 In other words, the commenting convention is very similar to original C
 (`/* ... */`). There is no single-line comment syntax (like
-`# ...` in Perl/Python or `// ...` in C99/C++/Java).
+`# ...` in Python or `// ...` in C99/C++/Java).
 
 OCaml counts nested `(* ... *)` blocks, and this allows you to comment
 out regions of code very easily:
@@ -190,8 +190,7 @@ asking:
 OK, let's get some answers.
 
 * OCaml is a strongly *statically typed* language (in other words,
- there's nothing dynamic going on between int, float and string, as
- in Perl).
+ there's nothing dynamic going on between int, float and string).
 * OCaml uses *type inference* to work out the types, so you don't have
  to.  If you use the OCaml interactive toplevel as above, then OCaml
  will tell you
@@ -456,7 +455,7 @@ Type inference is obviously easy for such a short program, but it works
 even for large programs, and it's a major time-saving feature because it
 removes a whole class of errors which cause segfaults,
 `NullPointerException`s and `ClassCastException`s in other languages (or
-important but often ignored runtime warnings, as in Perl).
+important but often ignored runtime warnings).
 
 
 [utop]: https://github.com/diml/utop

--- a/site/learn/tutorials/modules.md
+++ b/site/learn/tutorials/modules.md
@@ -106,7 +106,7 @@ interface. This is our `amodule.mli` file:
 val hello : unit -> unit
 (** Displays a greeting message. *)
 ```
-(note the double asterisk at the beginning of the commont - it is a good habit to document .mli files using the format
+(note the double asterisk at the beginning of the comment - it is a good habit to document .mli files using the format
 supported by
 [ocamldoc](/releases/{{! get LATEST_OCAML_VERSION_MAIN !}}/htmlman/ocamldoc.html))
 

--- a/site/learn/tutorials/modules.md
+++ b/site/learn/tutorials/modules.md
@@ -7,7 +7,7 @@
 ## Basic usage
 In OCaml, every piece of code is wrapped into a module. Optionally, a
 module itself can be a submodule of another module, pretty much like
-directories in a file system-but we don't do this very often.
+directories in a file system - but we don't do this very often.
 
 When you write a program let's say using two files `amodule.ml` and
 `bmodule.ml`, each of these files automatically defines a module named
@@ -39,7 +39,7 @@ else that a given module can provide.
 
 Libraries, starting with the standard library, provide collections of
 modules. for example,
-[`List.iter`](https://github.com/ocaml/ocaml/blob/trunk/stdlib/list.mli#L75)
+`List.iter`
 designates the `iter` function from
 the `List` module.
 
@@ -48,22 +48,16 @@ contents directly accessible. For this, we use the `open` directive. In
 our example, `bmodule.ml` could have been written:
 
 ```ocaml
-open Amodule;;
-hello ();;
-```
-As a side note, people tend to avoid the ugly ";;", so it more common to
-write it like:
-
-```ocaml
 open Amodule
-let () =
-  hello ()
+
+let () = hello ()
 ```
-Anyway, using `open` or not is a matter of personal taste. Some modules
+
+Using `open` or not is a matter of personal taste. Some modules
 provide names that are used in many other modules. This is the case of
 the `List` module for instance. Usually we don't do `open List`. Other
 modules like
-[`Printf`](https://github.com/ocaml/ocaml/blob/trunk/stdlib/printf.mli#L14)
+`Printf`
 provide names that are normally not subject to
 conflicts, such as `printf`. In order to avoid writing `Printf.printf`
 all over the place, it often makes sense to place one `open Printf` at
@@ -75,8 +69,8 @@ mentioned:
 
 ```ocamltop
 open Printf
-let my_data = [ "a"; "beautiful"; "day" ]
-let () = List.iter (fun s -> printf "%s\n" s) my_data
+let my_data = ["a"; "beautiful"; "day"]
+let () = List.iter (printf "%s\n") my_data
 ```
 
 ## Interfaces and signatures
@@ -112,7 +106,7 @@ interface. This is our `amodule.mli` file:
 val hello : unit -> unit
 (** Displays a greeting message. *)
 ```
-(note that it is a good habit to document .mli files, using the format
+(note the double asterisk at the beginning of the commont - it is a good habit to document .mli files using the format
 supported by
 [ocamldoc](/releases/{{! get LATEST_OCAML_VERSION_MAIN !}}/htmlman/ocamldoc.html))
 
@@ -136,7 +130,7 @@ But modules often define new types. Let's define a simple record type
 that would represent a date:
 
 ```ocaml
-type date = { day : int;  month : int;  year : int }
+type date = {day : int; month : int; year : int}
 ```
 
 There are not two, but four options when it comes to writing the .mli
@@ -191,7 +185,9 @@ module Hello = struct
   let message = "Hello"
   let hello () = print_endline message
 end
+
 let goodbye () = print_endline "Goodbye"
+
 let hello_goodbye () =
   Hello.hello ();
   goodbye ()
@@ -279,10 +275,11 @@ the programmer makes a mistake.
 For example, if we want to use sets of ints, we would do this:
 
 ```ocamltop
-module Int_set = Set.Make (struct
-                             type t = int
-                             let compare = compare
-                           end)
+module Int_set =
+  Set.Make (struct
+              type t = int
+              let compare = compare
+            end)
 ```
 For sets of strings, it is even easier because the standard library
 provides a `String` module with a type `t` and a function `compare`. If

--- a/site/learn/tutorials/structure_of_ocaml_programs.md
+++ b/site/learn/tutorials/structure_of_ocaml_programs.md
@@ -235,7 +235,7 @@ If we want to use the functions in `Graphics` there are two ways we can
 do it. Either at the start of our program we have the `open Graphics;;`
 declaration. Or we prefix all calls to the functions like this:
 `Graphics.open_graph`. `open` is a little bit like Java's `import`
-statement, and much more like Perl's `use` statement.
+statement.
 
 To use `Graphics` in the [interactive toplevel](basics.html), you must
 first load the
@@ -379,12 +379,12 @@ code, how they used local and global named expressions.
 
 * `?foo` and `~foo` is OCaml's way of doing optional and named
  arguments to functions. There is no real parallel to this in
- C-derived languages, but Perl, Python and Smalltalk all have this
+ C-derived languages, but Python and Smalltalk all have this
  concept that you can name the arguments in a function call, omit
  some of them, and supply the others in any order you like.
 * `foo#bar` is a method invocation (calling a method called `bar` on
- an object called `foo`). It's similar to `foo->bar` or `foo.bar` or
- `$foo->bar` in C++, Java or Perl respectively.
+ an object called `foo`). It's similar to `foo->bar` or `foo.bar` in
+ C++ or Java respectively.
 
 First snippet: The programmer opens a couple of standard libraries.
 They then create a function called `file_dialog`. Inside

--- a/site/learn/tutorials/structure_of_ocaml_programs.md
+++ b/site/learn/tutorials/structure_of_ocaml_programs.md
@@ -279,7 +279,7 @@ Graphics.open_graph " 640x480"
 let rec iterate r x_init i =
   if i = 1 then x_init else
     let x = iterate r x_init (i - 1) in
-      r *. x *. (1.0 -. x);;
+      r *. x *. (1.0 -. x)
 
 for x = 0 to 639 do
   let r = 4.0 *. (float_of_int x) /. 640.0 in

--- a/site/learn/tutorials/structure_of_ocaml_programs.md
+++ b/site/learn/tutorials/structure_of_ocaml_programs.md
@@ -6,7 +6,7 @@
 
 Now we're going to take some time out to take a high-level look at some
 real OCaml programs. I want to teach you about local and global
-definitions, when to use `;;` vs. `;`, modules, nested functions, and
+definitions, modules, nested functions, and
 references. For this we're going to look at a lot of OCaml concepts
 which won't yet make sense because we haven't seen them before. Don't
 worry about the details for the moment. Concentrate instead on the
@@ -28,13 +28,11 @@ Now let's do the same to our OCaml version:
 ```ocamltop
 let average a b =
   let sum = a +. b in
-  sum /. 2.0;;
+    sum /. 2.0;;
 ```
 The standard phrase `let name = expression in` is used to define a named
 local expression, and `name` can then be used later on in the function
-instead of `expression`, till a `;;` which ends the block of code.
-Notice that we don't indent after the `in`. Just think of `let ... in`
-as if it were a statement.
+instead of `expression`.
 
 Now comparing C local variables and these named local expressions is a
 sleight of hand. In fact they are somewhat different. The C variable
@@ -46,18 +44,18 @@ assign to `sum` or change its value in any way. (We'll see how you can
 do variables whose value changes in a minute).
 
 Here's another example to make this clearer. The following two code
-snippets should return the same value (namely (a+b) +
-(a+b)²):
+snippets should return the same value (namely (a + b) +
+(a + b)²):
 
 ```ocamltop
 let f a b =
-  (a +. b) +. (a +. b) ** 2.
-  ;;
+  (a +. b) +. (a +. b) ** 2.;;
+```
 
+```ocamltop
 let f a b =
   let x = a +. b in
-  x +. x ** 2.
-  ;;
+  x +. x ** 2.;;
 ```
 
 The second version might be faster (but most compilers ought to be able
@@ -74,18 +72,15 @@ just shorthand names for things. Here's a real (but cut-down) example:
 let html =
   let content = read_whole_file file in
   GHtml.html_from_string content
-  ;;
 
 let menu_bold () =
   match bold_button#active with
   | true -> html#set_font_style ~enable:[`BOLD] ()
   | false -> html#set_font_style ~disable:[`BOLD] ()
-  ;;
 
 let main () =
   (* code omitted *)
   factory#add_item "Cut" ~key:_X ~callback: html#cut
-  ;;
 ```
 
 In this real piece of code, `html` is an HTML editing widget (an object
@@ -108,8 +103,7 @@ function, is often called a **let-binding**.
 What happens if you want a real variable that you can assign to and
 change throughout your program? You need to use a **reference**.
 References are very similar to pointers in C/C++. In Java, all variables
-which store objects are really references (pointers) to the objects. In
-Perl, references are references - the same thing as in OCaml.
+which store objects are really references (pointers) to the objects.
 
 Here's how we create a reference to an `int` in OCaml:
 
@@ -122,18 +116,18 @@ came along and collected it immediately afterwards! (actually, it was
 probably thrown away at compile-time.) Let's name the reference:
 
 ```ocamltop
-let my_ref = ref 0
+let my_ref = ref 0;;
 ```
 This reference is currently storing a zero integer. Let's put something
 else into it (assignment):
 
 ```ocamltop
-my_ref := 100
+my_ref := 100;;
 ```
 And let's find out what the reference contains now:
 
 ```ocamltop
-!my_ref
+!my_ref;;
 ```
 So the `:=` operator is used to assign to references, and the `!`
 operator dereferences to get out the contents. Here's a rough-and-ready
@@ -202,14 +196,14 @@ let read_whole_channel chan =
   let buf = Buffer.create 4096 in
   let rec loop () =
     let newline = input_line chan in
-    Buffer.add_string buf newline;
-    Buffer.add_char buf '\n';
-    loop ()
+      Buffer.add_string buf newline;
+      Buffer.add_char buf '\n';
+      loop ()
   in
-  try
-    loop ()
-  with
-    End_of_file -> Buffer.contents buf;;
+    try
+      loop ()
+    with
+      End_of_file -> Buffer.contents buf;;
 ```
 Don't worry about what this code does - it contains many concepts which
 haven't been discussed in this tutorial yet. Concentrate instead on the
@@ -231,25 +225,11 @@ OCaml comes with lots of fun and interesting modules (libraries of
 useful code). For example there are standard libraries for drawing
 graphics, interfacing with GUI widget sets, handling large numbers, data
 structures, and making POSIX system calls. These libraries are located
-in `/usr/lib/ocaml/` (on Unix anyway). For these examples we're
-going to concentrate on one quite simple module called `Graphics`.
+in `/usr/lib/ocaml/` (on Unix anyway).
 
-The `Graphics` module is installed into 7 files (on my system):
-
-```
-/usr/lib/ocaml/graphics.a
-/usr/lib/ocaml/graphics.cma
-/usr/lib/ocaml/graphics.cmi
-/usr/lib/ocaml/graphics.cmx
-/usr/lib/ocaml/graphics.cmxa
-/usr/lib/ocaml/graphics.cmxs
-/usr/lib/ocaml/graphics.mli
-```
-For the moment let's just concentrate on the file `graphics.mli`. This
-is a text file, so you can read it now. Notice first of all that the
-name is `graphics.mli` and not `Graphics.mli`. OCaml always capitalizes
-the first letter of the file name to get the module name. This can be
-very confusing until you know about it!
+For these examples we're going to use module called `Graphics` which can be
+installed with `opam install graphics` and the `ocamlfind` program installed
+with `opam install ocamlfind`.
 
 If we want to use the functions in `Graphics` there are two ways we can
 do it. Either at the start of our program we have the `open Graphics;;`
@@ -262,39 +242,44 @@ first load the
 library with
 
 ```ocaml
-#require "graphics";;
+# #use "topfind";;
+- : unit = ()
+Findlib has been successfully loaded. Additional directives:
+  #require "package";;      to load a package
+
+- : unit = ()
+# #require "graphics";;
+/Users/me/.opam/4.12.0/lib/graphics: added to search path
+/Users/me/.opam/4.12.0/lib/graphics/graphics.cma: loaded
 ```
-Windows users: For this example to work interactively on Windows, you
-will need to create a custom toplevel. Issue the command `ocamlmktop
--o ocaml-graphics graphics.cma` from the command line.
-<!-- FIXME: is this last remark still true? -->
 
 A couple of examples should make this clear. (The two examples draw
 different things - try them out). Note the first example calls
 `open_graph` and the second one `Graphics.open_graph`.
 
 ```ocaml
-(* To compile this example: ocamlc graphics.cma grtest1.ml -o grtest1 *)
-open Graphics;;
+open Graphics
 
-open_graph " 640x480";;
+open_graph " 640x480"
+
 for i = 12 downto 1 do
   let radius = i * 20 in
-  set_color (if i mod 2 = 0 then red else yellow);
-  fill_circle 320 240 radius
+    set_color (if i mod 2 = 0 then red else yellow);
+    fill_circle 320 240 radius
 done;;
-read_line ();;
 
-(* To compile this example: ocamlc graphics.cma grtest2.ml -o grtest2 *)
+read_line ()
+```
 
-Random.self_init ();;
-Graphics.open_graph " 640x480";;
+```ocaml
+Random.self_init ()
+
+Graphics.open_graph " 640x480"
 
 let rec iterate r x_init i =
-  if i = 1 then x_init
-  else
-    let x = iterate r x_init (i-1) in
-    r *. x *. (1.0 -. x);;
+  if i = 1 then x_init else
+    let x = iterate r x_init (i - 1) in
+      r *. x *. (1.0 -. x);;
 
 for x = 0 to 639 do
   let r = 4.0 *. (float_of_int x) /. 640.0 in
@@ -302,11 +287,11 @@ for x = 0 to 639 do
     let x_init = Random.float 1.0 in
     let x_final = iterate r x_init 500 in
     let y = int_of_float (x_final *. 480.) in
-    Graphics.plot x y
+      Graphics.plot x y
   done
-done;;
+done
 
-read_line ();;
+read_line ()
 ```
 Both of these examples make use of some features we haven't talked about
 yet: imperative-style for-loops, if-then-else and recursion. We'll talk
@@ -314,23 +299,24 @@ about those later. Nevertheless you should look at these programs and
 try and find out (1) how they work, and (2) how type inference is
 helping you to eliminate bugs.
 
-## The `Pervasives` module
+## The `Stdlib` module
 There's one module that you never need to "`open`". That is the
-`Pervasives` module (go and read `/usr/lib/ocaml/pervasives.mli`
-now). All of the symbols from the `Pervasives` module are automatically
+`Stdlib` module. All of the symbols from the `Stdlib` module are automatically
 imported into every OCaml program.
 
 ## Renaming modules
 What happens if you want to use symbols in the `Graphics` module, but
 you don't want to import all of them and you can't be bothered to type
-`Graphics` each time? Just rename it using this trick:
+`Graphics` each time? Just rename it like this:
 
 ```ocaml
-module Gr = Graphics;;
+module Gr = Graphics
 
-Gr.open_graph " 640x480";;
-Gr.fill_circle 320 240 240;;
-read_line ();;
+Gr.open_graph " 640x480"
+
+Gr.fill_circle 320 240 240
+
+read_line ()
 ```
 Actually this is really useful when you want to import a nested module
 (modules can be nested inside one another), but you don't want to type
@@ -354,11 +340,11 @@ expression. The following code is perfectly legal (and all do the same
 thing):
 
  ```ocamltop
- let f x b y = if b then x+y else x+0
+ let f x b y = if b then x + y else x + 0
  let f x b y = x + (if b then y else 0)
  let f x b y = x + (match b with true -> y | false -> 0)
  let f x b y = x + (let g z = function true -> z | false -> 0 in g y b)
- let f = fun x -> fun b -> fun y -> if b then x+y else x+0
+ let f = fun x -> fun b -> fun y -> if b then x + y else x + 0
  let f x b y = x + (let _ = y + 3 in (); if b then y else 0)
 ```
 
@@ -366,7 +352,7 @@ Note especially the last one — I'm using `;` as an operator to "join"
 two statements. All functions in OCaml can be expressed as:
 
 ```ocaml
- let name [parameters] = expression ;;
+ let name [parameters] = expression
 ```
 OCaml's definition of what is an expression is just a little wider
 than C's. In fact, C has the concept of "statements" — but all of C's
@@ -378,98 +364,15 @@ The one place that `;` is different from `+` is that I can refer to
 function, to sum a list of ints, like:
 
 ```ocamltop
-let sum_list = List.fold_left ( + ) 0 ;;
+let sum_list = List.fold_left ( + ) 0;;
 ```
-
-## The disappearance of `;;`
-
-Now we're going to look at a very important issue. All examples above
-ended with a double semi-colon `;;`. However, if you look at OCaml code
-outside of tutorials, you will find whole code bases that does not
-use `;;`, not even once.
-
-The truth is that `;;` is mostly used in the toplevel and tutorials to
-mark the end of an OCaml phrase and send this phrase to the toplevel
-in order to evaluate it.
-
-Outside of the toplevel, uses of `;;` are, at best, infrequent
-and are _never required_ for well written code.
-Briefly, double semi-colon `;;` can be used for three reasons:
-
-* For compatibility with the toplevel;
-* To split the code to ease debugging;
-* To introduce a toplevel expression.
-
-Inserting `;;` can be sometimes useful for beginners when debugging,
-since it stops any running definition. For instance, in the following
-example, the definition of `f` does not stop at line 1 due to the
-comma `,` operator. Consequently, the compiler raises an error at the
-end of the second line:
-
-```ocaml
-let f x = x,
-let g = x * x
-```
-
-Inserting a double semi-colon between `f` and `g` detangles
-the definition of `f` and `g`:
-
-```ocaml
-let f x = x,
-;;
-let g = x * x
-```
-
-Another use of `;;` is to introduce a new toplevel expression after
-some definitions:
-
-```ocaml
-let b = "This started with"
-let s = "a very nonsensical message.";;
-print_endline b; print_endline s
-open String
-let s = concat "" ["Fortunately"; ", "; "the"; "end"; "is"; "near"; "."];;
-print_endline s;;
-let s = "let end here" in print_endline s
-```
-
-In particular, in the above examples, all lines starting after `;;` are
-purely effectful and deleting them will only affect the effect of the code,
-not the following definitions.
-
-However, this use of `;;` can (should) always be replaced by either
-
-```ocaml
-let () = expression ()
-```
-
-if the result of the expression is `unit`, or
-
-```ocaml
-let _ = expression ()
-```
-otherwise. Note that the first form is safer, since it requires that
-the type of the returned expression is `unit`; preventing us, for instance,
-from forgetting an argument in
-
-```ocaml
-let () =
-  print_newline
-  (* here, we forgot () and the compiler will complain. *)
-```
-
-With this convention, there are no toplevel expressions anymore: any
-module can be written as a sequence of definitions. Consequently, some
-style guidelines consider that `;;` should never be used outside of the
-toplevel (see for instance these [style guidelines](guidelines.html)).
 
 ## Putting it all together: some real code
 In this section we're going to show some real code fragments from the
 lablgtk 1.2 library. (Lablgtk is the OCaml interface to the native Unix
 Gtk widget library). A word of warning: these fragments contain a lot of
 ideas which we haven't discussed yet. Don't look at the details, look
-instead at the overall shape of the code, where the authors used `;;`,
-where they used `;` and where they used `open`, how they indented the
+instead at the overall shape of the code, where they used `open`, how they indented the
 code, how they used local and global named expressions.
 
 ... However, I'll give you some clues so you don't get totally lost!
@@ -483,9 +386,8 @@ code, how they used local and global named expressions.
  an object called `foo`). It's similar to `foo->bar` or `foo.bar` or
  `$foo->bar` in C++, Java or Perl respectively.
 
-First snippet: The programmer opens a couple of standard libraries
-(eliding the `;;` because the next keyword is `open` and `let`
-respectively). They then create a function called `file_dialog`. Inside
+First snippet: The programmer opens a couple of standard libraries.
+They then create a function called `file_dialog`. Inside
 this function they define a named expression called `sel` using a
 two-line `let sel = ... in` statement. Then they call several methods on
 `sel`.
@@ -497,10 +399,11 @@ open GMain
 
 let file_dialog ~title ~callback ?filename () =
   let sel =
-    GWindow.file_selection ~title ~modal:true ?filename () in
-  sel#cancel_button#connect#clicked ~callback:sel#destroy;
-  sel#ok_button#connect#clicked ~callback:do_ok;
-  sel#show ()
+    GWindow.file_selection ~title ~modal:true ?filename ()
+  in
+    sel#cancel_button#connect#clicked ~callback:sel#destroy;
+    sel#ok_button#connect#clicked ~callback:do_ok;
+    sel#show ()
 ```
 
 Second snippet: Just a long list of global names at the top level.


### PR DESCRIPTION
(This work funded by the OCaml Software Foundation).

The tutorials are a bit of a mess, mostly due to history. At the moment, some of them are harmful, since they suggest old-fashioned methods or use tools no longer recommended. We hope to upgrade them from harmful to neutral. Good can come later!

This PR deals with the first of eight sections of the tutorials. The idea is to bring them up to date, not to (yet) rewrite them.

I want to get feedback before proposing changes to the other seven sections.

To give an idea of what changes have been made, one can look at the diff. But here is a summary:

- Deal with the ;; vs ; issue conclusively.
- Remove references to ocamlbuild
- Format code as per style guide
- Update URLs
- Remove references to Bignum and Nat
- Deal with the fact that Graphics is now not included in OCaml
- Pervasives --> Stdlib
