### PR TITLE
Fix incorrect translation of menu item on french page

### DIFF
--- a/translations/en_to_fr.txt
+++ b/translations/en_to_fr.txt
@@ -1,6 +1,6 @@
 "Learn" -> "Apprendre"
 "Documentation" -> "Documentation"
-"Packages" -> "Contributions"
+"Packages" -> "Paquets"
 "Community" -> "Communauté"
 "Feedback" -> "Suggestions"
 "About This Site" -> "À propos de ce site"

--- a/translations/en_to_fr.txt
+++ b/translations/en_to_fr.txt
@@ -5,7 +5,7 @@
 "Feedback" -> "Suggestions"
 "About This Site" -> "À propos de ce site"
 "Find Us on GitHub" -> "Dépôt GitHub"
-"News" -> "Nouvelles"
+"News" -> "Actualités"
 "Code Examples" -> "Exemples de code"
 "Tutorials" -> "Tutoriels"
 "Books" -> "Livres"


### PR DESCRIPTION
# PR description

This PR fixes mismatching menu item names  on the English and French page. Before this fix, the third menu item on the French page is `Contribution` yet it is supposed to be `Paquets` which is the translation of `Packages` to French. The menu item  links to [opam.org](https://opam.ocaml.org/). After this fix, the third menu item on the French page is `Paquets` which is the translation of `Packages` to French and `News` is translated to  `Actualités` following the discussion in  [this thread](https://github.com/ocaml/ocaml.org/issues/1275#issuecomment-799267228).

# Issue

Fixes #1275 

# Before

![image](https://user-images.githubusercontent.com/52580190/111149716-48583780-859e-11eb-9067-e2dd969fd848.png)

# After

![image](https://user-images.githubusercontent.com/52580190/111163495-341c3680-85ae-11eb-8adb-a3334c66cb76.png)


