### PR TITLE
chore: remove obsolete travis-ci build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Travis Build Status](https://travis-ci.org/ocaml/ocaml.org.svg?branch=master)](https://travis-ci.org/ocaml/ocaml.org)
-
 OCAML.ORG PROJECT
 =================
 This is the source code implementing the ocaml.org


### PR DESCRIPTION
Since we are not using Travis-ci either we have any travis.yml, so we should remove the build status badge too regarding travis