### PR TITLE
Improved Videos section in https://ocaml.org/learn/ and https://ocaml.org/docs/

### DIFF
--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -170,7 +170,7 @@
       <div class="row">
 	<div class="span4">
 	  <p class="documentation-video">
-	    <iframe width="310" height="175" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" title="In this talk, Mark Shinwell explains how to track down hard-to-find bugs in OCaml programs" allowfullscreen></iframe>
+	    <iframe width="310" height="233" src="//www.youtube.com/embed/NF2WpWnB-nk?feature=player_detailpage" title="In this talk, Mark Shinwell explains how to track down hard-to-find bugs in OCaml programs" allowfullscreen></iframe>
 	  </p>
 	  <p>In this talk, Mark Shinwell explains how to
 	    track down hard-to-find bugs in OCaml programs.

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -77,25 +77,21 @@
           Learn more, and <a href="https://www.fun-mooc.fr/courses/course-v1:parisdiderot+56002+session03/about">register now on the FUN platform!</a>
 	  </p>
 		  <p class="documentation-video" style="margin-bottom:0">
-<iframe title="Xavier Leroy presents the state of OCaml 4.02" src="//www.slideshare.net/slideshow/embed_code/43836300" width="340" height="290" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
+<iframe title="Xavier Leroy presents the state of OCaml 4.02" src="//www.slideshare.net/slideshow/embed_code/43836300" width="380" height="220" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
           </p>
 
-          <p>An invited talk by Xavier Leroy explaining the current state
-		  of OCaml at the
+<p>An invited talk by Xavier Leroy explaining the current state of OCaml at the
 		  <a href="/meetings/ocaml/2014/" >OCaml Users and Developers
 		  Workshop 2014</a> in Gothenburg, Sweden
 			(<a href="/meetings/ocaml/2014/OCaml2014-Leroy-slides.pdf"
 			target="_blank">PDF slides</a>,
             <a href="https://www.youtube.com/watch?v=DMzZy1bqj6Q&list=UUP9g4dLR7xt6KzCYntNqYcw"
             target="_blank">Video</a>).
-			</p>
-	  <p class="documentation-video video16-9"
-	     style="padding-bottom: 50%"><!-- Adjust => avoid horiz bars -->
-	    <iframe title="Yaron Minsky explains how to program effectively in ML" src="//player.vimeo.com/video/14313378?portrait=0&amp;color=ff9933"
-		    frameborder="0" webkitallowfullscreen
-		    mozallowfullscreen allowfullscreen></iframe>
-	  </p>
-			<p>A guest lecture given by Yaron Minsky of Jane Street about how to program effectively in ML. The talk was given as part of the intro computer science class at Harvard, CS51, where the students had spent much of the semester programming in OCaml.</p>
+	</p>
+	  <p style="margin-bottom:0; margin-top: 6px"><!-- Adjust => avoid horiz bars -->
+	    <iframe title="Yaron Minsky explains how to program effectively in ML" src="//player.vimeo.com/video/14313378?portrait=0&amp;color=ff9933" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen width="380" height="220" style="max-width: 100%;" marginwidth="0" marginheight="0" scrolling="no"></iframe>
+	 </p>
+	<p>A guest lecture given by Yaron Minsky of Jane Street about how to program effectively in ML. The talk was given as part of the intro computer science class at Harvard, CS51, where the students had spent much of the semester programming in OCaml.</p>
           <footer>
             <p>
               <a href="/community/media.html">See more slides and videos</a></p>

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -80,18 +80,21 @@
 <iframe title="Xavier Leroy presents the state of OCaml 4.02" src="//www.slideshare.net/slideshow/embed_code/43836300" width="380" height="220" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe>
           </p>
 
-<p>An invited talk by Xavier Leroy explaining the current state of OCaml at the
+          <p>An invited talk by Xavier Leroy explaining the current state
+		  of OCaml at the
 		  <a href="/meetings/ocaml/2014/" >OCaml Users and Developers
 		  Workshop 2014</a> in Gothenburg, Sweden
 			(<a href="/meetings/ocaml/2014/OCaml2014-Leroy-slides.pdf"
 			target="_blank">PDF slides</a>,
             <a href="https://www.youtube.com/watch?v=DMzZy1bqj6Q&list=UUP9g4dLR7xt6KzCYntNqYcw"
             target="_blank">Video</a>).
-	</p>
-	  <p style="margin-bottom:0; margin-top:6px"><!-- Adjust => avoid horiz bars -->
-	    <iframe title="Yaron Minsky explains how to program effectively in ML" src="//player.vimeo.com/video/14313378?portrait=0&amp;color=ff9933" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen width="380" height="220" style="max-width: 100%;" marginwidth="0" marginheight="0" scrolling="no"></iframe>
-	 </p>
-	<p>A guest lecture given by Yaron Minsky of Jane Street about how to program effectively in ML. The talk was given as part of the intro computer science class at Harvard, CS51, where the students had spent much of the semester programming in OCaml.</p>
+			</p>
+	  <p style="margin-bottom:0; margin-top: 6px"><!-- Adjust => avoid horiz bars -->
+	    <iframe title="Yaron Minsky explains how to program effectively in ML" src="//player.vimeo.com/video/14313378?portrait=0&amp;color=ff9933"
+		    frameborder="0" webkitallowfullscreen
+		    mozallowfullscreen allowfullscreen width="380" height="220" style="max-width: 100%;" marginwidth="0" marginheight="0" scrolling="no" ></iframe>
+	  </p>
+			<p>A guest lecture given by Yaron Minsky of Jane Street about how to program effectively in ML. The talk was given as part of the intro computer science class at Harvard, CS51, where the students had spent much of the semester programming in OCaml.</p>
           <footer>
             <p>
               <a href="/community/media.html">See more slides and videos</a></p>

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -88,7 +88,7 @@
             <a href="https://www.youtube.com/watch?v=DMzZy1bqj6Q&list=UUP9g4dLR7xt6KzCYntNqYcw"
             target="_blank">Video</a>).
 	</p>
-	  <p style="margin-bottom:0; margin-top: 6px"><!-- Adjust => avoid horiz bars -->
+	  <p style="margin-bottom:0; margin-top:6px"><!-- Adjust => avoid horiz bars -->
 	    <iframe title="Yaron Minsky explains how to program effectively in ML" src="//player.vimeo.com/video/14313378?portrait=0&amp;color=ff9933" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen width="380" height="220" style="max-width: 100%;" marginwidth="0" marginheight="0" scrolling="no"></iframe>
 	 </p>
 	<p>A guest lecture given by Yaron Minsky of Jane Street about how to program effectively in ML. The talk was given as part of the intro computer science class at Harvard, CS51, where the students had spent much of the semester programming in OCaml.</p>


### PR DESCRIPTION
## Issue Description
On screen sizes less than 764px, when we navigate to Learn and docs section, the videos are not aligned properly.

Fixes # (1367)

## Changes Made
Earlier the videos and slides section in learn and docs section looked like-
![image](https://user-images.githubusercontent.com/53967592/113427831-5f4ab680-93f3-11eb-86ae-af4999fb7304.png)

![image](https://user-images.githubusercontent.com/53967592/113427850-67a2f180-93f3-11eb-8991-e58d2d109398.png)

After changes-
![image](https://user-images.githubusercontent.com/53967592/113427879-75f10d80-93f3-11eb-81f1-90074998e171.png)

![image](https://user-images.githubusercontent.com/53967592/113427896-7e494880-93f3-11eb-9dfa-3d366b2f3d8b.png)
