### PR TITLE
Added margin-left to logo

### DIFF
--- a/site/docs/logos.md
+++ b/site/docs/logos.md
@@ -45,7 +45,7 @@ The OCaml logo is released under a
 
 <img src="/img/OCaml_Sticker.svg"
 	alt="OCaml"
-	style="width: 150px; float: right" ></img>
+	style="width: 150px; float: right; margin-left: 20px" ></img>
 
 The following [SVG file](/img/OCaml_Sticker.svg) is suitable to
 [make stickers](https://twitter.com/ocamllabs/status/761191421680422912).


### PR DESCRIPTION
# Issue Description

The stickers section in https://ocaml.org/docs/logos.html needed a little spacing on smaller screens.

Fixes #1395

## Before

![image](https://user-images.githubusercontent.com/63427719/113708957-d1641980-96d9-11eb-8fe8-8023f8db3c61.png)

## Changes Made

Added margin-left to logos

## After

<img width="369" alt="Screenshot 2021-04-06 at 13 13 24" src="https://user-images.githubusercontent.com/63427719/113708995-e04acc00-96d9-11eb-88da-3a6859076186.png">

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
