### PR TITLE
Improved presentation of list of contributors

### DIFF
--- a/site/contributors.fr.md
+++ b/site/contributors.fr.md
@@ -4,7 +4,7 @@ Contributeurs
 =============
 
 Les contributeurs à ce site :
-<ul>
+<ul id="contributors_list">
 ((! cmd git log --format="%aN" | sort | uniq | awk '{print "<li>"$1,$2,$3"</li>"}' !))
 </ul>
 
@@ -17,35 +17,38 @@ Anciens contributeurs aux tutoriels
 Beaucoup des tutoriaux de ce site étaient à l'origine sur `ocaml-tutorial.org`.
 Voici la liste de ceux qui y ont contribué :
 
-* Doug Bagley
-* Daniel Bünzli
-* Nicolas Cannasse
-* Eric C. Cooper
-* Richard Donkin
-* Jim Farrand
-* Fabrice Le Fessant
-* Jacques Garrigue
-* Stephen Gilmore
-* Flavio Grossi
-* Damien Guichard
-* Brian Hurt
-* Richard Jones
-* Neel Krishnaswami
-* Michel Levy
-* Sven Luther
-* John Gerard Malecki
-* Luc Maranget
-* Jean-Francois Monin
-* Markus Mottl
-* Thomas Mraz
-* Wolfgang Mueller
-* Lars Nilsson
-* Jose Manuel Nunes
-* Frederic van der Plancke
-* Paul Steckler
-* Fabian Sturm
-* Ryan Tarpine
-* Rémi Vanicat
-* Yamagata Yoriyuki
-* Stefano Zacchiroli
+<ul id="contributors_list">
+<li>Doug Bagley</li>
+<li>Daniel Bünzli</li>
+<li>Nicolas Cannasse</li>
+<li>Eric C. Cooper</li>
+<li>Richard Donkin</li>
+<li>Jim Farrand</li>
+<li>Fabrice Le Fessant</li>
+<li>Jacques Garrigue</li>
+<li>Stephen Gilmore</li>
+<li>Flavio Grossi</li>
+<li>Damien Guichard</li>
+<li>Brian Hurt</li>
+<li>Richard Jones</li>
+<li>Neel Krishnaswami</li>
+<li>Michel Levy</li>
+<li>Sven Luther</li>
+<li>John Gerard Malecki</li>
+<li>Luc Maranget</li>
+<li>Jean-Francois Monin</li>
+<li>Markus Mottl</li>
+<li>Thomas Mraz</li>
+<li>Wolfgang Mueller</li>
+<li>Lars Nilsson</li>
+<li>Jose Manuel Nunes</li>
+<li>Frederic van der Plancke</li>
+<li>Paul Steckler</li>
+<li>Fabian Sturm</li>
+<li>Ryan Tarpine</li>
+<li>Rémi Vanicat</li>
+<li>Yamagata Yoriyuki</li>
+<li>Stefano Zacchiroli</li>
+</ul>
+
 

--- a/site/contributors.md
+++ b/site/contributors.md
@@ -43,7 +43,7 @@ Contributors
 The contributors to this site, extracted from the
 [Git log](https://github.com/ocaml/ocaml.org/commits/master), are:
 
-<ul>
+<ul id="contributors_list">
 ((! cmd git log --format="%aN" | sort | uniq | awk '{print "<li>"$1,$2,$3"</li>"}' !))
 </ul>
 
@@ -54,55 +54,59 @@ Older contributors to the tutorials
 Many of tutorials on this site originate from `ocaml-tutorial.org`.  Here are
 the people who contributed to them:
 
-* Doug Bagley
-* Daniel Bünzli
-* Nicolas Cannasse
-* Eric C. Cooper
-* Richard Donkin
-* Jim Farrand
-* Fabrice Le Fessant
-* Jacques Garrigue
-* Stephen Gilmore
-* Flavio Grossi
-* Damien Guichard
-* Brian Hurt
-* Richard Jones
-* Neel Krishnaswami
-* Michel Levy
-* Sven Luther
-* John Gerard Malecki
-* Luc Maranget
-* Jean-Francois Monin
-* Markus Mottl
-* Thomas Mraz
-* Wolfgang Mueller
-* Lars Nilsson
-* Jose Manuel Nunes
-* Frederic van der Plancke
-* Paul Steckler
-* Fabian Sturm
-* Ryan Tarpine
-* Rémi Vanicat
-* Yamagata Yoriyuki
-* Stefano Zacchiroli
-
+<ul id="contributors_list">
+<li>Doug Bagley</li>
+<li>Daniel Bünzli</li>
+<li>Nicolas Cannasse</li>
+<li>Eric C. Cooper</li>
+<li>Richard Donkin</li>
+<li>Jim Farrand</li>
+<li>Fabrice Le Fessant</li>
+<li>Jacques Garrigue</li>
+<li>Stephen Gilmore</li>
+<li>Flavio Grossi</li>
+<li>Damien Guichard</li>
+<li>Brian Hurt</li>
+<li>Richard Jones</li>
+<li>Neel Krishnaswami</li>
+<li>Michel Levy</li>
+<li>Sven Luther</li>
+<li>John Gerard Malecki</li>
+<li>Luc Maranget</li>
+<li>Jean-Francois Monin</li>
+<li>Markus Mottl</li>
+<li>Thomas Mraz</li>
+<li>Wolfgang Mueller</li>
+<li>Lars Nilsson</li>
+<li>Jose Manuel Nunes</li>
+<li>Frederic van der Plancke</li>
+<li>Paul Steckler</li>
+<li>Fabian Sturm</li>
+<li>Ryan Tarpine</li>
+<li>Rémi Vanicat</li>
+<li>Yamagata Yoriyuki</li>
+<li>Stefano Zacchiroli</li>
+</ul>
 The ocamlbuild documentation was imported from a former wiki at
 Inria. The contributors to that wiki were:
 
-* Aravantv
-* Romain Bardou
-* Berke Durak
-* Bruno de Fraine
-* ChriS
-* Cstork
-* Daniel Weil
-* Daniel Buenzli
-* Maxence Guesdon
-* Martin Jambon
-* Mwipliez
-* Na (Dana) Xu
-* Alexandre Pilkiewicz
-* Nicolas Pouillard
-* Hendrik Tews
-* Thelema
-* Xavier Clerc
+<ul id="contributors_list">
+<li>Aravantv</li>
+<li>Romain Bardou</li>
+<li>Berke Durak</li>
+<li>Bruno de Fraine</li>
+<li>ChriS</li>
+<li>Cstork</li>
+<li>Daniel Weil</li>
+<li>Daniel Buenzli</li>
+<li>Maxence Guesdon</li>
+<li>Martin Jambon</li>
+<li>Mwipliez</li>
+<li>Na (Dana) Xu</li>
+<li>Alexandre Pilkiewicz</li>
+<li>Nicolas Pouillard</li>
+<li>Hendrik Tews</li>
+<li>Thelema</li>
+<li>Xavier Clerc</li>
+</ul>
+

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -334,7 +334,7 @@ font-weight: bold;
   width: 85vw;
 }
 #contributors_list > li {
-  width: 11em;
+  width: 12em;
 }
 /*  ||  */
 /* When the navigation bar has reduced size */

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -326,7 +326,17 @@ color: #a20505;
 dl h2{
 font-weight: bold;
 }
-
+/* Fixed list of contributors */
+#contributors_list {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  width: 85vw;
+}
+#contributors_list > li {
+  width: 11em;
+}
+/*  ||  */
 /* When the navigation bar has reduced size */
 @media (max-height: 600px) and (min-width: 980px) {
   a.edit-this-page {


### PR DESCRIPTION
# Issue Description

When you navigate to contributors page, there is a very long list of contributors arranged in alphabetical order. Check the screenshot below. As you can see there is one column leaving a lot of wasted space on the right in desktop view. Besides one will have to scroll all the way down to check the entire list.

Fixes #1337 

## Changes Made
MD:

- added an id="contributors_list" for ul in contributors.md and contributors.fr.md

- re-written old contributors as ul and li to fit under one css rule

CSS:

- added Flexbox for ul with id="contributors_list" with width of 85vw;

- added width for each li under above ul

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)

before:
![113116082-c90d6980-9215-11eb-9461-4e08018ca141](https://user-images.githubusercontent.com/76935202/113579060-1ac75100-9667-11eb-8aa2-c61f090bfffc.png)

after:


https://user-images.githubusercontent.com/76935202/113957948-8d9d1b80-9863-11eb-8b96-1d66b01c60fe.mov






