### PR TITLE
Improved footer on tablet view

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -48,23 +48,23 @@
     background-color:lightgray;
 }
 
-#opamdoc-contents .expander { 
-  width:1.5em; 
-  height:1.5em; 
-  border-radius:0.3em; 
-  font-weight: bold; 
-  font-family:Sans; 
-  line-height:16px; 
+#opamdoc-contents .expander {
+  width:1.5em;
+  height:1.5em;
+  border-radius:0.3em;
+  font-weight: bold;
+  font-family:Sans;
+  line-height:16px;
 }
 #opamdoc-contents .expanding_sig { border-spacing: 5px 1px }
 #opamdoc-contents .expanding_sig td { vertical-align: text-top }
-#opamdoc-contents .expanding_include_0 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_1 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_2 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_3 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_4 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_5 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_6 td { vertical-align: text-top } 
+#opamdoc-contents .expanding_include_0 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_1 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_2 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_3 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_4 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_5 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_6 td { vertical-align: text-top }
 #opamdoc-contents table.expanding_include_0, table.expanding_include_1, table.expanding_include_2, table.expanding_include_3,
 table.expanding_include_4, table.expanding_include_5, table.expanding_include_6 {
   border-top: thin dashed;
@@ -72,12 +72,12 @@ table.expanding_include_4, table.expanding_include_5, table.expanding_include_6 
   border-collapse: collapse;
 }
 #opamdoc-contents table.expanding_include_0 { background-color: #FFF5F5; }
-#opamdoc-contents table.expanding_include_1 { background-color: #F5F5FF; } 
-#opamdoc-contents table.expanding_include_2 { background-color: #F5FFF5; } 
-#opamdoc-contents table.expanding_include_3 { background-color: #FFF5FF; } 
-#opamdoc-contents table.expanding_include_4 { background-color: #FFFFF5; } 
-#opamdoc-contents table.expanding_include_5 { background-color: #F5FFFF; } 
-#opamdoc-contents table.expanding_include_6 { background-color: #FFF5EB; } 
+#opamdoc-contents table.expanding_include_1 { background-color: #F5F5FF; }
+#opamdoc-contents table.expanding_include_2 { background-color: #F5FFF5; }
+#opamdoc-contents table.expanding_include_3 { background-color: #FFF5FF; }
+#opamdoc-contents table.expanding_include_4 { background-color: #FFFFF5; }
+#opamdoc-contents table.expanding_include_5 { background-color: #F5FFFF; }
+#opamdoc-contents table.expanding_include_6 { background-color: #FFF5EB; }
 #opamdoc-contents td.edge_column { border-right: 3px solid lightgrey }
 
 /* end of section for opam-doc */
@@ -112,7 +112,7 @@ h1 code, h2 code, h3 code, h4 code, h5 code, h5 code { font-size: 80%; }
 .string .governing,
 .ocaml .st {
   color: #a95472;
-  font-weight: normal;  
+  font-weight: normal;
 }
 .warning { color : Red ; font-weight : bold }
 .info { margin-left : 3em; margin-right: 3em }
@@ -281,13 +281,13 @@ html.svg a.edit-this-page:hover {
   justify-content: flex-end;
 }
 
-/* 
+/*
 This styling overrides bootstrap style which removes outline
 when an element is in focus
 */
 a:focus{
   outline: 0.2rem solid #c77a27;
- 
+
  }
  .navbar .edit-this-page:focus{
    background-color: #6e5437;
@@ -543,13 +543,19 @@ ul.translations:after { content: "]"; }
   min-width: 22%;
   margin-right: 1em; /* To visually "compensate" for left alignment */
 }
+@media screen and (max-width: 767px) and (min-width: 480px) {
+  #footer .column{
+    min-width: 40%;
+    text-align: center;
+  }
+}
 @media (max-width: 767px) {
   #footer {
     margin-left: -20px;
     margin-right: -20px;
   }
   #footer .column {
-    text-align: left;
+    text-align: center;
     padding-right: 5%;
   }
 }
@@ -557,6 +563,7 @@ ul.translations:after { content: "]"; }
   #footer .column {
     width: 98%;
     margin-right: 0px;
+    text-align: left;
   }
 }
 #footer .entry {
@@ -565,7 +572,7 @@ ul.translations:after { content: "]"; }
 }
 
 #footer h1 {
-  font-size: 109%;
+  font-size: 130%;
   font-weight: bold;
   margin-bottom: 0;
 }

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -570,7 +570,9 @@ ul.translations:after { content: "]"; }
   display: inline-block;
   text-align: left;
 }
-
+footer div.navbar-inner{
+  padding-top: 20px;
+}
 #footer h1 {
   font-size: 130%;
   font-weight: bold;


### PR DESCRIPTION
# Issue Description
This a fix for #1338 
Please include a summary of the issue.
The content columns of the footer are not properly arranged on screen sizes between 767px and 481px
Fixes # (issue)
#1338 
## Changes Made
Made changes to the ocamlorg.css to adjust the columns on tablet view.
Please describe the changes that you made.
Change the footer CSS to display two columns per row on the mentioned screen sizes, increased the font size of the h1 elements of the footer.

Please describe the changes that you made.
The before and the after images

![before](https://user-images.githubusercontent.com/15726413/113473213-fea59300-945f-11eb-8149-2c13e942865a.PNG)
![after](https://user-images.githubusercontent.com/15726413/113473209-fa797580-945f-11eb-838e-268efa95ce4d.PNG)


* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
