### PR TITLE
Make click-ability of texts on Home Page visible. Fixes #1307

### DIFF
--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -5594,10 +5594,10 @@ body {
   padding: 25px 0;
 }
 #home-learn a {
-  text-decoration: underline;
+  text-decoration: none;
 }
 #home-learn a:hover {
-  text-decoration: none;
+  text-decoration: underline;
   color: #c45641;
 }
 #home-learn img {

--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -5594,7 +5594,7 @@ body {
   padding: 25px 0;
 }
 #home-learn a {
-  color: #404040;
+  text-decoration: underline;
 }
 #home-learn a:hover {
   text-decoration: none;


### PR DESCRIPTION
Update bootstrap.css in order to fix #1307
Before: 
![before](https://user-images.githubusercontent.com/73695161/113011076-07b00f00-9197-11eb-90c2-16e6ce9741cb.png)
After:
![ocaml index](https://user-images.githubusercontent.com/73695161/113011278-43e36f80-9197-11eb-8e88-dd92dccc895d.png)

