### PR TITLE
Reinstate debugging tutorial

### DIFF
--- a/site/learn/tutorials/debug.md
+++ b/site/learn/tutorials/debug.md
@@ -3,16 +3,18 @@
 *Table of contents*
 
 # Debugging
-This note quickly presents two techniques to debug OCaml programs:
 
-* [Tracing functions calls](#Tracingfunctionscallsinthetoplevel)
-  that works in the [interactive toplevel](basics.html),
-* [OCaml debugger](#The-OCaml-debugger), which allows analysing programs
+This tutorial presents two techniques for debugging OCaml programs:
+
+* [Tracing functions calls](#Tracingfunctionscallsinthetoplevel),
+  which works in the interactive top level.
+* The [OCaml debugger](#The-OCaml-debugger), which allows analysing programs
   compiled with `ocamlc`.
 
-## Tracing functions calls in the toplevel
-The simplest way to debug programs in the toplevel is to follow the
-function calls, by “tracing” the faulty function:
+## Tracing functions calls in the top level
+
+The simplest way to debug programs in the top level is to follow the function
+calls, by “tracing” the faulty function:
 
 ```ocamltop
 let rec fib x = if x <= 1 then 1 else fib (x - 1) + fib (x - 2);;
@@ -21,15 +23,17 @@ fib 3;;
 #untrace fib;;
 ```
 
-###  Polymorphic function
-A difficulty with polymorphic functions is that the output of the trace
-system is not very informative in case of polymorphic arguments and/or
-results. Consider a sorting algorithm (say bubble sort):
+###  Polymorphic functions
+
+A difficulty with polymorphic functions is that the output of the trace system
+is not very informative in case of polymorphic arguments and/or results.
+Consider a sorting algorithm (say bubble sort):
 
 ```ocamltop
 let exchange i j v =
   let aux = v.(i) in
-  v.(i) <- v.(j); v.(j) <- aux
+    v.(i) <- v.(j);
+    v.(j) <- aux
 
 let one_pass_vect fin v =
   for j = 1 to fin do
@@ -41,30 +45,32 @@ let bubble_sort_vect v =
     one_pass_vect i v
   done;;
 
-let q = [| 18; 3; 1 |];;
+let q = [|18; 3; 1|];;
 
 #trace one_pass_vect;;
 bubble_sort_vect q;;
 ```
 
-The function `one_pass_vect` being polymorphic, its vector argument is
-printed as a vector containing polymorphic values,
-`[|<poly>; <poly>; <poly>|]`, and thus we cannot properly
-follow the computation.
+The function `one_pass_vect` being polymorphic, its vector argument is printed
+as a vector containing polymorphic values, `[|<poly>; <poly>; <poly>|]`, and
+thus we cannot properly follow the computation.
 
-A simple way to overcome this problem is to define a monomorphic version
-of the faulty function. This is fairly easy using a *type constraint*.
-Generally speaking, this allows a proper understanding of the error in
-the definition of the polymorphic function. Once this has been
-corrected, you just have to suppress the type constraint to revert to a
-polymorphic version of the function. For our sorting routine, a single
-type constraint on the argument of the `exchange` function warranties a
-monomorphic typing, that allows a proper trace of function calls:
+A simple way to overcome this problem is to define a monomorphic version of the
+faulty function. This is fairly easy using a *type constraint*.  Generally
+speaking, this allows a proper understanding of the error in the definition of
+the polymorphic function. Once this has been corrected, you just have to
+suppress the type constraint to revert to a polymorphic version of the
+function.
+
+For our sorting routine, a single type constraint on the argument of the
+`exchange` function warranties a monomorphic typing, that allows a proper trace
+of function calls:
 
 ```ocamltop
 let exchange i j (v : int array) =    (* notice the type constraint *)
   let aux = v.(i) in
-  v.(i) <- v.(j); v.(j) <- aux
+    v.(i) <- v.(j);
+    v.(j) <- aux
 
 let one_pass_vect fin v =
   for j = 1 to fin do
@@ -83,36 +89,37 @@ bubble_sort_vect q;;
 ```
 
 ###  Limitations
-To keep track of assignments to data structures and mutable variables in
-a program, the trace facility is not powerful enough. You need an extra
-mechanism to stop the program in any place and ask for internal values:
-that is a symbolic debugger with its stepping feature.
 
-Stepping a functional program has a meaning which is a bit weird to
-define and understand. Let me say that we use the notion of *runtime
-events* that happen for instance when a parameter is passed to a
-function or when entering a pattern matching, or selecting a clause in a
-pttern matching. Computation progress is taken into account by these
-events, independently of the instructions executed on the hardware.
+To keep track of assignments to data structures and mutable variables in a
+program, the trace facility is not powerful enough. You need an extra mechanism
+to stop the program in any place and ask for internal values: that is a
+symbolic debugger with its stepping feature.
 
-Although this is difficult to implement, there exists such a debugger
-for OCaml under Unix: `ocamldebug` (there also exists one for Caml
-Light, as a user contribution). Its use is illustrated in the next
-section.
+Stepping a functional program has a meaning which is a bit weird to define and
+understand. Let me say that we use the notion of *runtime events* that happen
+for instance when a parameter is passed to a function or when entering a
+pattern matching, or selecting a clause in a pttern matching. Computation
+progress is taken into account by these events, independently of the
+instructions executed on the hardware.
 
-In fact, for complex programs, it is likely the case that the programmer
-will use explicit printing to find the bugs, since this methodology
-allows the reduction of the trace material : only useful data are
-printed and special purpose formats are more suited to get the relevant
-information, than what can be output automatically by the generic
-pretty-printer used by the trace mechanism.
+Although this is difficult to implement, there exists such a debugger for OCaml
+under Unix: `ocamldebug`. Its use is illustrated in the next section.
+
+In fact, for complex programs, it is likely the case that the programmer will
+use explicit printing to find the bugs, since this methodology allows the
+reduction of the trace material: only useful data are printed and special
+purpose formats are more suited to get the relevant information, than what can
+be output automatically by the generic pretty-printer used by the trace
+mechanism.
 
 ## The OCaml debugger
-We now give a quick tutorial for the OCaml debugger (`ocamldebug`).
-Before starting, please note that `ocamldebug` does not work under
-native Windows ports of OCaml (but it runs under the Cygwin port).
+
+We now give a quick tutorial for the OCaml debugger (`ocamldebug`).  Before
+starting, please note that `ocamldebug` does not work under native Windows
+ports of OCaml (but it runs under the Cygwin port).
 
 ###  Launching the debugger
+
 Consider the following obviously wrong program written in the file
 `uncaught.ml`:
 
@@ -127,32 +134,30 @@ let () =
   print_string (find_address "INRIA"); print_newline ();;
 ```
 
-At runtime, the program raises an uncaught exception `Not_found`.
-Suppose we want to find where and why this exception has been raised, we
-can proceed as follows:
+At runtime, the program raises an uncaught exception `Not_found`.  Suppose we
+want to find where and why this exception has been raised, we can proceed as
+follows. First, we compile the program in debug mode:
 
-1. we compile the program in debug mode:
+```
+ocamlc -g uncaught.ml
+```
 
-    ```
-    ocamlc -g uncaught.ml
-    ```
+We launch the debugger:
 
-1. we launch the debugger:
+```
+ocamldebug a.out
+```
 
-    ```
-    ocamldebug a.out
-    ```
+Then the debugger answers with a banner and a prompt:
 
-	Then the debugger answers with a banner and a prompt:
+```
+OCaml Debugger version 4.12.0
 
-	```
-        OCaml Debugger version 4.00.1
-	
-	(ocd)
-	```
-
+(ocd)
+```
 
 ###  Finding the cause of a spurious exception
+
 Type `r` (for *run*); you get
 
 ```
@@ -163,31 +168,33 @@ Program end.
 Uncaught exception: Not_found
 (ocd)
 ```
-Self explanatory, isn't it? So, you want to step backward to set the
-program counter before the time the exception is raised; hence type in
-`b` as *backstep*, and you get
+
+Self explanatory, isn't it? So, you want to step backward to set the program
+counter before the time the exception is raised; hence type in `b` as
+*backstep*, and you get
 
 ```
 (ocd) b
 Time : 11 - pc : 15500 - module List
 143     [] -> <|b|>raise Not_found
 ```
-The debugger tells you that you are in module `List`, inside a pattern
-matching on a list that already chose the `[]` case and is about to
-execute `raise Not_found`, since the program is stopped just before this
-expression (as witnessed by the `<|b|>` mark).
 
-But, as you know, you want the debugger to tell you which procedure
-calls the one from `List`, and also who calls the procedure that calls
-the one from `List`; hence, you want a backtrace of the execution stack:
+The debugger tells you that you are in module `List`, inside a pattern matching
+on a list that already chose the `[]` case and is about to execute `raise
+Not_found`, since the program is stopped just before this expression (as
+witnessed by the `<|b|>` mark).
+
+But, as you know, you want the debugger to tell you which procedure calls the
+one from `List`, and also who calls the procedure that calls the one from
+`List`; hence, you want a backtrace of the execution stack:
 
 ```
 (ocd) bt
 #0  Pc : 15500  List char 3562
 #1  Pc : 19128  Uncaught char 221
 ```
-So the last function called is from module `List` at character 3562,
-that is :
+
+So the last function called is from module `List` at character 3562, that is:
 
 ```ocaml
 let rec assoc x = function
@@ -195,19 +202,22 @@ let rec assoc x = function
           ^
   | (a,b)::l -> if a = x then b else assoc x l
 ```
-The function that calls it is in module `Uncaught`, file `uncaught.ml`
-char 221:
+
+The function that calls it is in module `Uncaught`, file `uncaught.ml` char
+221:
 
 ```ocaml
 print_string (find_address "INRIA"); print_newline ();;
                                   ^
 ```
-To sum up: if you're developping a program you can compile it with the
-`-g` option, to be ready to debug the program if necessary. Hence, to
-find a spurious exception you just need to type `ocamldebug a.out`, then
-`r`, `b`, and `bt` gives you the backtrace.
+
+To sum up: if you're developing a program you can compile it with the `-g`
+option, to be ready to debug the program if necessary. Hence, to find a
+spurious exception you just need to type `ocamldebug a.out`, then `r`, `b`, and
+`bt` gives you the backtrace.
 
 ###  Getting help and info in the debugger
+
 To get more info about the current status of the debugger you can ask it
 directly at the toplevel prompt of the debugger; for instance:
 
@@ -224,10 +234,11 @@ break @ [module] # characternum
 ```
 
 ###  Setting break points
+
 Let's set up a breakpoint and rerun the entire program from the
 beginning (`(g)oto 0` then `(r)un`):
 
-```ocamltop
+```ocaml
 (ocd) break @Uncaught 9
 Breakpoint 3 at 19112 : file Uncaught, line 9 column 34
 
@@ -241,8 +252,8 @@ Breakpoint : 1
 9 add "IRIA" "Rocquencourt"<|a|>;;
 ```
 
-Then, we can step and find what happens when `find_address` is about to
-be called
+Then, we can step and find what happens when `find_address` is about to be
+called
 
 ```
 (ocd) s
@@ -257,16 +268,11 @@ $1 : (string * string) list = ["IRIA", "Rocquencourt"]
 (ocd)
 ```
 
-Now we can guess why `List.assoc` will fail to find "INRIA" in the
-list...
+Now we can guess why `List.assoc` will fail to find "INRIA" in the list...
 
+###  Using the debugger under Emacs
 
-###  Using the debugger under (X)Emacs
-
-Note also that under Emacs you call the debugger using `ESC-x`
-`camldebug a.out`. Then Emacs will set you directly to the file and
-character reported by the debugger, and you can step back and forth
-using `ESC-b` and `ESC-s`, you can set up break points using
-`CTRL-X space`, and so on...
-
-
+Under Emacs you call the debugger using `ESC-x` `ocamldebug a.out`. Then Emacs
+will send you directly to the file and character reported by the debugger, and
+you can step back and forth using `ESC-b` and `ESC-s`, you can set up break
+points using `CTRL-X space`, and so on...

--- a/site/learn/tutorials/debug.md
+++ b/site/learn/tutorials/debug.md
@@ -7,13 +7,13 @@
 This tutorial presents two techniques for debugging OCaml programs:
 
 * [Tracing functions calls](#Tracingfunctionscallsinthetoplevel),
-  which works in the interactive top level.
+  which works in the interactive toplevel.
 * The [OCaml debugger](#The-OCaml-debugger), which allows analysing programs
   compiled with `ocamlc`.
 
-## Tracing functions calls in the top level
+## Tracing functions calls in the toplevel
 
-The simplest way to debug programs in the top level is to follow the function
+The simplest way to debug programs in the toplevel is to follow the function
 calls, by “tracing” the faulty function:
 
 ```ocamltop

--- a/site/learn/tutorials/index.md
+++ b/site/learn/tutorials/index.md
@@ -31,10 +31,11 @@ there to request or offer new tutorials.
  Warnings](null_pointers_asserts_and_warnings.html)
 * [Objects](objects.html)
 
-### Errors
+### Errors and Debugging
 
 * [Error handling](error_handling.html)
 * [Common Error Messages](common_error_messages.html)
+* [Debugging](debug.html)
 
 ((! get second_of_two_columns !))
 


### PR DESCRIPTION
There is a decent debugging tutorial in `site/learn/tutorials/debug.md` which appears to be unused.

This PR includes a lightly edited version of it, and links it back into the tutorials.