### PR TITLE
Improve companies page

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -280,6 +280,16 @@ html.svg a.edit-this-page:hover {
   display: flex;
   justify-content: flex-end;
 }
+dl{
+  padding: 1em;
+  background: #eee;
+}
+dl a{
+color: #a20505;
+}
+dl h2{
+font-weight: bold;
+}
 /* When the navigation bar has reduced size */
 @media (max-height: 600px) and (min-width: 980px) {
   a.edit-this-page {

--- a/site/learn/companies.md
+++ b/site/learn/companies.md
@@ -36,7 +36,7 @@
     </dt>
     <dd class="span5">
         <h2><a href="http://www.bloomberg.com/">Bloomberg L.P.</a>, United States </h2>
-        <p>Bloomberg, the global business and financial information and news leader, gives influential decision makers a critical edge by connecting them to a dynamic network of information, people and ideas. Bloomberg employs OCaml in a advanced financial derivatives risk management application delivered through its Bloomberg Professional service.</p> 
+        <p>Bloomberg, the global business and financial information and news leader, gives influential decision makers a critical edge by connecting them to a dynamic network of information, people and ideas. Bloomberg employs OCaml in an advanced financial derivatives risk management application delivered through its Bloomberg Professional service.</p> 
     </dd>
 </dl>
 
@@ -56,7 +56,7 @@
         <p>As of summer 2018, Citrix in Cambridge UK is hiring
         software engineers passionate about functional programming and
         OCaml in particular.</p>
-    </p> </dd> </dl>
+    </dd> </dl>
 
 <dl class="row">
     <dt class="span3">
@@ -116,7 +116,7 @@
     </dt>
     <dd class="span5">
         <h2><a href="http://cacaoweb.org">CACAOWEB</a>, United Kingdom and Hong Kong</h2>
-        <p>Cacaoweb is a developing an application platform of a new
+        <p>Cacaoweb is developing an application platform of a new
         kind. It runs on top of our peer-to-peer network, which
         happens to be one of the largest in the world. The
         capabilities of the platform are diverse and range from
@@ -179,7 +179,7 @@
     <dd class="span5">
         <h2><a href="http://www.hostnet.com.br/">Digirati dba Hostnet</a>,
 		Brazil</h2>
-        <p>Digirati dba Hostnet is a web hosting company. We use OCaml mostly for internal systems programming and infrastructure services. We also have contributed with the community by releasing a few open source <a href="https://github.com/andrenth">OCaml libraries</a>.</p>
+        <p>Digirati dba Hostnet is a web hosting company. We use OCaml mostly for internal systems programming and infrastructure services. We have also contributed to the community by releasing a few open source <a href="https://github.com/andrenth">OCaml libraries</a>.</p>
     </dd>
 </dl>
 <dl class="row">
@@ -497,7 +497,7 @@ form of lightweight formal method that can be used on a daily basis.
     </dt>
     <dd class="span5">
         <h2><a href="http://trust-in-soft.com">TrustInSoft</a>, France</h2>
-        <p>TrustInSoft is a company that changes the rules in cybersecurity. TrustInSoft is the software publisher of the software analysis <a href="http://frama-c.com">Frama-C</a> platform. Our only moto is simple: make the formal methods accessible to the majority of software developers.</p>
+        <p>TrustInSoft is a company that changes the rules in cybersecurity. TrustInSoft is the software publisher of the software analysis <a href="http://frama-c.com">Frama-C</a> platform. Our motto is simple: make the formal methods accessible to the majority of software developers.</p>
     </dd>
 </dl>
 <dl class="row">
@@ -506,12 +506,12 @@ form of lightweight formal method that can be used on a daily basis.
     </dt>
     <dd class="span5">
         <h2><a href="https://zeo.org/">Zeo Agency</a>, London</h2>
-        <p>Zeo is a digital marketing company focus on helping companies to do better in SEO. Due to the nature of our business, we manage billions of lines in our database & create insights by using this data. To utilize our needs effectively, we use OCaml in our data crawling & processing part.</p>
+        <p>Zeo is a digital marketing company focused on helping companies to do better in SEO. Due to the nature of our business, we manage billions of lines in our database & create insights by using this data. To utilize our needs effectively, we use OCaml in our data crawling & processing part.</p>
     </dd>
 </dl>
 
 
-<h4>Disclaimer</h4>
+<h3>Disclaimer</h3>
 Appearance of a company's name here does not necessarily imply
 endorsement by that company of OCaml or of the descriptions provided
 here. Company representatives should <a href="https://github.com/ocaml/ocaml.org/issues/new">contact us</a> to have information about their company removed, modified, or added.


### PR DESCRIPTION
# PR description

This PR improves the [companies page](https://ocaml.org/learn/companies.html) by fixing the following issues.

## Typos and grammatical errors
Before this fix there were a couple of typos on the [companies page](https://ocaml.org/learn/companies.html). You can view them before and after the fix in the following screenshots.
### TrustInSoft, France
**Before**
![image](https://user-images.githubusercontent.com/52580190/112029055-e4a7ae80-8b49-11eb-82dc-1e6bde539f1c.png)
**After**
![image](https://user-images.githubusercontent.com/52580190/112130526-a0fc8580-8bd9-11eb-8fdf-7841bc30e627.png)


### Digirati dba Hostnet, Brazil
**Before**
![image](https://user-images.githubusercontent.com/52580190/112029126-f5f0bb00-8b49-11eb-811b-226f9d0bf9fb.png)
**After**
![image](https://user-images.githubusercontent.com/52580190/112132256-73b0d700-8bdb-11eb-9ccc-2d4df2f80d34.png)

### CACAOWEB, United Kingdom and Hong Kong
**Before**
![image](https://user-images.githubusercontent.com/52580190/112029198-09038b00-8b4a-11eb-8923-90be63057fee.png)
 **After**
![image](https://user-images.githubusercontent.com/52580190/112131845-08ff9b80-8bdb-11eb-9730-8e004b8b29df.png)

## Non sequential heading tags
Before this fix, there was a [`h4`](https://github.com/ocaml/ocaml.org/blob/master/site/learn/companies.md#disclaimer) element following `h2` skipping `h3` in between. It is important to have properly ordered headings that do not skip levels  because the headings convey the semantic structure of the page, making it easier to navigate and understand when using assistive technologies. The `h4` has been changed to `h3` to follow the correct semantic order.

## Styling to  improve appearance and  reading experience
It was difficult to to tell which block of text is describing which company as illustrated in the following before and after screenshots.
**Before**
![image](https://user-images.githubusercontent.com/52580190/112125869-ee2a2880-8bd4-11eb-8895-8b56ff86830a.png)
**After**
![image](https://user-images.githubusercontent.com/52580190/112125966-08640680-8bd5-11eb-8070-70c7735587bf.png)

# Related issue

If merged, this PR fixes #1287 