### PR TITLE
Fixed focus in success stories page

### DIFF
--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -7015,4 +7015,9 @@ body {
   */
 
 }
-
+a.success-links:focus {
+  outline: none;
+}
+a.success-links:focus img{
+  outline: 0.2rem solid #c77a27;
+}

--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -7015,9 +7015,3 @@ body {
   */
 
 }
-a.success-links:focus {
-  outline: none;
-}
-a.success-links:focus img{
-  outline: 0.2rem solid #c77a27;
-}

--- a/site/learn/success.md
+++ b/site/learn/success.md
@@ -4,7 +4,7 @@
 *Table of contents*
 
 ## Jane Street
-<a href="http://janestreet.com/technology/" class="success-links"
+<a href="http://janestreet.com/technology/" style="float: left"
     ><img
       src="../img/users/jane-street.jpg"
       alt="Jane Street"
@@ -34,7 +34,7 @@ be found at <http://janestreet.github.io>.  All in, we've open-sourced
 more than 200k lines of code.
 
 ## The Unison File Synchronizer
-<a href="../img/unison.png" class="success-links"
+<a href="../img/unison.png" style="float: left"
     ><img
       src="../img/unison-thumb.jpg"
       style="float: left; margin-right: 10px"
@@ -68,7 +68,7 @@ projects in having been *translated* from Java to OCaml midway through
 its development. Moving to OCaml was like a breath of fresh air.”
 
 ## The MLdonkey peer-to-peer client
-<a href="../img/mldonkey.jpg" class="success-links"
+<a href="../img/mldonkey.jpg" style="float: left"
     ><img
       src="../img/mldonkey-thumb.jpg"
       style="float: left; margin-right: 10px"
@@ -97,7 +97,7 @@ remotely using a choice of three different kinds of interfaces: GTK, web
 and telnet.”
 
 ## LexiFi's Modeling Language for Finance
-<a href="../img/lexifi.jpg" class="success-links"
+<a href="../img/lexifi.jpg" style="float: left"
     ><img
       src="../img/lexifi-thumb.jpg"
       style="float: left; margin-right: 10px"
@@ -136,7 +136,7 @@ are gaining growing acceptance throughout Europe and are contributing to
 spread the use of OCaml in the financial services industry.
 
 ## The Coq Proof Assistant
-<a href="../img/coq.jpg" class="success-links"
+<a href="../img/coq.jpg" style="float: left"
     ><img
       src="../img/coq-thumb.jpg"
       style="float: left; margin-right: 10px"
@@ -163,7 +163,7 @@ execution, which is indispensable for a tool whose primary goal is
 precisely rigor.”
 
 ## The ASTRÉE Static Analyzer
-<a href="http://www.airbus.com/" class="success-links"
+<a href="http://www.airbus.com/" style="float: left"
     ><img
       src="../img/astree.gif"
       alt="A340"
@@ -220,7 +220,7 @@ functional programming language. The expressiveness of this language and
 robustness of its implementation provided a great productivity boost.”
 
 ## FFTW
-<a href="http://www.fftw.org/" class="success-links">
+<a href="http://www.fftw.org/" style="float: left">
   <img
     src="../img/fftw-thumb.png"
     alt="FFTW"

--- a/site/learn/success.md
+++ b/site/learn/success.md
@@ -4,8 +4,12 @@
 *Table of contents*
 
 ## Jane Street
-[<img src='/img/users/jane-street.jpg' alt='Jane Street'
-style='float: left; margin-right: 10px' />](http://janestreet.com/technology/)
+<a href="http://janestreet.com/technology/" class="success-links"
+    ><img
+      src="../img/users/jane-street.jpg"
+      alt="Jane Street"
+      style="float: left; margin-right: 10px"
+/></a>
 
 Jane Street is a proprietary trading firm that uses OCaml as its primary
 development platform.  Our operation runs at a large scale,
@@ -30,9 +34,13 @@ be found at <http://janestreet.github.io>.  All in, we've open-sourced
 more than 200k lines of code.
 
 ## The Unison File Synchronizer
-[<img src='/img/unison-thumb.jpg'
-style='float: left; margin-right: 10px'
-alt='Screenshot'  title='Screenshot of Unison&#39;s main window' />](/img/unison.png)
+<a href="../img/unison.png" class="success-links"
+    ><img
+      src="../img/unison-thumb.jpg"
+      style="float: left; margin-right: 10px"
+      alt="Screenshot"
+      title="Screenshot of Unison&#39;s main window"
+/></a>
 
 [Unison](http://www.cis.upenn.edu/%7Ebcpierce/unison/) is a popular
 file-synchronization tool for Windows and most flavors of Unix. It
@@ -60,9 +68,13 @@ projects in having been *translated* from Java to OCaml midway through
 its development. Moving to OCaml was like a breath of fresh air.”
 
 ## The MLdonkey peer-to-peer client
-[<img src='/img/mldonkey-thumb.jpg'
-style='float: left; margin-right: 10px'
-alt='Screenshot'  title='Screenshot of one of MLdonkey&#39;s windows' />](/img/mldonkey.jpg)
+<a href="../img/mldonkey.jpg" class="success-links"
+    ><img
+      src="../img/mldonkey-thumb.jpg"
+      style="float: left; margin-right: 10px"
+      alt="Screenshot"
+      title="Screenshot of one of MLdonkey&#39;s windows"
+/></a>
 
 [MLdonkey](http://mldonkey.sourceforge.net/Main_Page) is a
 multi-platform multi-networks peer-to-peer client. It was the first
@@ -85,10 +97,13 @@ remotely using a choice of three different kinds of interfaces: GTK, web
 and telnet.”
 
 ## LexiFi's Modeling Language for Finance
-[<img src='/img/lexifi-thumb.jpg'
-style='float: left; margin-right: 10px'
-alt='Screenshot'  title='A report produced by LexiFi software'
-/>](/img/lexifi.jpg)
+<a href="../img/lexifi.jpg" class="success-links"
+    ><img
+      src="../img/lexifi-thumb.jpg"
+      style="float: left; margin-right: 10px"
+      alt="Screenshot"
+      title="A report produced by LexiFi software"
+/></a>
 
 Developed by the company [LexiFi](http://www.lexifi.com/), the Modeling
 Language for Finance (MLFi) is the first formal language that accurately
@@ -121,9 +136,13 @@ are gaining growing acceptance throughout Europe and are contributing to
 spread the use of OCaml in the financial services industry.
 
 ## The Coq Proof Assistant
-[<img src='/img/coq-thumb.jpg'
-style='float: left; margin-right: 10px'
-alt='Screenshot'  title='Screenshot of Coq&#39;s integrated development environment' />](/img/coq.jpg)
+<a href="../img/coq.jpg" class="success-links"
+    ><img
+      src="../img/coq-thumb.jpg"
+      style="float: left; margin-right: 10px"
+      alt="Screenshot"
+      title="Screenshot of Coq&#39;s integrated development environment"
+/></a>
 
 *[Jean-Christophe Filliâtre](https://www.lri.fr/~filliatr/) (CNRS), a
 Coq developer, says:* “The [Coq](http://coq.inria.fr/) tool is a system
@@ -144,9 +163,13 @@ execution, which is indispensable for a tool whose primary goal is
 precisely rigor.”
 
 ## The ASTRÉE Static Analyzer
-[<img src='/img/astree.gif' alt='A340'
-style='float: left; margin-right: 10px'
-title='ASTRÉE has been used to certify the Airbus A340 flight control software' />](http://www.airbus.com/)
+<a href="http://www.airbus.com/" class="success-links"
+    ><img
+      src="../img/astree.gif"
+      alt="A340"
+      style="float: left; margin-right: 10px"
+      title="ASTRÉE has been used to certify the Airbus A340 flight control software"
+/></a>
 
 *[David Monniaux](http://www-verimag.imag.fr/~monniaux/) (CNRS), member
 of the ASTRÉE project, says:* “[ASTRÉE](http://www.astree.ens.fr/) is a
@@ -197,8 +220,13 @@ functional programming language. The expressiveness of this language and
 robustness of its implementation provided a great productivity boost.”
 
 ## FFTW
-<img src='/img/fftw-thumb.png' alt='FFTW'
-style='float: left; margin-right: 10px' />
+<a href="http://www.fftw.org/" class="success-links">
+  <img
+    src="../img/fftw-thumb.png"
+    alt="FFTW"
+    style="float: left; margin-right: 10px"
+  />
+</a>
 
 [FFTW](http://www.fftw.org/) is a [very fast](http://www.fftw.org/benchfft/) C
 library for computing Discrete Fourier Transforms (DFT). It uses a powerful


### PR DESCRIPTION
# Issue Description

When the brand image/logo is clicked in https://ocaml.org/learn/success.html, the focus is on the text beside the image instead of the image.

## Before

![image](https://user-images.githubusercontent.com/63427719/113700283-927c9680-96ce-11eb-9859-36863a25f886.png)

Fixes #1415

## Changes Made

Made focus to be on the image.

## After

<img width="711" alt="Screenshot 2021-04-06 at 11 51 36" src="https://user-images.githubusercontent.com/63427719/113700190-74af3180-96ce-11eb-8759-7838bc612eb7.png">

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
