### PR TITLE
add ocaml.org-media to docker images

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -9,6 +9,7 @@ RUN opam install -y --deps-only ocamlorg
 COPY --chown=opam . /home/opam/src
 RUN opam exec -- make -j production
 RUN git clone --depth=1 https://github.com/ocaml/ocaml-logo /home/opam/src/ocaml.org/logo
+RUN git clone --depth=1 https://github.com/ocaml/ocaml.org-media /home/opam/src/media && cp -r /home/opam/src/media/* /home/opam/src/ocaml.org
 FROM caddy:2-alpine
 COPY --from=build /home/opam/src/ocaml.org /usr/share/caddy
 ENTRYPOINT ["caddy", "file-server"]

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -9,6 +9,7 @@ RUN opam install -y --deps-only ocamlorg
 COPY --chown=opam . /home/opam/src
 RUN opam exec -- make -j local
 RUN git clone --depth=1 https://github.com/ocaml/ocaml-logo /home/opam/src/ocaml.org/logo
+RUN git clone --depth=1 https://github.com/ocaml/ocaml.org-media /home/opam/src/media && cp -r /home/opam/src/media/* /home/opam/src/ocaml.org
 FROM caddy:2-alpine
 COPY --from=build /home/opam/src/ocaml.org /usr/share/caddy
 ENTRYPOINT ["caddy", "file-server"]


### PR DESCRIPTION
This PR clones the https://github.com/ocaml/ocaml.org-media repository into the build directory of the deploy and staging images, this fixes:

 - The dead links on pages like https://ocaml.org/meetings/ocaml/2011/ 
 - It also adds the missing images on pages like https://ocaml.org/learn/success.html (part of #1258)

Tested it locally and seemed to work -- would be good to push to staging to double check. 