### PR TITLE
script/http: don't leak response body

### DIFF
--- a/script/http.ml
+++ b/script/http.ml
@@ -34,7 +34,7 @@ let rec http_get_and_follow ~max_redirects uri =
 and follow_redirect ~max_redirects request_uri (response, body) =
   let open Lwt in
   let status = Cohttp.Response.status response in
-  (* The uncosumed body would otherwise leak memory *)
+  (* The unconsumed body would otherwise leak memory *)
   if status <> `OK then Lwt.ignore_result (Cohttp_lwt.Body.drain_body body);
   match status with
   | `OK -> Lwt.return (response, body)


### PR DESCRIPTION
With the port to cohttp 4.0 I had not noticed the appearance of many warnings about 'Cohttp_lwt: body not consumed - leaking stream!'. This commit ensures that unused response bodies are drained before following the redirects or logging errors and are not leaked.

See https://github.com/mirage/ocaml-cohttp/issues/730 for more details and the reference to the PR introducing the leak check.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>