### PR TITLE
Update ocamlorg.css

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -484,7 +484,7 @@ ul.translations:after { content: "]"; }
  ***********************************************************************/
 /* Footer */
 #footer {
-  font-size: 95%;
+  font-size: 104%;
   margin-top: 4ex;
   margin-bottom: 0;
   height: auto;
@@ -503,8 +503,8 @@ ul.translations:after { content: "]"; }
   }
   #footer .column {
     text-align: left;
-    padding-left: 10%;
     padding-right: 5%;
+    width: 41%;
   }
 }
 @media (max-width: 480px) {
@@ -519,7 +519,7 @@ ul.translations:after { content: "]"; }
 }
 
 #footer h1 {
-  font-size: 109%;
+  font-size: 31px;
   font-weight: bold;
   margin-bottom: 0;
 }


### PR DESCRIPTION
footer heading size gets larger and text size has also changed and footer is aligned in two column for screen size 767px

# Issue Description

Please include a summary of the issue.

Fixes # (issue)

## Changes Made

Please describe the changes that you made.

* **Please check if the PR fulfills these requirements**

- [ ] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
