### PR TITLE
google+ links removed

### DIFF
--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -382,9 +382,7 @@ let html_of_post e =
                      "title", "Go to the original post"] in
        let post =
          Netencoding.Url.encode (planet_full_url ^ "#" ^ title_anchor) in
-       let google = ["href", "https://plus.google.com/share?url="
-                             ^ (Netencoding.Url.encode url_orig);
-                     "target", "_blank"; "title", "Share on Google+"] in
+
        let fb = ["href", "https://www.facebook.com/share.php?u=" ^ post
                          ^ "&amp;t=" ^ (Netencoding.Url.encode title);
                  "target", "_blank"; "title", "Share on Facebook"] in
@@ -407,9 +405,7 @@ let html_of_post e =
                 Element("a", a_args,
                         [Element("img", ["src", "/img/chain-link-icon.png";
                                          "alt", ""], []) ])
-                :: Element("a", ("class", "googleplus") :: google,
-                           [Element("img", ["src", "/img/googleplus.png";
-                                            "alt", "Google+"], []) ])
+
                 :: Element("a", ("class", "facebook") :: fb,
                            [Element("img", ["src", "/img/facebook.png";
                                             "alt", "FB"], []) ])


### PR DESCRIPTION
# Removed outdated google+ links from the News page.



Fixes #1319

## Before
![beforenews](https://user-images.githubusercontent.com/63343906/113406809-c3588500-93c9-11eb-82e3-acddf7d76da0.png)

##After
![news](https://user-images.githubusercontent.com/63343906/113406852-d3706480-93c9-11eb-9508-d7f3157b4d0b.PNG)




* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
