### PR TITLE
Make iframe elements  on documentation page accessible

### DIFF
--- a/site/docs/index.fr.md
+++ b/site/docs/index.fr.md
@@ -164,7 +164,7 @@
       <div class="row">
         <div class="span4">
           <p class="documentation-video">
-	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" allowfullscreen></iframe>
+	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" title="Dans cet exposé, Mark Shinwell explique comment trouver des bugs difficiles dans les programmes OCaml" allowfullscreen></iframe>
           </p>
           <p>Dans cet exposé, Mark Shinwell explique comment
 	    trouver des bugs difficiles dans les programmes OCaml.
@@ -175,7 +175,7 @@
         </div>
         <div class="span4">
           <p class="documentation-video">
-            <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" allowfullscreen></iframe>
+            <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" title="Exposé de Yaron Minsky à CMU présentant le retour d'expérience de Jane Street sur l'utilisation d'OCaml comme principal langage de développement" allowfullscreen></iframe>
           </p>
           <p>Exposé de Yaron Minsky à CMU présentant
 	    le retour d'expérience de Jane Street sur l'utilisation d'OCaml comme
@@ -183,7 +183,7 @@
         </div>
         <div class="span4">
           <p class="documentation-video">
-            <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" allowfullscreen></iframe>
+            <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" title="Rapport d'expérience: OCaml utilisé pour une plateforme d'analyse statique de niveau industriel, par Pascal Cuoq et Julien Signoles du CEA LIST, à ICFP'2009" allowfullscreen></iframe>
           </p>
           <p>Rapport d'expérience: OCaml utilisé pour une
 	    plateforme d'analyse statique de niveau industriel, par

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -170,7 +170,7 @@
       <div class="row">
 	<div class="span4">
 	  <p class="documentation-video">
-	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" allowfullscreen></iframe>
+	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" title="In this talk, Mark Shinwell explains how to track down hard-to-find bugs in OCaml programs" allowfullscreen></iframe>
 	  </p>
 	  <p>In this talk, Mark Shinwell explains how to
 	    track down hard-to-find bugs in OCaml programs.
@@ -181,13 +181,13 @@
 	</div>
 	<div class="span4">
 	  <p class="documentation-video">
-	    <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" allowfullscreen></iframe>
+	    <iframe src="//player.vimeo.com/video/14317442?portrait=0&amp;color=ff9933" width="310" height="233" title="Talk at CMU describing the experiences that Jane Street has had using OCaml as its primary development language" allowfullscreen></iframe>
 	  </p>
 	  <p>Talk at CMU describing the experiences that Jane Street has had using OCaml as its primary development language.</p>
 	</div>
 	<div class="span4">
 	  <p class="documentation-video">
-	    <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" allowfullscreen></iframe>
+	    <iframe src="//player.vimeo.com/video/6652523?portrait=0&amp;color=ff9933" width="310" height="233" title="Experience Report: OCaml for an Industrial-strength Static Analysis Framework Pascal Cuoq and Julien Signoles; CEA LIST International Conference on Functional Programming (ICFP) Edinburgh 2009" allowfullscreen></iframe>
 	  </p>
 	  <p>Experience Report: OCaml for an Industrial-strength Static Analysis Framework
 	    Pascal Cuoq and Julien Signoles; CEA LIST


### PR DESCRIPTION
This PR fixes [accessibility issue](https://github.com/ocaml/ocaml.org/issues/1236) on the `iframe` elements of the documentation page which should have been fixed in [in this PR](https://github.com/ocaml/ocaml.org/pull/1249) but wasn't because the code was accidentally removed while [resolving merge conflict](https://github.com/ocaml/ocaml.org/pull/1249/commits/31c3b765e524ab479c833e87db6684d440002234).

**Before**

![image](https://user-images.githubusercontent.com/52580190/111075006-da0c6a00-84f6-11eb-8691-d61af511098c.png)

**After**

![image](https://user-images.githubusercontent.com/52580190/111075047-29529a80-84f7-11eb-9ec8-c453acc9be5d.png)
