### PR TITLE
UI fixes: Fix footer website link and no-opener external links as best practice

### DIFF
--- a/site/index.fr.md
+++ b/site/index.fr.md
@@ -41,7 +41,7 @@
                     <p><a href="docs/install.fr.html" >Installer</a> OCaml,
 					trouver des <a href="https://opam.ocaml.org/packages/">docs de paquets</a>, accéder au
 					<a href="/releases/latest/manual.html"
-					target="_blank"
+					target="_blank" rel="noopener"
 					>Manuel</a>, obtenir <a href="/docs/cheat_sheets.html">des mémentos</a> et <a href="/docs/index.fr.html">bien plus</a>.</p>
                 </section>
             </div>
@@ -73,7 +73,7 @@
             </div>
             <div id="home-learn">
 			     <a href="https://discuss.ocaml.org/"
-                   target="_blank"
+                   target="_blank" rel="noopener"
 			      ><img src="/img/chat.svg" alt="chat" class="svg"
                     style="width: 4ex;" />
                    <img src="/img/chat.png" alt="chat" class="png"

--- a/site/index.md
+++ b/site/index.md
@@ -73,7 +73,7 @@
             </div>
             <div id="home-learn">
 			     <a href="https://discuss.ocaml.org/"
-                   target="_blank"
+                   target="_blank" rel="noopener"
 			      ><img src="/img/chat.svg" alt="chat" class="svg"
                     style="width: 4ex;" />
                    <img src="/img/chat.png" alt="chat" class="png"

--- a/site/learn/description.md
+++ b/site/learn/description.md
@@ -6,7 +6,7 @@
 <div style="float:right; width: 35%; padding-left: 2ex; text-decoration: none">
   <a
   href="https://www.infoq.com/presentations/ocaml-browser-iot?utm_source=twitter&utm_medium=link&utm_campaign=qcon"
-  target="_blank" ><img src="/img/QCon1805.png" />
+  target="_blank" rel="noopener"><img src="/img/QCon1805.png" />
   <br/>Fast, Flexible and Functional Programming with OCaml,
   Gemma Gordon and Anil Madhavapeddy
   </a>

--- a/site/learn/index.fr.md
+++ b/site/learn/index.fr.md
@@ -75,9 +75,9 @@ OCaml est un langage générique de programmation, de puissance industrielle, qu
          >réunion annuelle des développeurs OCaml 2014</a>
          à Gothenburg, Suède
 		 (<a href="/meetings/ocaml/2014/OCaml2014-Leroy-slides.pdf"
-		 target="_blank">en PDF</a>,
+		 target="_blank" rel="noopener">en PDF</a>,
          <a href="https://www.youtube.com/watch?v=DMzZy1bqj6Q&list=UUP9g4dLR7xt6KzCYntNqYcw"
-         target="_blank">Vidéo</a>).
+         target="_blank" rel="noopener">Vidéo</a>).
 		 </p>
 	  <p class="documentation-video video16-9"
 	     style="padding-bottom: 50%"><!-- Adjust => avoid horiz bars -->
@@ -141,7 +141,7 @@ OCaml est un langage générique de programmation, de puissance industrielle, qu
 	       >Unison</a> est un synchroniseur de fichiers innovant, basé
 	       sur
 	       <a href="http://www.cis.upenn.edu/~bcpierce/papers/index.shtml#Synchronization"
-		  target="_blank"
+		  target="_blank" rel="noopener"
 		  >la plus récente recherche</a>. Il tolère les pannes
 	       et fonctionne aussi bien sous Windows que sous la plupart
 	       des variantes d'Unix, en incluant MacOSX.

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -72,7 +72,7 @@
         <section class="span4 condensed">
           <h1 class="ruled"><a href="/community/media.html">Online Courses, Slides &amp; Videos</a></h1>
 
-<iframe title="A massive open online course on OCaml" frameborder="0" width="380" height="220" src="//www.dailymotion.com/embed/video/x2ymo3x" style="max-width: 100%;" allowfullscreen></iframe><br /><a href="//www.dailymotion.com/video/x2ymo3x_fun-mooc-introduction-to-functional-programming-in-ocaml_school" target="_blank"> A massive open online course (MOOC) entirely centered around OCaml</a> <i>is now available, and runs once a year!</i>
+<iframe title="A massive open online course on OCaml" frameborder="0" width="380" height="220" src="//www.dailymotion.com/embed/video/x2ymo3x" style="max-width: 100%;" allowfullscreen></iframe><br /><a href="//www.dailymotion.com/video/x2ymo3x_fun-mooc-introduction-to-functional-programming-in-ocaml_school" target="_blank" rel="noopener"> A massive open online course (MOOC) entirely centered around OCaml</a> <i>is now available, and runs once a year!</i>
 	  <p>
           Learn more, and <a href="https://www.fun-mooc.fr/courses/course-v1:parisdiderot+56002+session03/about">register now on the FUN platform!</a>
 	  </p>
@@ -85,9 +85,9 @@
 		  <a href="/meetings/ocaml/2014/" >OCaml Users and Developers
 		  Workshop 2014</a> in Gothenburg, Sweden
 			(<a href="/meetings/ocaml/2014/OCaml2014-Leroy-slides.pdf"
-			target="_blank">PDF slides</a>,
+			target="_blank" rel="noopener">PDF slides</a>,
             <a href="https://www.youtube.com/watch?v=DMzZy1bqj6Q&list=UUP9g4dLR7xt6KzCYntNqYcw"
-            target="_blank">Video</a>).
+            target="_blank" rel="noopener">Video</a>).
 			</p>
 	  <p class="documentation-video video16-9"
 	     style="padding-bottom: 50%"><!-- Adjust => avoid horiz bars -->
@@ -148,7 +148,7 @@
 	       >Unison</a> is an innovative <em>two-way</em>
 	    file synchronizer stemming from the
 	       <a href="http://www.cis.upenn.edu/~bcpierce/papers/index.shtml#Synchronization"
-		  target="_blank"
+		  target="_blank" rel="noopener"
 		  >latest research</a>.  It is resilient to failures
 	       and  runs on Windows as well as most flavors of Unix,
 	       including MacOSX.

--- a/site/platform/index.md
+++ b/site/platform/index.md
@@ -25,37 +25,37 @@
             <ul class="news-feed">
                 <li>
                     <article>
-                        <h1><a href="https://opam.ocaml.org/" target="_blank">Opam</a></h1>
+                        <h1><a href="https://opam.ocaml.org/" target="_blank" rel="noopener">Opam</a></h1>
                         <p>A source-based OCaml package manager</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml/dune" target="_blank">Dune</a></h1>
+                        <h1><a href="https://github.com/ocaml/dune" target="_blank" rel="noopener">Dune</a></h1>
                         <p>A build tool that has been widely adopted in the OCaml ecosystem</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml-ppx/ppxlib" target="_blank">Ppxlib</a></h1>
+                        <h1><a href="https://github.com/ocaml-ppx/ppxlib" target="_blank" rel="noopener">Ppxlib</a></h1>
                         <p>A collection of useful tools for writing PPX libraries</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml-community/utop" target="_blank">UTOP</a></h1>
+                        <h1><a href="https://github.com/ocaml-community/utop" target="_blank" rel="noopener">UTOP</a></h1>
                         <p>OCaml's Universal Top Level</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml-opam/opam-publish" target="_blank">Opam-publish</a></h1>
+                        <h1><a href="https://github.com/ocaml-opam/opam-publish" target="_blank" rel="noopener">Opam-publish</a></h1>
                         <p>A tool for publishing packages to the opam repository</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml/merlin" target="_blank">Merlin</a></h1>
+                        <h1><a href="https://github.com/ocaml/merlin" target="_blank" rel="noopener">Merlin</a></h1>
                         <p>Context sensitive completion for OCaml in Vim and Emacs</p>
                     </article>
                 </li>
@@ -66,37 +66,37 @@
             <ul class="news-feed">
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml/odoc" target="_blank">Odoc</a></h1>
+                        <h1><a href="https://github.com/ocaml/odoc" target="_blank" rel="noopener">Odoc</a></h1>
                         <p>Documentation generator for OCaml</p>
                     </article>
                 </li>   
                 <li>
                     <article>
-                        <h1><a href="https://github.com/realworldocaml/mdx" target="_blank">Mdx</a></h1>
+                        <h1><a href="https://github.com/realworldocaml/mdx" target="_blank" rel="noopener">Mdx</a></h1>
                         <p>Executable code blocks in your markdown</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml/ocaml-lsp" target="_blank">Lsp-server</a></h1>
+                        <h1><a href="https://github.com/ocaml/ocaml-lsp" target="_blank" rel="noopener">Lsp-server</a></h1>
                         <p>an OCaml implementation of the Language Server Protocol (LSP)</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml-ppx/ocamlformat" target="_blank">OCamlformat</a></h1>
+                        <h1><a href="https://github.com/ocaml-ppx/ocamlformat" target="_blank" rel="noopener">OCamlformat</a></h1>
                         <p>Enforcing styles on an OCaml project</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocamllabs/dune-release" target="_blank">Dune-release</a></h1>
+                        <h1><a href="https://github.com/ocamllabs/dune-release" target="_blank" rel="noopener">Dune-release</a></h1>
                         <p>A CLI tool for easier packaging and publishing with opam, dune and Github</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/yomimono/ocaml-bun" target="_blank">Bun</a></h1>
+                        <h1><a href="https://github.com/yomimono/ocaml-bun" target="_blank" rel="noopener">Bun</a></h1>
                         <p>A CLI tool making fuzz testing easier</p>
                     </article>
                 </li>
@@ -109,25 +109,25 @@
             <ul class="news-feed">
                 <li>
                     <article>
-                        <h1><a href="https://github.com/OCamlPro/ocp-indent" target="_blank">Ocp-indent</a></h1>
+                        <h1><a href="https://github.com/OCamlPro/ocp-indent" target="_blank" rel="noopener">Ocp-indent</a></h1>
                         <p>An indentation tool for OCaml</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml-ppx/ocaml-migrate-parsetree" target="_blank">Omp</a></h1>
+                        <h1><a href="https://github.com/ocaml-ppx/ocaml-migrate-parsetree" target="_blank" rel="noopener">Omp</a></h1>
                         <p>A conversion tool for major version of the OCaml parsetree</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml/ocamlbuild" target="_blank">OCamlbuild</a></h1>
+                        <h1><a href="https://github.com/ocaml/ocamlbuild" target="_blank" rel="noopener">OCamlbuild</a></h1>
                         <p>A build tool for OCaml programs</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml/ocamlfind" target="_blank">OCamlfind</a></h1>
+                        <h1><a href="https://github.com/ocaml/ocamlfind" target="_blank" rel="noopener">OCamlfind</a></h1>
                         <p>A library manager for OCaml packages</p>
                     </article>
                 </li>
@@ -138,13 +138,13 @@
             <ul class="news-feed">
                 <li>
                     <article>
-                        <h1><a href="https://github.com/ocaml/oasis" target="_blank">Oasis</a></h1>
+                        <h1><a href="https://github.com/ocaml/oasis" target="_blank" rel="noopener">Oasis</a></h1>
                         <p>A build tool for OCaml programs</p>
                     </article>
                 </li>
                 <li>
                     <article>
-                        <h1><a href="https://github.com/camlp4/camlp4" target="_blank">Camlp4</a></h1>
+                        <h1><a href="https://github.com/camlp4/camlp4" target="_blank" rel="noopener">Camlp4</a></h1>
                         <p>A tool for writing extensible parsers</p>
                     </article>
                 </li>

--- a/template/footer.mpp
+++ b/template/footer.mpp
@@ -32,7 +32,7 @@
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/community/planet/" !}}" >{{! cmd script/translate ((! get filename !)) "News" !}}</a></li>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/community/support.html" !}}">{{! cmd script/translate ((! get filename !)) "Support" !}}</a></li>
       <li><a href="http://caml.inria.fr/mantis/my_view_page.php"
-	     target="_blank" >{{! cmd script/translate ((! get filename !)) "Bug Tracker" !}}</a></li>
+	     target="_blank" rel="noopener">{{! cmd script/translate ((! get filename !)) "Bug Tracker" !}}</a></li>
     </ul>
   </div>
 </div>
@@ -40,16 +40,15 @@
 {{!c else <div
      class="column">
   <div class="entry">
-    <h1>{{! cmd script/translate ((! get filename !)) Website !}}</h1>
+    <h1><a href="{{! cmd script/link_of_lang ((! get filename !)) "/" !}}">{{! cmd script/translate ((! get filename !)) Website !}}</a></h1>
     <ul>
       <li><a href="https://github.com/ocaml/ocaml.org/tree/master/((! tryget filename !))"
-	     target="_blank"
-	     >{{! cmd script/translate ((! get filename !)) "Edit this page" !}}</a></li>
+	     target="_blank" rel="noopener">{{! cmd script/translate ((! get filename !)) "Edit this page" !}}</a></li>
       <li><a href="https://github.com/ocaml/ocaml.org/issues"
-	     target="_blank" >{{! cmd script/translate ((! get filename !)) "Website Issues" !}}</a></li>
+	     target="_blank" rel="noopener">{{! cmd script/translate ((! get filename !)) "Website Issues" !}}</a></li>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/about.html" !}}" >{{! cmd script/translate ((! get filename !)) "About This Site" !}}</a></li>
     <li><a href="https://github.com/ocaml/ocaml.org/"
-	   target="_blank" >{{! cmd script/translate ((! get filename !)) "Find Us on GitHub" !}}</a></li>
+	   target="_blank" rel="noopener">{{! cmd script/translate ((! get filename !)) "Find Us on GitHub" !}}</a></li>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/contributors.html" !}}" >{{! cmd script/translate ((! get filename !)) "Credits" !}}</a></li>
     </ul>
   </div>


### PR DESCRIPTION
Patch: Changed the website text on the footer to be a link to the home page of the website to sync with other headers. Also added ` rel="noopener" ` to all external links with target set "_blank" just as best practice.

This PR Resolves #1313 