### PR TITLE
Fixed Spacing of books in Learn/books.html

### DIFF
--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -382,9 +382,7 @@ let html_of_post e =
                      "title", "Go to the original post"] in
        let post =
          Netencoding.Url.encode (planet_full_url ^ "#" ^ title_anchor) in
-       let google = ["href", "https://plus.google.com/share?url="
-                             ^ (Netencoding.Url.encode url_orig);
-                     "target", "_blank"; "title", "Share on Google+"] in
+
        let fb = ["href", "https://www.facebook.com/share.php?u=" ^ post
                          ^ "&amp;t=" ^ (Netencoding.Url.encode title);
                  "target", "_blank"; "title", "Share on Facebook"] in
@@ -407,9 +405,7 @@ let html_of_post e =
                 Element("a", a_args,
                         [Element("img", ["src", "/img/chain-link-icon.png";
                                          "alt", ""], []) ])
-                :: Element("a", ("class", "googleplus") :: google,
-                           [Element("img", ["src", "/img/googleplus.png";
-                                            "alt", "Google+"], []) ])
+
                 :: Element("a", ("class", "facebook") :: fb,
                            [Element("img", ["src", "/img/facebook.png";
                                             "alt", "FB"], []) ])

--- a/site/learn/books.md
+++ b/site/learn/books.md
@@ -81,7 +81,7 @@ their skills, and to experienced programmers eager to explore functional
 languages such as OCaml. It is hoped that each reader will find something new,
 or see an old thing in a new light. For the more casual reader, or those who are
 used to a different functional language, a summary of basic OCaml is provided at
-the front of the book. 
+the front of the book.
 
 [Book Website](http://ocaml-book.com/more-ocaml-algorithms-methods-diversions/) |
 [Amazon](http://www.amazon.com/gp/product/0957671113)
@@ -552,6 +552,9 @@ last chapter a comprehensive description of the language kernel.
 
 [Emacs Org source](http://minimalprocedure.pragmas.org/writings/programmazione_funzionale/programmazione_funzionale.org) | [HTML](http://minimalprocedure.pragmas.org/writings/programmazione_funzionale/programmazione_funzionale.html) | [PDF](http://minimalprocedure.pragmas.org/writings/programmazione_funzionale/programmazione_funzionale.pdf)
 
+<br />
+<br />
+<br />
 ****
 
 ###  Introduzione alla programmazione funzionale


### PR DESCRIPTION
# Fixed Spacing of books in Learn/books.html (https://www.ocaml.org/learn/books.html)



Fixes # (1373)

## Before

![old3](https://user-images.githubusercontent.com/63343906/113473958-74265900-948a-11eb-8f76-6a421262f8d5.PNG)


## After

![new](https://user-images.githubusercontent.com/63343906/113473967-80aab180-948a-11eb-905d-c0eea5563f35.PNG)




* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
