### PR TITLE
Fixed sidebar for all TOCs

### DIFF
--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -5360,7 +5360,10 @@ body {
 #nav-secondary {
   padding-top: 52px;
   padding-bottom: 52px;
-  overflow: hidden;
+  top: 0;
+  position: fixed;
+  z-index: 1;
+  overflow-x: hidden;
 }
 #content-primary {
   padding-bottom: 28px;

--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -5359,12 +5359,14 @@ body {
 }
 #nav-secondary {
   padding-top: 52px;
-  padding-bottom: 52px;
   top: 0;
   position: fixed;
   z-index: 1;
   overflow-x: hidden;
+  height: 250px;
+  width: 300px;
 }
+
 #content-primary {
   padding-bottom: 28px;
 }


### PR DESCRIPTION
# Issue Description

For all the pages having a Table of Contents section, we can style it as a fixed sidebar for easy navigation and usability. The user wouldn't have to scroll up or down to explore other topics directly go to the desired sub-part.

Fixes #1363

## Changes Made

I have done styling changes in the `nav-secondary` class.

Before:
![Screenshot from 2021-04-02 01-08-23](https://user-images.githubusercontent.com/26017359/113634389-4a3c8480-968c-11eb-8802-aac4d42fee1f.png)

After:
![Screenshot from 2021-04-02 01-25-28](https://user-images.githubusercontent.com/26017359/113634396-51fc2900-968c-11eb-9605-65ecc42ba4f0.png)


* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
