### PR TITLE
Fixes the footer on cheat_sheets page

### DIFF
--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -525,6 +525,9 @@ a:focus {
 .row-fluid [class*="span"].pull-right {
   float: right;
 }
+.site-container {
+  min-height: 80vh;
+}
 .container {
   margin-right: auto;
   margin-left: auto;

--- a/site/docs/cheat_sheets.md
+++ b/site/docs/cheat_sheets.md
@@ -1,20 +1,15 @@
 <!-- ((! set title Cheat Sheets !)) ((! set documentation !)) -->
 
-# Cheat Sheets
+<div class="site-container">
+<h1 id="Cheat-Sheets">Cheat Sheets</h1>
 
-[OCamlPro](http://www.ocamlpro.com/) has published cheat sheets (one or
-two-page summaries) on OCaml:
-
-* [The OCaml Language](http://www.ocamlpro.com/wp-content/uploads/2019/09/ocaml-lang.pdf) (PDF, September 2019)  
-General overview of the OCaml language: basic data types, basic
-concepts, functions, modules, etc.
-
-* [OCaml Standard Tools](http://www.ocamlpro.com/files/ocaml-tools.pdf) (PDF, June 2011)  
-Overview of OCaml compilers and their options, tools for lexing and
-parsing, Makefile rules, etc.
-
-* [OCaml Standard Library](http://www.ocamlpro.com/wp-content/uploads/2019/09/ocaml-stdlib.pdf) (PDF, September 2019)  
-Overview of the standard library's most common modules.
-
-* [OCaml Emacs Mode (Tuareg)](http://www.ocamlpro.com/files/tuareg-mode.pdf) (PDF, June 2011)  
-Overview of the Emacs Tuareg mode keyboard shortcuts.
+<p><a href="http://www.ocamlpro.com/">OCamlPro</a> has published cheat sheets (one or
+two-page summaries) on OCaml:</p>
+<ul><li><p><a href="http://www.ocamlpro.com/wp-content/uploads/2019/09/ocaml-lang.pdf">The OCaml Language</a> (PDF, September 2019)<br/> General overview of the OCaml language: basic data types, basic
+ concepts, functions, modules, etc.</p>
+</li><li><p><a href="http://www.ocamlpro.com/files/ocaml-tools.pdf">OCaml Standard Tools</a> (PDF, June 2011)<br/> Overview of OCaml compilers and their options, tools for lexing and
+ parsing, Makefile rules, etc.</p>
+</li><li><p><a href="http://www.ocamlpro.com/wp-content/uploads/2019/09/ocaml-stdlib.pdf">OCaml Standard Library</a> (PDF, September 2019)<br/> Overview of the standard library&#39;s most common modules.</p>
+</li><li><p><a href="http://www.ocamlpro.com/files/tuareg-mode.pdf">OCaml Emacs Mode (Tuareg)</a> (PDF, June 2011)<br/> Overview of the Emacs Tuareg mode keyboard shortcuts.</p>
+</li></ul>
+</div>


### PR DESCRIPTION
# Issue Description

Because of less content footer was shifted from the bottom of the page.
It Fixes the footer on the cheat_sheets page.


Fixes #1361 

## Changes Made

Replaced the markdown code with HTML  in `cheat_sheets.md` file and styled it with a `div` by giving a `min-height.`

Before :
![Screenshot from 2021-04-07 01-00-05](https://user-images.githubusercontent.com/53010252/113812638-0f217a80-978c-11eb-93e2-47ba9a9f238b.png)

After :
![Screenshot from 2021-04-07 01-00-12](https://user-images.githubusercontent.com/53010252/113812652-15175b80-978c-11eb-8926-b5055afba7e1.png)


* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
