### PR TITLE
Fix the translation for 'Books' in /learn/index.fr.html #1408

### DIFF
--- a/site/learn/index.fr.md
+++ b/site/learn/index.fr.md
@@ -45,7 +45,7 @@ OCaml est un langage générique de programmation, de puissance industrielle, qu
             </footer>
         </section>
         <section class="span4 condensed">
-            <h1 class="ruled"><a href="books.html">Livres anglais et français</a></h1>
+            <h1 class="ruled"><a href="books.html">Livres</a></h1>
                 <a href="https://realworldocaml.org"><img style="float:
                 left; margin-right: 2px; margin-bottom: 10px"
                 src="/img/real-world-ocaml.jpg" width="48%"


### PR DESCRIPTION
# Issue Description

The translation for 'Books' in https://ocaml.org/learn/index.fr.html was written to be 'Livres anglais et français' which translates to 'English and French books'. The heading should be 'Livres' (books in en).

Fixes #1408

Before: 
![Screenshot 2021-04-06 154526](https://user-images.githubusercontent.com/64313783/113696033-23636a00-96ef-11eb-87bf-8761e3665ab2.png)
After:
![Screenshot 2021-04-06 154735](https://user-images.githubusercontent.com/64313783/113696293-70474080-96ef-11eb-818b-70785c41b4ff.png)

