### PR TITLE
Add bottom border to h2 elements in documentation page

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -245,6 +245,10 @@ h4.news img.rss {
   height: 1.5ex;
 }
 
+.condensed > h2.ruled {
+  border-bottom: 1px #ACACAC solid;
+}
+
 /* Edit buttom, right of the navbar. */
 a.edit-this-page {
   margin-top: 22.5px;


### PR DESCRIPTION
This PR adds `border-bottom` CSS styling  to `h2` elements. Initially, the styling was applied to `h1` elements but the `h1` elements were converted to `h2` elements in [this PR](https://github.com/ocaml/ocaml.org/pull/1248). 

**Before**
![image](https://user-images.githubusercontent.com/52580190/110779237-593e3b80-8274-11eb-86da-9bdeff173260.png)


**After**
![image](https://user-images.githubusercontent.com/52580190/110779064-2ac06080-8274-11eb-83d5-31a531519bcc.png)
