### PR TITLE
scripts/http: error input_value: not_a_binary_channel [Windows]

### DIFF
--- a/script/http.ml
+++ b/script/http.ml
@@ -93,7 +93,7 @@ let get ?(cache_secs=cache_secs) url =
   let fn = Filename.concat (Filename.get_temp_dir_name ()) ("ocamlorg-" ^ md5) in
   eprintf "Downloading %s ... %!" url;
   let get_from_cache () =
-    let fh = open_in fn in
+    let fh = open_in_bin fn in
     let data = input_value fh in
     close_in fh;
     eprintf "done.\n  (using cache %s, updated %s ago).\n%!"
@@ -104,7 +104,7 @@ let get ?(cache_secs=cache_secs) url =
     try
       let data = http_get url in
       eprintf "done %!";
-      let fh = open_out fn in
+      let fh = open_out_bin fn in
       output_value fh data;
       close_out fh;
       eprintf "(cached).\n%!";


### PR DESCRIPTION
This is addressing a windows only failure in the HTTP module.
You can see the error in the screenshot below

![](https://aws1.discourse-cdn.com/standard11/uploads/ocaml/original/2X/b/bbd04edf362edf019c7830a9b723c82ebc3eb850.png)

The compilation failure on windows is due to incompatibility with non-binary channels.

The issue was reported [here](https://discuss.ocaml.org/t/error-while-trying-to-set-up-ocaml-project-on-windows-10-via-cygwin-terminal/7567/12) and triaged [here](https://discuss.ocaml.org/t/error-while-trying-to-set-up-ocaml-project-on-windows-10-via-cygwin-terminal/7567/13).

Tested locally on mac, which did not and keep not having issues. Would be nice if somebody can actually test it on windows.
Feel free to close it if it is not relevant, I have decided to send the patch to ease the onboarding for the outreachy participants by trying to minimise potential setup issues.