### PR TITLE
Fix a couple of typos in the logos page

### DIFF
--- a/site/docs/logos.md
+++ b/site/docs/logos.md
@@ -11,7 +11,7 @@ The logo is available in
 [colors](https://github.com/ocaml/ocaml-logo).  Two versions are
 displayed below.  To include one of them on your web page, just copy
 and paste the associated HTML code and tweak it (e.g. adapt the `width`
-or change the part after `logo/` to match the one of the file you are
+or change the part after `logo/` to match the one of the file you
 want in the [repository](https://github.com/ocaml/ocaml-logo)).
 The OCaml logo is released under a
 [liberal license](https://github.com/ocaml/ocaml.org/blob/master/LICENSE.md).
@@ -49,12 +49,12 @@ The OCaml logo is released under a
 
 The following [SVG file](/img/OCaml_Sticker.svg) is suitable to
 [make stickers](https://twitter.com/ocamllabs/status/761191421680422912).
-Its is is released under the same
+It is released under the same
 [liberal license](https://github.com/ocaml/ocaml.org/blob/master/LICENSE.md) as
 the logo so do not hesitate to print your own stickers to promote
 OCaml!
 
 Before printing some stickers, it would be great if you
 [tweeted it](https://twitter.com/search?q=%23OCaml%20stickers&src=typd) with
-tags `#OCaml stickers` so that other interested people in you area can
+tags `#OCaml stickers` so that other interested people in your area can
 get in touch with you!


### PR DESCRIPTION
# Description of the PR

This PR fixes a couple of typos in the logos page.
**Before fix**
![image](https://user-images.githubusercontent.com/52580190/111455130-78cadd80-8726-11eb-84f8-2324dbf5f371.png)
![image](https://user-images.githubusercontent.com/52580190/111455781-45d51980-8727-11eb-9bdb-e9f0f867ae0d.png)

**After fix**
![image](https://user-images.githubusercontent.com/52580190/111457053-c6e0e080-8728-11eb-95e1-31b66a134327.png)
![image](https://user-images.githubusercontent.com/52580190/111457388-2ccd6800-8729-11eb-869c-9fdbe57122da.png)


# Related issue
Fixes #1278 

