### PR TITLE
Add focus styling on all interactive elements

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -280,6 +280,40 @@ html.svg a.edit-this-page:hover {
   display: flex;
   justify-content: flex-end;
 }
+/* 
+This styling overrides bootstrap style which removes outline
+when an element is in focus
+*/
+a:focus{
+  outline: 0.2rem solid #c77a27;
+ 
+ }
+ .navbar .edit-this-page:focus{
+   background-color: #6e5437;
+   border-radius: 5px;
+ }
+ .navbar-inverse .navbar-search .search-query:focus{
+   box-shadow: 0 0 0 0.2rem #c77a27;
+ }
+ select.form-control:focus{
+   box-shadow: 0 0 0 0.2rem #c77a27;
+ }
+ a.btn:focus, button.btn:focus{
+   outline: none;
+   box-shadow: 0 0 0 0.2rem #c77a27;
+ }
+ #menu-items .nav a:focus{
+   background-color: #6e5437;
+ }
+ .brand:hover, .brand:focus{
+   background-color:#6e5437;
+ }
+ .navbar a:focus{
+   outline: none;
+ }
+ #footer a:focus{
+   outline: 3px solid #c77a27;
+ }
 /* When the navigation bar has reduced size */
 @media (max-height: 600px) and (min-width: 980px) {
   a.edit-this-page {


### PR DESCRIPTION
# PR description

This PR adds outline to all interactive elements when they are in focus to improve user experience for keyboard users. The before and after  screencasts below demonstrate what someone experiences while  using the keyboard to access certain web pages of [ocaml.org](https://ocaml.org/).

**Before fix**
You will notice it is difficult to tell which element is in focus while tabbing through the page.
https://user-images.githubusercontent.com/52580190/112324471-e2695f80-8cc3-11eb-951e-3b840e250003.mp4

**After fix**
Here, focused interactive elements have been styled to be distinct when in focus.
https://user-images.githubusercontent.com/52580190/112324553-fb721080-8cc3-11eb-92d9-281bd7ec9184.mp4

# Additional information

While working on this PR, I noticed the following:

- It is better to have custom outline styles for uniformity across different browsers rather than relying on default styles provided by the browsers. Default styles vary from one browser to another.
- Adding an outline to a menu item when in focus affects their appearance. I think they look quite ugly with outline. Therefore I decided to maintain background color to show that a menu item is in focus. 
- Default bootstrap styles conceal certain  sections of the outline when some `a` tags are in focus especially on the landing page.  You can see the  annotated screenshot below. 
 
![szoter_annotated_image](https://user-images.githubusercontent.com/52580190/112329253-18a8de00-8cc8-11eb-8097-6b7ae47311ce.jpeg)

**Note** The above outlines appear only when the element is in focus. All the outlines have been displayed to illustrate the preceding textual description.

Essentially, outlines are displayed outside the border. To make the hidden sides visible, margins need to be applied to the `a` tags which affects the bootstrap styling ultimately distorting the page layout. I need some guidance here because I don't know any way of fixing this without significantly changing the page layout. 
I am thinking of the following though.
1. Change the markup, remove bootstrap classes and style the affected sections from ground up without relying on bootstrap because I have noticed this version of bootstrap relies on `float` a lot which is quite difficult to  work against when aligning items.
2. Leave the current outline to be displayed the way it is even if some sections of the outline are not displayed.


# Issue

This PR fixes #1282 
