### PR TITLE
Fixed typos

### DIFF
--- a/site/learn/tutorials/map.md
+++ b/site/learn/tutorials/map.md
@@ -4,12 +4,12 @@
 # Map
 
 ## Module Map
-Map creates a "mapping". For instance, lets say I have some data that is
+Map creates a "mapping". For instance, let's say I have some data that is
 users and their associated passwords. I could with the Map module create
 a mapping from user names to their passwords. The mapping module not
 only does this but it does it fairly efficiently. It also does this in a
 functional way. In the example below I am going to do a mapping from
-strings to strings. However it is possible to do mappings with all
+strings to strings. However, it is possible to do mappings with all
 different types of data.
 
 To create a Map I can do:
@@ -18,14 +18,14 @@ To create a Map I can do:
 module MyUsers = Map.Make(String);;
 ```
 
-OK, we have created the module `MyUsers`.  Now, lets start putting
+OK, we have created the module `MyUsers`.  Now, let's start putting
 something into it.  Where do we start?  Well, let's create an empty
 map to begin with:
 
 ```ocamltop
 let m = MyUsers.empty;;
 ```
-Hummm. An empty map is kind of boring, so lets add some data.
+Hummm. An empty map is kind of boring, so let's add some data.
 
 ```ocamltop
 let m = MyUsers.add "fred" "sugarplums" m;;
@@ -39,7 +39,7 @@ This means our mapping in our module `MyUsers` is from strings _to strings_.
 If we want a mapping from strings to integers or a mapping from integers
 to whatever we will have to create a different mapping.
 
-Lets add in some additional data just for kicks.
+Let's add in some additional data just for kicks.
 
 ```ocamltop
 let m = MyUsers.add "tom" "ilovelucy" m;;
@@ -47,14 +47,14 @@ let m = MyUsers.add "mark" "ocamlrules" m;;
 let m = MyUsers.add "pete" "linux" m;;
 ```
 Now that we have some data inside of our map, wouldn't it be nice
-to be able to view that data at some point? Lets begin by creating a
+to be able to view that data at some point? Let's begin by creating a
 simple print function.
 
 ```ocamltop
 let print_user key password =
   print_string(key ^ " " ^ password ^ "\n");;
 ```
-We have here a function that will take two strings, a key and a password,
+We have here a function that will take two strings, a key, and a password,
 and print them out nicely, including a new line character at the end.
 All we need to do is to have this function applied to our mapping. Here
 is what that would look like.
@@ -63,11 +63,11 @@ is what that would look like.
 MyUsers.iter print_user m;;
 ```
 The reason we put our data into a mapping however is probably so we can
-quickly find the data. Lets actually show how to do a find.
+quickly find the data. Let's actually show how to do a find.
 
 ```ocamltop
 MyUsers.find "fred" m;;
 ```
-This should quickly and efficienty return Fred's password: "sugarplums".
+This should quickly and efficiently return Fred's password: "sugarplums".
 
 


### PR DESCRIPTION
# Issue Description
Fixed typos on the Map tutorial page
Please include a summary of the issue.
Fixed typos
Fixes # (issue)

## Changes Made
Changed the "lets" on the page to "let's" depending on how they were used and also corrected a misspelled word.
Please describe the changes that you made.

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
