### PR TITLE
Extra white spaces removed on the right of all pages

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -503,7 +503,6 @@ ul.translations:after { content: "]"; }
   }
   #footer .column {
     text-align: left;
-    padding-left: 10%;
     padding-right: 5%;
   }
 }


### PR DESCRIPTION
Hello @avsm @patricoferris, I am raising another PR with only the necessary changes and removing the style changes from the commit. All the pages of the site were having some extra white space on the right side. I have fixed that by adjusting the padding issues with the footer. Kindly have a look at the screenshot below for a better description of the issue.
![1](https://user-images.githubusercontent.com/63946672/112495991-66961280-8daa-11eb-96d6-fd5360b7ae94.png)
![2](https://user-images.githubusercontent.com/63946672/112496013-6ac23000-8daa-11eb-8dda-3f56b2b8eea9.png)
