### PR TITLE
Fixed the missing 'Hosting' section in contributors.fr.md

### DIFF
--- a/site/contributors.fr.md
+++ b/site/contributors.fr.md
@@ -1,5 +1,42 @@
 <!-- ((! set title Contributeurs !)) -->
 
+Hébergement
+=======
+
+<div class="container">
+  <div style="padding: 24px 0px" class="row">
+    <div class="span6">
+      <p style="text-align: center;"><img width="300" height="100" src="/img/equinix-metal_440x105.png" alt="Equinix Metal"></p>
+      <h2 class="lead"style="text-align: center;">Equinix Metal: hébergement x86 et arm baremetal</h2>
+    </div>
+    <div class="span6">
+      <p style="text-align: center;"><img width="300" height="100" src="/img/scaleway_456x110.png" alt="Scaleway"></p>
+      <h2 class="lead"style="text-align: center;">Scaleway: hébergement x86 (VM / baremetal)</h2>
+    </div>
+  </div>
+  <div style="padding: 24px 0px" class="row">
+    <div class="span6">
+      <p style="text-align: center;"><img width="150" src="/img/aws_300x180.png" alt="Amazon Web Services"></p>
+      <h2 class="lead"style="text-align: center;">Hébergement de VM AWS: arm64</h2>
+    </div>
+    <div class="span6">
+      <p style="text-align: center;"><img width="300" height="100" src="/img/uni-of-cam-computer-lab_488x169.png" alt="University of Cambridge Computer Laboratory"></p>
+      <h2 class="lead"style="text-align: center;">Université de Cambridge: hébergement de machines</h2>
+    </div>
+  </div>
+  <div style="padding: 24px 0px" class="row">
+    <div class="span6">
+      <p style="text-align: center;"><img width="275" src="/img/ibm_390x186.jpg" alt="IBM"></p>
+      <h2 class="lead"style="text-align: center;">IBM: machines PowerPC (POWER8 / 9)</h2>
+    </div>
+    <div class="span6">
+      <p style="text-align: center;"><img width="300" height="100" src="/img/rackspace_300x109.jpg" alt="Rackspace"></p>
+      <h2 class="lead"style="text-align: center;">Hébergement fourni de 2012 à 2020</h2>
+    </div>
+  </div>
+</div>
+
+
 Contributeurs
 =============
 


### PR DESCRIPTION
# Issue Description

The French translation of the Contributors page had no 'Hosting' section.

Fixes #1429

## Changes Made
Added Hosting section in French translation of Contributors page.
Before:
<img width="953" alt="before" src="https://user-images.githubusercontent.com/58878761/113723017-929c8680-970e-11eb-8dcf-422552657e57.png">
After:
![afyer](https://user-images.githubusercontent.com/58878761/113723051-992afe00-970e-11eb-8492-8d582a738396.png)

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
