### PR TITLE
UI fixes: Moved the language selector `[ en fr ]` to the top-right corner of the page.

### DIFF
--- a/site/community/index.md
+++ b/site/community/index.md
@@ -74,7 +74,7 @@
             <p>If you would like to give support to OCaml, you can join the Consortium or support the work of OCaml Labs. <a href="/community/support.html#GivingSupport">Find out more</a>.</p>
             <p>Suggestions or bug reports about the OCaml language
             itself can be posted to <a
-            href="https://github.com/ocaml/ocaml/issues">Gihub issues</a>.</p>
+            href="https://github.com/ocaml/ocaml/issues">Github issues</a>.</p>
         </section>
         <section class="span4 condensed">
            <h1 class="ruled"><a href="/meetings/">Meetings</a></h1>

--- a/site/community/index.md
+++ b/site/community/index.md
@@ -74,7 +74,7 @@
             <p>If you would like to give support to OCaml, you can join the Consortium or support the work of OCaml Labs. <a href="/community/support.html#GivingSupport">Find out more</a>.</p>
             <p>Suggestions or bug reports about the OCaml language
             itself can be posted to <a
-            href="https://github.com/ocaml/ocaml/issues">Github issues</a>.</p>
+            href="https://github.com/ocaml/ocaml/issues">GitHub issues</a>.</p>
         </section>
         <section class="span4 condensed">
            <h1 class="ruled"><a href="/meetings/">Meetings</a></h1>

--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -530,6 +530,14 @@ a:focus {
   margin-left: auto;
   *zoom: 1;
 }
+.navbar-inner > .container-fluid {
+  margin-right: 65px;
+}
+@media (max-width: 767px){
+  .navbar-inner > .container-fluid {
+    margin-right: 85px;
+  }
+}
 .container:before,
 .container:after {
   display: table;

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -408,10 +408,13 @@ figure.code td.code {
 }
 
 /* Running header on the front page */
-
-header + .core-running-header {
-  margin-top: -27px;
-  margin-bottom: 12px;
+.core-running-header {
+  color: #ffffff;
+  width: fit-content !important;
+  position: absolute;
+  right: 20px;
+  top: 5%;
+  z-index: 21221;
 }
 
 /* Translations and breadcrumb */
@@ -437,8 +440,8 @@ ul.translations {
   padding: 0;
   margin: 0px 1ex 0px 2ex;
 }
-ul.translations:before { content: "["; }
-ul.translations:after { content: "]"; }
+ul.translations:before { content: "["; color: #ffffff; }
+ul.translations:after { content: "]"; color: #ffffff;}
 .translations > li  {
   display: inline-block;
   *display: inline;
@@ -447,7 +450,9 @@ ul.translations:after { content: "]"; }
   *zoom: 1;
   text-shadow: 0 1px 0 #ffffff;
 }
-
+.translations > .active {
+  color: #ffffff;
+}
 /* Accessibility Helpers */
 .visually-hidden {
   clip: rect(0 0 0 0);
@@ -511,6 +516,12 @@ ul.translations:after { content: "]"; }
   #footer .column {
     width: 98%;
     margin-right: 0px;
+  }
+}
+@media (min-width: 980px)and (max-width: 1058px) {
+  #searchform, #search {
+    margin-right: 1.8rem;
+    width: 125px !important;
   }
 }
 #footer .entry {

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -408,13 +408,9 @@ figure.code td.code {
 }
 
 /* Running header on the front page */
-.core-running-header {
-  color: #ffffff;
-  width: fit-content !important;
-  position: absolute;
-  right: 20px;
-  top: 5%;
-  z-index: 21221;
+header + .core-running-header {
+  margin-top: -27px;
+  margin-bottom: 12px;
 }
 
 /* Translations and breadcrumb */
@@ -426,8 +422,8 @@ div.running-header {
 }
 ul.translations {
   float: right;
-  position: relative;
-  z-index: 10;
+  position: fixed;
+  z-index: 21221;
 
   padding: 8px 0;
   list-style: none;
@@ -435,10 +431,13 @@ ul.translations {
   font-family: Lato, sans-serif;
 
   font-weight: normal;
-  color: #6f6f6f; /* current language name */
+  color: #ffffff;  /* current language name */
   border: 0;
   padding: 0;
   margin: 0px 1ex 0px 2ex;
+  top: 1.5rem;
+  right: 20px;
+  width: fit-content !important;
 }
 ul.translations:before { content: "["; color: #ffffff; }
 ul.translations:after { content: "]"; color: #ffffff;}
@@ -452,6 +451,17 @@ ul.translations:after { content: "]"; color: #ffffff;}
 }
 .translations > .active {
   color: #ffffff;
+}
+@media (max-width: 980px) {
+  ul.translations {
+    position: absolute;
+    top: 1rem;
+  }
+}
+@media (max-height: 600px) {
+  ul.translations {
+    top: 0.5rem;
+  }
 }
 /* Accessibility Helpers */
 .visually-hidden {

--- a/site/docs/logos.md
+++ b/site/docs/logos.md
@@ -11,7 +11,7 @@ The logo is available in
 [colors](https://github.com/ocaml/ocaml-logo).  Two versions are
 displayed below.  To include one of them on your web page, just copy
 and paste the associated HTML code and tweak it (e.g. adapt the `width`
-or change the part after `logo/` to match the one of the file you are
+or change the part after `logo/` to match the one of the file you
 want in the [repository](https://github.com/ocaml/ocaml-logo)).
 The OCaml logo is released under a
 [liberal license](https://github.com/ocaml/ocaml.org/blob/master/LICENSE.md).
@@ -49,12 +49,12 @@ The OCaml logo is released under a
 
 The following [SVG file](/img/OCaml_Sticker.svg) is suitable to
 [make stickers](https://twitter.com/ocamllabs/status/761191421680422912).
-Its is is released under the same
+It is released under the same
 [liberal license](https://github.com/ocaml/ocaml.org/blob/master/LICENSE.md) as
 the logo so do not hesitate to print your own stickers to promote
 OCaml!
 
 Before printing some stickers, it would be great if you
 [tweeted it](https://twitter.com/search?q=%23OCaml%20stickers&src=typd) with
-tags `#OCaml stickers` so that other interested people in you area can
+tags `#OCaml stickers` so that other interested people in your area can
 get in touch with you!

--- a/site/index.md
+++ b/site/index.md
@@ -104,38 +104,38 @@
 			<ul class="news-feed" style="margin-bottom: 0px">
 
             <!-- Commented out between workshops -->
-			<li class="announcement"><article>
-			  <h1><a title="OCaml Users and Developers Workshop"
-			       href="/meetings/ocaml/2020/">OCaml 2020</a></h1>
-			  <p>August 28, 2020</p>
-			  <a title="OCaml Users and Developers Workshop"
-			     href="/meetings/ocaml/2020/">
-			    <img alt="" src="/img/announcement.svg" class="svg" />
-			    <img alt="" src="/img/announcement.png" class="png" />
-			  </a>
-			</article></li>
-			<li class="announcement"><article>
-			  <h1><a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
-			       href="/releases/{{! get LATEST_OCAML_VERSION !}}.html"
-				   >Release of OCaml {{! get LATEST_OCAML_VERSION !}}</a></h1>
-			   <p>February 24, 2021</p>
-			   <a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
-			      href="/releases/{{! get LATEST_OCAML_VERSION !}}.html">
-			    <img alt="" src="/img/announcement.svg" class="svg" />
-			    <img alt="" src="/img/announcement.png" class="png" />
-			  </a>
-			</article></li>
-			<li class="announcement"><article>
-			  <h1><a title="OCaml Weekly News"
-			       href="/community/cwn/" >OCaml Weekly News</a></h1>
-			   <p>{{! cmd script/weekly_news --date !}}</p>
-			   <a title="OCaml Weekly News" href="/community/cwn/">
-			    <img alt="" src="/img/announcement.svg" class="svg" />
-			    <img alt="" src="/img/announcement.png" class="png" />
-			  </a>
-			</article></li>
+    		<li class="announcement"><article>
+    		  <h1><a title="OCaml Users and Developers Workshop"
+    		       href="/meetings/ocaml/2020/">OCaml 2020</a></h1>
+    		  <p>August 28, 2020</p>
+    		  <a title="OCaml Users and Developers Workshop"
+    		     href="/meetings/ocaml/2020/">
+    		    <img alt="" src="/img/announcement.svg" class="svg" />
+    		    <img alt="" src="/img/announcement.png" class="png" />
+    		  </a>
+    		</article></li>
+    		<li class="announcement"><article>
+    		  <h1><a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
+    		       href="/releases/{{! get LATEST_OCAML_VERSION !}}.html"
+    			   >Release of OCaml {{! get LATEST_OCAML_VERSION !}}</a></h1>
+    		   <p>February 24, 2021</p>
+    		   <a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
+    		      href="/releases/{{! get LATEST_OCAML_VERSION !}}.html">
+    		    <img alt="" src="/img/announcement.svg" class="svg" />
+    		    <img alt="" src="/img/announcement.png" class="png" />
+    		  </a>
+    		</article></li>
+    		<li class="announcement"><article>
+    		  <h1><a title="OCaml Weekly News"
+    		       href="/community/cwn/" >OCaml Weekly News</a></h1>
+    		   <p>{{! cmd script/weekly_news --date !}}</p>
+    		   <a title="OCaml Weekly News" href="/community/cwn/">
+    		    <img alt="" src="/img/announcement.svg" class="svg" />
+    		    <img alt="" src="/img/announcement.png" class="png" />
+    		  </a>
+    		</article></li>
 
-	        </ul>
+            </ul>
             {{! cmd script/rss2html -n 4 --headlines http://planet.ocaml.org/rss20.xml !}}
             <p><a href="community/planet/">More...</a></p>
         </section>
@@ -152,4 +152,5 @@
             ((! input template/front_package.mpp !))
         </section>
     </div>
+
 </div>

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -124,7 +124,7 @@
             a set of tools and APIs to perform static analysis,
             dynamic analysis, code visualizations, code navigations,
             and style-preserving source-to-source transformations such
-            as refactorings on source code.  They also designed
+            as refactoring on source code.  They also designed
 	    <em>Hack</em>, a new statically typed
 	    programming language for HHVM, a fast PHP runtime.
 	    See Julien Verlaguet's
@@ -149,7 +149,7 @@
 	    file synchronizer stemming from the
 	       <a href="http://www.cis.upenn.edu/~bcpierce/papers/index.shtml#Synchronization"
 		  target="_blank"
-		  >latest research</a>.  It is resilent to failures
+		  >latest research</a>.  It is resilient to failures
 	       and  runs on Windows as well as most flavors of Unix,
 	       including MacOSX.
 	       OCaml helped the authors to


### PR DESCRIPTION
Patch: Changed the language selector [ en fr ] component to the top-right corner of the page: on the desktop, it's next to the edit button; on the phone that's next to the hamburger menu. This follows the left-to-right design layout that suggests the language selector should be in the top-right corner of the page, that's where people intuitively would look for it

Test: The responsiveness and consistency of the component across all screen resolution, and also ascertain how intuitive the change truly is to design layout.

Previous: 
![ocaml-prev](https://user-images.githubusercontent.com/60588809/113017476-636aa000-9177-11eb-9a8d-1275209e7ebf.png)

Recent: 
![ocaml-recent](https://user-images.githubusercontent.com/60588809/113017520-71b8bc00-9177-11eb-9823-11d44f478396.png)
