### PR TITLE
Added context to links in header and footer 

### DIFF
--- a/template/footer.mpp
+++ b/template/footer.mpp
@@ -12,7 +12,7 @@
 </div>
 <div class="column">
   <div class="entry">
-    <h1><a title="Official Documentation for Ocaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></h1>
+    <h1><a title="Official Documentation for OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></h1>
     <ul>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) /docs/install.html !}}">{{! cmd script/translate ((! get filename !)) "Install" !}}</a></li>
       <li><a href="http://caml.inria.fr/pub/docs/manual-ocaml/">{{! cmd script/translate ((! get filename !)) "Manual" !}}</a></li>

--- a/template/footer.mpp
+++ b/template/footer.mpp
@@ -1,7 +1,7 @@
 <!-- footer							-*-html-*- -->
 <div class="column">
   <div class="entry">
-    <h1><a alt="Beginner's guide to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/" !}}">{{! cmd script/translate ((! get filename !)) Learn !}}</a></h1>
+    <h1><a title="Beginner's guide to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/" !}}">{{! cmd script/translate ((! get filename !)) Learn !}}</a></h1>
     <ul>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/taste.html" !}}" >{{! cmd script/translate ((! get filename !)) "Code Examples" !}}</a></li>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/tutorials/" !}}">{{! cmd script/translate ((! get filename !)) "Tutorials" !}}</a></li>
@@ -12,7 +12,7 @@
 </div>
 <div class="column">
   <div class="entry">
-    <h1><a alt="Official Documentation for Ocaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></h1>
+    <h1><a title="Official Documentation for Ocaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></h1>
     <ul>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) /docs/install.html !}}">{{! cmd script/translate ((! get filename !)) "Install" !}}</a></li>
       <li><a href="http://caml.inria.fr/pub/docs/manual-ocaml/">{{! cmd script/translate ((! get filename !)) "Manual" !}}</a></li>
@@ -25,7 +25,7 @@
 </div>
 <div class="column">
   <div class="entry">
-    <h1><a alt="To contribute to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/" !}}">{{! cmd script/translate ((! get filename !)) Community !}}</a></h1>
+    <h1><a title="To contribute to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/" !}}">{{! cmd script/translate ((! get filename !)) Community !}}</a></h1>
     <ul>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/community/mailing_lists.html" !}}">{{! cmd script/translate ((! get filename !)) "Mailing Lists" !}}</a></li>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/meetings/" !}}" >{{! cmd script/translate ((! get filename !)) "Meetings" !}}</a></li>

--- a/template/footer.mpp
+++ b/template/footer.mpp
@@ -1,7 +1,7 @@
 <!-- footer							-*-html-*- -->
 <div class="column">
   <div class="entry">
-    <h1><a href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/" !}}">{{! cmd script/translate ((! get filename !)) Learn !}}</a></h1>
+    <h1><a alt="Beginner's guide to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/" !}}">{{! cmd script/translate ((! get filename !)) Learn !}}</a></h1>
     <ul>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/taste.html" !}}" >{{! cmd script/translate ((! get filename !)) "Code Examples" !}}</a></li>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/tutorials/" !}}">{{! cmd script/translate ((! get filename !)) "Tutorials" !}}</a></li>
@@ -12,7 +12,7 @@
 </div>
 <div class="column">
   <div class="entry">
-    <h1><a href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></h1>
+    <h1><a alt="Official Documentation for Ocaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></h1>
     <ul>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) /docs/install.html !}}">{{! cmd script/translate ((! get filename !)) "Install" !}}</a></li>
       <li><a href="http://caml.inria.fr/pub/docs/manual-ocaml/">{{! cmd script/translate ((! get filename !)) "Manual" !}}</a></li>
@@ -25,7 +25,7 @@
 </div>
 <div class="column">
   <div class="entry">
-    <h1><a href="{{! cmd script/link_of_lang ((! get filename !)) "/community/" !}}">{{! cmd script/translate ((! get filename !)) Community !}}</a></h1>
+    <h1><a alt="To contribute to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/" !}}">{{! cmd script/translate ((! get filename !)) Community !}}</a></h1>
     <ul>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/community/mailing_lists.html" !}}">{{! cmd script/translate ((! get filename !)) "Mailing Lists" !}}</a></li>
       <li><a href="{{! cmd script/link_of_lang ((! get filename !)) "/meetings/" !}}" >{{! cmd script/translate ((! get filename !)) "Meetings" !}}</a></li>

--- a/template/navbar.mpp
+++ b/template/navbar.mpp
@@ -1,7 +1,7 @@
             <ul class="nav">
-              <li ((! ifdef learn class="active" !))><a alt=" Beginner's guide to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/" !}}">{{! cmd script/translate ((! get filename !)) Learn !}}</a></li>
-              <li ((! ifdef documentation class="active" !))><a alt="Official Documentation for Ocaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></li>
-              <li ((! ifdef packages class="active" !))><a alt="Documentation for OCaml Packages" href="https://opam.ocaml.org/">{{! cmd script/translate ((! get filename !)) Packages !}}</a></li>
-              <li ((! ifdef community class="active" !))><a alt="To Contribute to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/" !}}">{{! cmd script/translate ((! get filename !)) Community !}}</a></li>
-              <li ((! ifdef news class="active" !))><a alt="Blogs and News" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/planet/" !}}">{{! cmd script/translate ((! get filename !)) News !}}</a></li>
+              <li ((! ifdef learn class="active" !))><a title=" Beginner's guide to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/" !}}">{{! cmd script/translate ((! get filename !)) Learn !}}</a></li>
+              <li ((! ifdef documentation class="active" !))><a title="Official Documentation for Ocaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></li>
+              <li ((! ifdef packages class="active" !))><a title="Documentation for OCaml Packages" href="https://opam.ocaml.org/">{{! cmd script/translate ((! get filename !)) Packages !}}</a></li>
+              <li ((! ifdef community class="active" !))><a title="To Contribute to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/" !}}">{{! cmd script/translate ((! get filename !)) Community !}}</a></li>
+              <li ((! ifdef news class="active" !))><a title="Blogs and News" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/planet/" !}}">{{! cmd script/translate ((! get filename !)) News !}}</a></li>
             </ul>

--- a/template/navbar.mpp
+++ b/template/navbar.mpp
@@ -1,5 +1,5 @@
             <ul class="nav">
-              <li ((! ifdef learn class="active" !))><a title=" Beginner's guide to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/" !}}">{{! cmd script/translate ((! get filename !)) Learn !}}</a></li>
+              <li ((! ifdef learn class="active" !))><a title="Beginner's guide to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/" !}}">{{! cmd script/translate ((! get filename !)) Learn !}}</a></li>
               <li ((! ifdef documentation class="active" !))><a title="Official Documentation for Ocaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></li>
               <li ((! ifdef packages class="active" !))><a title="Documentation for OCaml Packages" href="https://opam.ocaml.org/">{{! cmd script/translate ((! get filename !)) Packages !}}</a></li>
               <li ((! ifdef community class="active" !))><a title="To Contribute to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/" !}}">{{! cmd script/translate ((! get filename !)) Community !}}</a></li>

--- a/template/navbar.mpp
+++ b/template/navbar.mpp
@@ -1,6 +1,6 @@
             <ul class="nav">
               <li ((! ifdef learn class="active" !))><a title="Beginner's guide to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/" !}}">{{! cmd script/translate ((! get filename !)) Learn !}}</a></li>
-              <li ((! ifdef documentation class="active" !))><a title="Official Documentation for Ocaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></li>
+              <li ((! ifdef documentation class="active" !))><a title="Official Documentation for OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></li>
               <li ((! ifdef packages class="active" !))><a title="Documentation for OCaml Packages" href="https://opam.ocaml.org/">{{! cmd script/translate ((! get filename !)) Packages !}}</a></li>
               <li ((! ifdef community class="active" !))><a title="To Contribute to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/" !}}">{{! cmd script/translate ((! get filename !)) Community !}}</a></li>
               <li ((! ifdef news class="active" !))><a title="Blogs and News" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/planet/" !}}">{{! cmd script/translate ((! get filename !)) News !}}</a></li>

--- a/template/navbar.mpp
+++ b/template/navbar.mpp
@@ -1,7 +1,7 @@
             <ul class="nav">
-              <li ((! ifdef learn class="active" !))><a href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/" !}}">{{! cmd script/translate ((! get filename !)) Learn !}}</a></li>
-              <li ((! ifdef documentation class="active" !))><a href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></li>
-              <li ((! ifdef packages class="active" !))><a href="https://opam.ocaml.org/">{{! cmd script/translate ((! get filename !)) Packages !}}</a></li>
-              <li ((! ifdef community class="active" !))><a href="{{! cmd script/link_of_lang ((! get filename !)) "/community/" !}}">{{! cmd script/translate ((! get filename !)) Community !}}</a></li>
-              <li ((! ifdef news class="active" !))><a href="{{! cmd script/link_of_lang ((! get filename !)) "/community/planet/" !}}">{{! cmd script/translate ((! get filename !)) News !}}</a></li>
+              <li ((! ifdef learn class="active" !))><a alt=" Beginner's guide to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/learn/" !}}">{{! cmd script/translate ((! get filename !)) Learn !}}</a></li>
+              <li ((! ifdef documentation class="active" !))><a alt="Official Documentation for Ocaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/docs/" !}}">{{! cmd script/translate ((! get filename !)) Documentation !}}</a></li>
+              <li ((! ifdef packages class="active" !))><a alt="Documentation for OCaml Packages" href="https://opam.ocaml.org/">{{! cmd script/translate ((! get filename !)) Packages !}}</a></li>
+              <li ((! ifdef community class="active" !))><a alt="To Contribute to OCaml" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/" !}}">{{! cmd script/translate ((! get filename !)) Community !}}</a></li>
+              <li ((! ifdef news class="active" !))><a alt="Blogs and News" href="{{! cmd script/link_of_lang ((! get filename !)) "/community/planet/" !}}">{{! cmd script/translate ((! get filename !)) News !}}</a></li>
             </ul>


### PR DESCRIPTION
# Issue Description
Fixes #1327 
The text "Learn" in the nav-bar and the footer is unclear without context and may be confusing to screen readers. You can add a special screen reader text than can help with accessibility.
 If there's alt text that can help provide context for screen readers it will make the link more accessible.

## Summary of the issue.
The current code is not friendly to screen readers. The texts in the nav-bar and footer does not have context. 

## Changes Made
Although the issue focused on "Learn", I've fixed the other texts in the nav-bar and footer as well.
* **I have added relevant alt text to each text in the nav-bar and footer**

