### PR TITLE
Adding a section for mobile devices on Install page

### DIFF
--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -15,6 +15,7 @@ The OCaml compiler and libraries can be installed in several ways:
   ([Linux](#Linux), [macOS](#macOS), [FreeBSD](#FreeBSD),
    [OpenBSD](#OpenBSD), [NetBSD](#NetBSD), [Windows](#Windows))
 * In your [browser](#Browser).
+* On your [mobile device](#Mobile).
 * By compiling [the source](#From-Source).
 
 For finding and installing OCaml libraries, see the
@@ -208,6 +209,10 @@ Here are a few other alternatives:
 * [Cygwin](http://cygwin.com/)-based port. Requires Cygwin, you can
   install them using the `setup` tool. The compilers generate executables
   that do require Cygwin (`cygwin1.dll`).
+  
+## Mobile
+
+* [OCaml: Learn & Code](https://apps.apple.com/app/ocaml-learn-code/id1547506826) provides an editor and an interactive toplevel for iOS, iPadOS and macOS, with a growing learn section.
 
 ## Browser
 


### PR DESCRIPTION
I added a section containing an editor + toplevel + compiler for mobile devices (currently iOS and iPadOS)