### PR TITLE
Position navbar on small screens

### DIFF
--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -6364,6 +6364,7 @@ body {
   .row {
     margin-left: -20px;
     *zoom: 1;
+    margin-top: 30px;
   }
   .row:before,
   .row:after {
@@ -6732,6 +6733,7 @@ body {
   .row,
   .thumbnails {
     margin-left: 0;
+    margin-top: 30px;
   }
   .thumbnails > li {
     float: none;
@@ -6865,6 +6867,11 @@ body {
   .navbar-fixed-top .navbar-inner,
   .navbar-fixed-bottom .navbar-inner {
     padding: 5px;
+    position: fixed;
+    width: 100%;
+    top: 0;
+    z-index: 99;
+
   }
   .navbar .container {
     width: auto;

--- a/site/css/bootstrap_mod.css
+++ b/site/css/bootstrap_mod.css
@@ -7,8 +7,9 @@
 }
 
 h1 {
-  margin-top: 0px;
+  margin-top: 25px;
   line-height: 50px;
+ 
 }
 
 h2 a, h3 a, h4 a, h5 a, h6 a {

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -484,6 +484,11 @@ ul.translations {
   padding: 0;
   margin: 0px 1ex 0px 2ex;
 }
+@media  (max-width: 979px) {
+ul.translations{
+   margin: 15px 1ex 0px 2ex;
+}
+}
 ul.translations:before { content: "["; }
 ul.translations:after { content: "]"; }
 .translations > li  {


### PR DESCRIPTION
# Issue Description

The navbar of most of the pages on the tutorial section remains static at the top on smaller screens view and this makes it difficult for a user to navigate to another page once they have scrolled down the page they are on

Fixes #1436

## Changes Made

I made changes to the .row class in bootstrap.css for smaller screens
I made changes to the h1 in bootstrap_mod.css file to reposition it after making the navbar fixed
I made changes to the ul.translations in the ocamlorg.css on smaller screens to reposition it after making the navbar fixed

 Before:

https://user-images.githubusercontent.com/67186679/113806541-5f7fe480-975a-11eb-8bb2-da46367570db.mp4

After:

https://user-images.githubusercontent.com/67186679/113806828-f351b080-975a-11eb-82e0-234812c75bed.mp4



* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
