### PR TITLE
Change breadcrumb position and differentiate languages

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -458,6 +458,12 @@ ul.translations:after { content: "]"; }
   text-shadow: 0 1px 0 #ffffff;
 }
 
+.translations > li:not(:last-child):after {
+  display: inline-block;
+  content: "\00a0|\00a0";
+  font-weight: 600;
+}
+
 /* Accessibility Helpers */
 .visually-hidden {
   clip: rect(0 0 0 0);

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -427,6 +427,8 @@ header + .core-running-header {
 /* Translations and breadcrumb */
 div.running-header {
   margin-top: -10px;
+  width: 100%;
+  box-sizing: border-box;
 }
 .breadcrumb {
   display: inline;

--- a/template/core.mpp
+++ b/template/core.mpp
@@ -2,10 +2,7 @@
 <div class="container">
   <div class="row">
     {{!x ifdef toc
-    <div class="span4"></div>
-    <div class="span8">
-      ((! input template/running-header.mpp !))
-    </div>
+    ((! input template/running-header.mpp !))
     <div class="span4">
       <nav id="nav-secondary">
         <ul class="nav nav-list">

--- a/template/running-header.mpp
+++ b/template/running-header.mpp
@@ -1,18 +1,23 @@
 <!--								-*-html-*- -->
-<div class="running-header">
-  {{!z ifndef nobreadcrumb
-  <div class="row">
-    <ol class="breadcrumb">
-      {{! cmd script/breadcrumb "((! get filename !))" !}}
-    </ol>
+
+<div class="row">
+  <div class="running-header">
+    {{!z ifndef nobreadcrumb
+    <div class="span7">
+     <ol class="breadcrumb">
+        {{! cmd script/breadcrumb "((! get filename !))" !}}
+      </ol>
+    </div>
+    <div class="span5">
+      <ul class="translations">
+        {{! cmd script/translations "((! get filename !))" !}}
+      </ul>
+    </div>
+    z!}}
+    {{!z ifdef nobreadcrumb
     <ul class="translations">
       {{! cmd script/translations "((! get filename !))" !}}
     </ul>
+    z!}}
   </div>
-  z!}}
-  {{!z ifdef nobreadcrumb
-  <ul class="translations">
-    {{! cmd script/translations "((! get filename !))" !}}
-  </ul>
-  z!}}
 </div>


### PR DESCRIPTION
# Issue Description
On pages with  left sidebar,  the breadcrumbs appear on the middle of the page which isn't a good user experience as users are used to seeing breadcrumbs on the left side of the page. Also the language are clustered and difficult to differentiate. This can confuse users on which one to select.

Fixes #1378 

This PR positions the breadcrumbs on the left side of the page
  
Before
![before-breadcrumbs](https://user-images.githubusercontent.com/39722740/113832150-3bcf9500-9780-11eb-9ef7-686442467580.PNG)
  
After
![breadcrumbs-after](https://user-images.githubusercontent.com/39722740/113833622-cc5aa500-9781-11eb-902c-957401ba627e.PNG)

This PR adds | character to languages to differentiate them
  
Before
![bfore](https://user-images.githubusercontent.com/39722740/115244874-45f87880-a11c-11eb-9a92-3522fb8e2aa1.PNG)

After
![before](https://user-images.githubusercontent.com/39722740/115244991-632d4700-a11c-11eb-8aa3-16f1805197e7.PNG)

Test Platforms:
- Mobile, Tablet and desktop devices using chrome devices
- Chrome and Firefox browsers
  
* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
