### PR TITLE
manual: update for 4.12

### DIFF
--- a/site/releases/4.12/htmlman/advexamples.html
+++ b/site/releases/4.12/htmlman/advexamples.html
@@ -5,21 +5,21 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍6 Advanced examples with classes and modules</title>
+<title>OCaml - Advanced examples with classes and modules</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍I An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">Chapter ‍1 The core language</a></li><li><a href="moduleexamples.html">Chapter ‍2 The module system</a></li><li><a href="objectexamples.html">Chapter ‍3 Objects in OCaml</a></li><li><a href="lablexamples.html">Chapter ‍4 Labels and variants</a></li><li><a href="polymorphism.html">Chapter ‍5 Polymorphism and its limitations</a></li><li class="active"><a href="advexamples.html">Chapter ‍6 Advanced examples with classes and modules</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a></li><li class="active"><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec64">Chapter ‍6 Advanced examples with classes and modules</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍6 Advanced examples with classes and modules</a></li>
-<li><a href="advexamples.html#s%3Aextended-bank-accounts">6.1 Extended example: bank accounts</a>
-</li><li><a href="advexamples.html#s%3Amodules-as-classes">6.2 Simple modules as classes</a>
-</li><li><a href="advexamples.html#s%3Asubject-observer">6.3 The subject/observer pattern</a>
+<h1 class="chapter" id="sec64"><span class="number">Chapter 6</span>Advanced examples with classes and modules</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Advanced examples with classes and modules</a></li>
+<li><a href="advexamples.html#s%3Aextended-bank-accounts"><span class="number">1</span>Extended example: bank accounts</a>
+</li><li><a href="advexamples.html#s%3Amodules-as-classes"><span class="number">2</span>Simple modules as classes</a>
+</li><li><a href="advexamples.html#s%3Asubject-observer"><span class="number">3</span>The subject/observer pattern</a>
 </li></ul></nav></header>
 <p>
-<a id="c:advexamples"></a></p><p><span class="c010">(Chapter written by Didier Rémy)</span></p><p><br>
+<a id="c:advexamples"></a></p><p></p><p><br>
 <br>
 </p><p>In this chapter, we show some larger examples using objects, classes
 and modules. We review many of the object features simultaneously on
@@ -27,11 +27,11 @@ the example of a bank account. We show how modules taken from the
 standard library can be expressed as classes. Lastly, we describe a
 programming pattern known as <em>virtual types</em> through the example
 of window managers.</p>
-<h2 class="section" id="s:extended-bank-accounts"><a class="section-anchor" href="#s:extended-bank-accounts" aria-hidden="true"></a>6.1 Extended example: bank accounts</h2>
+<h2 class="section" id="s:extended-bank-accounts"><a class="section-anchor" href="#s:extended-bank-accounts" aria-hidden="true"></a><span class="number">1</span>Extended example: bank accounts</h2>
 <p>In this section, we illustrate most aspects of Object and inheritance
 by refining, debugging, and specializing the following
 initial naive definition of a simple bank account. (We reuse the
-module <span class="c004">Euro</span> defined at the end of chapter ‍<a href="objectexamples.html#c%3Aobjectexamples">3</a>.)
+module <span class="c004">Euro</span> defined at the end of chapter&nbsp;<a href="objectexamples.html#c%3Aobjectexamples">3</a>.)
 
 </p><div class="caml-example toplevel">
 
@@ -497,13 +497,13 @@ account can be given to the client.
     <span class="ocamlkeyword">end</span>;;</div></div>
 
 </div>
-<h2 class="section" id="s:modules-as-classes"><a class="section-anchor" href="#s:modules-as-classes" aria-hidden="true">﻿</a>6.2 Simple modules as classes</h2>
+<h2 class="section" id="s:modules-as-classes"><a class="section-anchor" href="#s:modules-as-classes" aria-hidden="true">﻿</a><span class="number">2</span>Simple modules as classes</h2>
 <p>One may wonder whether it is possible to treat primitive types such as
 integers and strings as objects. Although this is usually uninteresting
 for integers or strings, there may be some situations where
 this is desirable. The class <span class="c004">money</span> above is such an example.
 We show here how to do it for strings.</p>
-<h3 class="subsection" id="ss:string-as-class"><a class="section-anchor" href="#ss:string-as-class" aria-hidden="true">﻿</a>6.2.1 Strings</h3>
+<h3 class="subsection" id="ss:string-as-class"><a class="section-anchor" href="#ss:string-as-class" aria-hidden="true">﻿</a><span class="number">2.1</span>Strings</h3>
 <p>A naive definition of strings as objects could be:
 
 </p><div class="caml-example toplevel">
@@ -561,7 +561,7 @@ class.
 
 </div><p>
 
-As seen in section ‍<a href="objectexamples.html#s%3Abinary-methods">3.16</a>, the solution is to use
+As seen in section&nbsp;<a href="objectexamples.html#s%3Abinary-methods">3.16</a>, the solution is to use
 functional update instead. We need to create an instance variable
 containing the representation <span class="c004">s</span> of the string.
 
@@ -653,7 +653,7 @@ string of a given length:
 
 Here, exposing the representation of strings is probably harmless. We do
 could also hide the representation of strings as we hid the currency in the
-class <span class="c004">money</span> of section ‍<a href="objectexamples.html#s%3Afriends">3.17</a>.</p>
+class <span class="c004">money</span> of section&nbsp;<a href="objectexamples.html#s%3Afriends">3.17</a>.</p>
 <h4 class="subsubsection" id="sss:stack-as-class"><a class="section-anchor" href="#sss:stack-as-class" aria-hidden="true">﻿</a>Stacks</h4>
 <p>There is sometimes an alternative between using modules or classes for
 parametric data types.
@@ -799,7 +799,7 @@ the type checker cannot infer the polymorphic type by itself.
   <span class="ocamlkeyword">end</span></div></div>
 
 </div>
-<h3 class="subsection" id="ss:hashtbl-as-class"><a class="section-anchor" href="#ss:hashtbl-as-class" aria-hidden="true">﻿</a>6.2.2 Hashtbl</h3>
+<h3 class="subsection" id="ss:hashtbl-as-class"><a class="section-anchor" href="#ss:hashtbl-as-class" aria-hidden="true">﻿</a><span class="number">2.2</span>Hashtbl</h3>
 <p>A simplified version of object-oriented hash tables should have the
 following class type.
 
@@ -867,11 +867,11 @@ true hash table… whose elements are small hash tables!
 <div class="pre caml-output ok"><span class="ocamlkeyword">class</span> ['a, 'b] hashtbl : int -&gt; ['a, 'b] hash_table</div></div>
 
 </div>
-<h3 class="subsection" id="ss:set-as-class"><a class="section-anchor" href="#ss:set-as-class" aria-hidden="true">﻿</a>6.2.3 Sets</h3>
+<h3 class="subsection" id="ss:set-as-class"><a class="section-anchor" href="#ss:set-as-class" aria-hidden="true">﻿</a><span class="number">2.3</span>Sets</h3>
 <p>Implementing sets leads to another difficulty. Indeed, the method
 <span class="c004">union</span> needs to be able to access the internal representation of
 another object of the same class.</p><p>This is another instance of friend functions as seen in
-section ‍<a href="objectexamples.html#s%3Afriends">3.17</a>. Indeed, this is the same mechanism used in the module
+section&nbsp;<a href="objectexamples.html#s%3Afriends">3.17</a>. Indeed, this is the same mechanism used in the module
 <span class="c004">Set</span> in the absence of objects.</p><p>In the object-oriented version of sets, we only need to add an additional
 method <span class="c004">tag</span> to return the representation of a set. Since sets are
 parametric in the type of elements, the method <span class="c004">tag</span> has a parametric type
@@ -929,7 +929,7 @@ of the same type will share the same representation.
     <span class="ocamlkeyword">end</span>;;</div></div>
 
 </div>
-<h2 class="section" id="s:subject-observer"><a class="section-anchor" href="#s:subject-observer" aria-hidden="true">﻿</a>6.3 The subject/observer pattern</h2>
+<h2 class="section" id="s:subject-observer"><a class="section-anchor" href="#s:subject-observer" aria-hidden="true">﻿</a><span class="number">3</span>The subject/observer pattern</h2>
 <p>The following example, known as the subject/observer pattern, is often
 presented in the literature as a difficult inheritance problem with
 inter-connected classes.
@@ -1252,10 +1252,10 @@ and attach several observers to the same object:
 
 </div>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="polymorphism.html">« Chapter ‍5 Polymorphism and its limitations</a><a class="next" href="language.html">Chapter ‍7 The OCaml language »</a></div>
+<div class="bottom-navigation"><a class="previous" href="polymorphism.html">« Polymorphism and its limitations</a><a class="next" href="language.html">The OCaml language »</a></div>
 
 
 
 
-<div class="copyright">Copyright © 2021 Institut National de
+<span class="authors c010">(Chapter written by Didier Rémy)</span><div class="copyright">Copyright © 2021 Institut National de
 Recherche en Informatique et en Automatique</div></div></body></html>

--- a/site/releases/4.12/htmlman/afl-fuzz.html
+++ b/site/releases/4.12/htmlman/afl-fuzz.html
@@ -5,21 +5,21 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍20 Fuzzing with afl-fuzz</title>
+<title>OCaml - Fuzzing with afl-fuzz</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li class="active"><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li class="active"><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec546">Chapter ‍20 Fuzzing with afl-fuzz</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍20 Fuzzing with afl-fuzz</a></li>
-<li><a href="afl-fuzz.html#s%3Aafl-overview">20.1 Overview</a>
-</li><li><a href="afl-fuzz.html#s%3Aafl-generate">20.2 Generating instrumentation</a>
-</li><li><a href="afl-fuzz.html#s%3Aafl-example">20.3 Example</a>
+<h1 class="chapter" id="sec546"><span class="number">Chapter 20</span>Fuzzing with afl-fuzz</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Fuzzing with afl-fuzz</a></li>
+<li><a href="afl-fuzz.html#s%3Aafl-overview"><span class="number">1</span>Overview</a>
+</li><li><a href="afl-fuzz.html#s%3Aafl-generate"><span class="number">2</span>Generating instrumentation</a>
+</li><li><a href="afl-fuzz.html#s%3Aafl-example"><span class="number">3</span>Example</a>
 </li></ul></nav></header>
 
-<h2 class="section" id="s:afl-overview"><a class="section-anchor" href="#s:afl-overview" aria-hidden="true"></a>20.1 Overview</h2>
+<h2 class="section" id="s:afl-overview"><a class="section-anchor" href="#s:afl-overview" aria-hidden="true"></a><span class="number">1</span>Overview</h2>
 <p>American fuzzy lop (“afl-fuzz”) is a <em>fuzzer</em>, a tool for
 testing software by providing randomly-generated inputs, searching for
 those inputs which cause the program to crash.</p><p>Unlike most fuzzers, afl-fuzz observes the internal behaviour of the
@@ -32,17 +32,17 @@ generate such instrumentation, allowing afl-fuzz to be used against
 programs written in OCaml.</p><p>For more information on afl-fuzz, see the website at
 <a href="http://lcamtuf.coredump.cx/afl/">http://lcamtuf.coredump.cx/afl/</a>.
 </p>
-<h2 class="section" id="s:afl-generate"><a class="section-anchor" href="#s:afl-generate" aria-hidden="true">﻿</a>20.2 Generating instrumentation</h2>
+<h2 class="section" id="s:afl-generate"><a class="section-anchor" href="#s:afl-generate" aria-hidden="true">﻿</a><span class="number">2</span>Generating instrumentation</h2>
 <p>The instrumentation that afl-fuzz requires is not generated by
 default, and must be explicitly enabled, by passing the <span class="c004">-afl-instrument</span> option to <span class="c004">ocamlopt</span>.</p><p>To fuzz a large system without modifying build tools, OCaml’s <span class="c004">configure</span> script also accepts the <span class="c004">afl-instrument</span> option. If
 OCaml is configured with <span class="c004">afl-instrument</span>, then all programs
 compiled by <span class="c004">ocamlopt</span> will be instrumented.</p>
-<h3 class="subsection" id="ss:afl-advanced"><a class="section-anchor" href="#ss:afl-advanced" aria-hidden="true">﻿</a>20.2.1 Advanced options</h3>
+<h3 class="subsection" id="ss:afl-advanced"><a class="section-anchor" href="#ss:afl-advanced" aria-hidden="true">﻿</a><span class="number">2.1</span>Advanced options</h3>
 <p>In rare cases, it is useful to control the amount of instrumentation
 generated. By passing the <span class="c004">-afl-inst-ratio N</span> argument to <span class="c004">ocamlopt</span> with <span class="c004">N</span> less than 100, instrumentation can be
 generated for only N% of branches. (See the afl-fuzz documentation on
 the parameter <span class="c004">AFL_INST_RATIO</span> for the precise effect of this).</p>
-<h2 class="section" id="s:afl-example"><a class="section-anchor" href="#s:afl-example" aria-hidden="true">﻿</a>20.3 Example</h2>
+<h2 class="section" id="s:afl-example"><a class="section-anchor" href="#s:afl-example" aria-hidden="true">﻿</a><span class="number">3</span>Example</h2>
 <p>As an example, we fuzz-test the following program, <span class="c004">readline.ml</span>:</p><pre>let _ =
   let s = read_line () in
   match Array.to_list (Array.init (String.length s) (String.get s)) with
@@ -61,7 +61,7 @@ afl-fuzz -i input -o output ./readline
 
 </p>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="flambda.html">« Chapter ‍19 Optimisation with Flambda</a><a class="next" href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime »</a></div>
+<div class="bottom-navigation"><a class="previous" href="flambda.html">« Optimisation with Flambda</a><a class="next" href="instrumented-runtime.html">Runtime tracing with the instrumented runtime »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/alerts.html
+++ b/site/releases/4.12/htmlman/alerts.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:alerts"><a class="section-anchor" href="#s:alerts" aria-hidden="true"></a>8.21 Alerts</h2>
+<h2 class="section" id="s:alerts"><a class="section-anchor" href="#s:alerts" aria-hidden="true"></a><span class="number">21</span>Alerts</h2>
 <p>
 (Introduced in 4.08)</p><p>Since OCaml 4.08, it is possible to mark components (such as value or
 type declarations) in signatures with “alerts” that will be reported
@@ -104,7 +104,7 @@ is equivalent to:</p><pre>val x: int
   [@@@ocaml.alert deprecated "Please do something else"]
 </pre>
 
-<div class="bottom-navigation"><a class="previous" href="emptyvariants.html">« 8.20 Empty variant types</a><a class="next" href="generalizedopens.html">8.22 Generalized open statements »</a></div>
+<div class="bottom-navigation"><a class="previous" href="emptyvariants.html">« Empty variant types</a><a class="next" href="generalizedopens.html">Generalized open statements »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/attributes.html
+++ b/site/releases/4.12/htmlman/attributes.html
@@ -5,45 +5,45 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:attributes"><a class="section-anchor" href="#s:attributes" aria-hidden="true"></a>8.12 Attributes</h2>
+<h2 class="section" id="s:attributes"><a class="section-anchor" href="#s:attributes" aria-hidden="true"></a><span class="number">12</span>Attributes</h2>
 <ul>
-<li><a href="attributes.html#ss%3Abuiltin-attributes">8.12.1 Built-in attributes</a>
+<li><a href="attributes.html#ss%3Abuiltin-attributes"><span class="number">12.1</span>Built-in attributes</a>
 </li></ul>
 <p><a id="hevea_manual.kwd227"></a></p><p>(Introduced in OCaml 4.02,
 infix notations for constructs other than expressions added in 4.03)</p><p>Attributes are “decorations” of the syntax tree which are mostly
@@ -293,7 +293,7 @@ For <span class="c004">let</span>, the attributes are applied to each bindings:<
 let[@foo] x = 2
 and[@bar] y = 3 in x + y           === (let x = 2 [@@foo] and y = 3 [@@bar] in x + y)
 </pre>
-<h3 class="subsection" id="ss:builtin-attributes"><a class="section-anchor" href="#ss:builtin-attributes" aria-hidden="true">﻿</a>8.12.1 Built-in attributes</h3>
+<h3 class="subsection" id="ss:builtin-attributes"><a class="section-anchor" href="#ss:builtin-attributes" aria-hidden="true">﻿</a><span class="number">12.1</span>Built-in attributes</h3>
 <p>Some attributes are understood by the type-checker:
 </p><ul class="itemize"><li class="li-itemize">
 “ocaml.warning” or “warning”, with a string literal payload.
@@ -309,8 +309,8 @@ Note that it is not well-defined which scope is used for a specific
 warning. This is implementation dependent and can change between versions.
 Some warnings are even completely outside the control of “ocaml.warning”
 (for instance, warnings 1, 2, 14, 29 and 50).</li><li class="li-itemize">“ocaml.warnerror” or “warnerror”, with a string literal payload.
-Same as “ocaml.warning”, for the <span class="c004">-warn-error</span> command-line option.</li><li class="li-itemize">“ocaml.alert” or “alert”: see section ‍<a href="alerts.html#s%3Aalerts">8.21</a>.</li><li class="li-itemize">“ocaml.deprecated” or “deprecated”: alias for the
-“deprecated” alert, see section ‍<a href="alerts.html#s%3Aalerts">8.21</a>.
+Same as “ocaml.warning”, for the <span class="c004">-warn-error</span> command-line option.</li><li class="li-itemize">“ocaml.alert” or “alert”: see section&nbsp;<a href="alerts.html#s%3Aalerts">8.21</a>.</li><li class="li-itemize">“ocaml.deprecated” or “deprecated”: alias for the
+“deprecated” alert, see section&nbsp;<a href="alerts.html#s%3Aalerts">8.21</a>.
 </li><li class="li-itemize">“ocaml.deprecated_mutable” or “deprecated_mutable”.
 Can be applied to a mutable record label. If the label is later
 used to modify the field (with “expr.l &lt;- expr”), the “deprecated” alert
@@ -533,7 +533,7 @@ val fragile_match_2 : fragile -&gt; unit = &lt;fun&gt;</div></div>
 
 </div>
 
-<div class="bottom-navigation"><a class="previous" href="bigarray.html">« 8.11 Syntax for Bigarray access</a><a class="next" href="extensionnodes.html">8.13 Extension nodes »</a></div>
+<div class="bottom-navigation"><a class="previous" href="bigarray.html">« Syntax for Bigarray access</a><a class="next" href="extensionnodes.html">Extension nodes »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/bigarray.html
+++ b/site/releases/4.12/htmlman/bigarray.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:bigarray-access"><a class="section-anchor" href="#s:bigarray-access" aria-hidden="true"></a>8.11 Syntax for Bigarray access</h2>
+<h2 class="section" id="s:bigarray-access"><a class="section-anchor" href="#s:bigarray-access" aria-hidden="true"></a><span class="number">11</span>Syntax for Bigarray access</h2>
 <p>(Introduced in Objective Caml 3.00)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a></td><td class="c016">::=</td><td class="c018">
 ...
@@ -68,7 +68,7 @@ elements in the arrays provided by the <a href="../api/Bigarray.html"><span clas
  <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a><sub><span class="c010">n</span></sub> <span class="c005">|]</span>  <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a> </td></tr>
 </tbody></table></div></div><p>The last two entries are valid for any <span class="c010">n</span> &gt; 3.</p>
 
-<div class="bottom-navigation"><a class="previous" href="gadts.html">« 8.10 Generalized algebraic datatypes</a><a class="next" href="attributes.html">8.12 Attributes »</a></div>
+<div class="bottom-navigation"><a class="previous" href="gadts.html">« Generalized algebraic datatypes</a><a class="next" href="attributes.html">Attributes »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/bindingops.html
+++ b/site/releases/4.12/htmlman/bindingops.html
@@ -5,44 +5,44 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
-<h2 class="section" id="s:binding-operators"><a class="section-anchor" href="#s:binding-operators" aria-hidden="true"></a>8.23 Binding operators</h2>
+<h2 class="section" id="s:binding-operators"><a class="section-anchor" href="#s:binding-operators" aria-hidden="true"></a><span class="number">23</span>Binding operators</h2>
 <ul>
-<li><a href="bindingops.html#ss%3Aletops-rationale">8.23.1 Rationale</a>
+<li><a href="bindingops.html#ss%3Aletops-rationale"><span class="number">23.1</span>Rationale</a>
 </li></ul>
 <p>
 (Introduced in 4.08.0)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -193,7 +193,7 @@
 <div class="pre caml-output ok"><span class="ocamlkeyword">val</span> sum3 : int Seq.t -&gt; int Seq.t -&gt; int Seq.t -&gt; int Seq.t = &lt;<span class="ocamlkeyword">fun</span>&gt;</div></div>
 
 </div>
-<h3 class="subsection" id="ss:letops-rationale"><a class="section-anchor" href="#ss:letops-rationale" aria-hidden="true">﻿</a>8.23.1 Rationale</h3>
+<h3 class="subsection" id="ss:letops-rationale"><a class="section-anchor" href="#ss:letops-rationale" aria-hidden="true">﻿</a><span class="number">23.1</span>Rationale</h3>
 <p>This extension is intended to provide a convenient syntax for working
 with monads and applicatives.</p><p>An applicative should provide a module implementing the following
 interface:</p><div class="caml-example verbatim">
@@ -223,7 +223,7 @@ the monoidal product operation.</p><p>A monad should provide a module implementi
 
 </div><p>where <span class="c004">(let*)</span> is bound to the <span class="c004">bind</span> operation, and <span class="c004">(and*)</span> is also
 bound to the monoidal product operation.</p>
-<div class="bottom-navigation"><a class="previous" href="generalizedopens.html">« 8.22 Generalized open statements</a><a class="next up" href="extn.html">Chapter ‍8 Language extensions</a></div>
+<div class="bottom-navigation"><a class="previous" href="generalizedopens.html">« Generalized open statements</a><a class="next up" href="extn.html">Language extensions</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/classes.html
+++ b/site/releases/4.12/htmlman/classes.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:classes"><a class="section-anchor" href="#s:classes" aria-hidden="true"></a>7.9 Classes</h2>
+<h2 class="section" id="s:classes"><a class="section-anchor" href="#s:classes" aria-hidden="true"></a><span class="number">9</span>Classes</h2>
 <ul>
-<li><a href="classes.html#ss%3Aclasses%3Aclass-types">7.9.1 Class types</a>
-</li><li><a href="classes.html#ss%3Aclass-expr">7.9.2 Class expressions</a>
-</li><li><a href="classes.html#ss%3Aclass-def">7.9.3 Class definitions</a>
-</li><li><a href="classes.html#ss%3Aclass-spec">7.9.4 Class specifications</a>
-</li><li><a href="classes.html#ss%3Aclasstype">7.9.5 Class type definitions</a>
+<li><a href="classes.html#ss%3Aclasses%3Aclass-types"><span class="number">9.1</span>Class types</a>
+</li><li><a href="classes.html#ss%3Aclass-expr"><span class="number">9.2</span>Class expressions</a>
+</li><li><a href="classes.html#ss%3Aclass-def"><span class="number">9.3</span>Class definitions</a>
+</li><li><a href="classes.html#ss%3Aclass-spec"><span class="number">9.4</span>Class specifications</a>
+</li><li><a href="classes.html#ss%3Aclasstype"><span class="number">9.5</span>Class type definitions</a>
 </li></ul>
 <p>
 Classes are defined using a small language, similar to the module
 language.</p>
-<h3 class="subsection" id="ss:classes:class-types"><a class="section-anchor" href="#ss:classes:class-types" aria-hidden="true">﻿</a>7.9.1 Class types</h3>
+<h3 class="subsection" id="ss:classes:class-types"><a class="section-anchor" href="#ss:classes:class-types" aria-hidden="true">﻿</a><span class="number">9.1</span>Class types</h3>
 <p>Class types are the class-level equivalent of type expressions: they
 specify the general shape and type properties of classes.</p><p><a id="hevea_manual.kwd101"></a>
 <a id="hevea_manual.kwd102"></a>
@@ -144,7 +144,7 @@ name of the method and <a class="syntax" href="types.html#poly-typexpr"><span cl
 type expressions to be equal. This is typically used to specify type
 parameters: in this way, they can be bound to specific type
 expressions.</p>
-<h3 class="subsection" id="ss:class-expr"><a class="section-anchor" href="#ss:class-expr" aria-hidden="true">﻿</a>7.9.2 Class expressions</h3>
+<h3 class="subsection" id="ss:class-expr"><a class="section-anchor" href="#ss:class-expr" aria-hidden="true">﻿</a><span class="number">9.2</span>Class expressions</h3>
 <p>Class expressions are the class-level equivalent of value expressions:
 they evaluate to classes, thus providing implementations for the
 specifications expressed in class types.</p><p><a id="hevea_manual.kwd118"></a>
@@ -353,9 +353,9 @@ overriding. Namely, <span class="c005">method!</span> requires <a class="syntax"
 defined in this class, <span class="c005">val!</span> requires <a class="syntax" href="names.html#inst-var-name"><span class="c011">inst-var-name</span></a> to be already
 defined in this class, and <span class="c005">inherit!</span> requires <a class="syntax" href="#class-expr"><span class="c011">class-expr</span></a> to
 override some definitions. If no such overriding occurs, an error is
-signaled.</p><p>As a side-effect, these 3 keywords avoid the warnings ‍7
-(method override) and ‍13 (instance variable override).
-Note that warning ‍7 is disabled by default.</p><h4 class="subsubsection" id="sss:class-type-constraints"><a class="section-anchor" href="#sss:class-type-constraints" aria-hidden="true">﻿</a>Constraints on type parameters</h4>
+signaled.</p><p>As a side-effect, these 3 keywords avoid the warnings&nbsp;7
+(method override) and&nbsp;13 (instance variable override).
+Note that warning&nbsp;7 is disabled by default.</p><h4 class="subsubsection" id="sss:class-type-constraints"><a class="section-anchor" href="#sss:class-type-constraints" aria-hidden="true">﻿</a>Constraints on type parameters</h4>
 <p><a id="hevea_manual.kwd141"></a>
 The construct <span class="c005">constraint</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a><sub>1</sub> <span class="c005">=</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a><sub>2</sub> forces the two
 type expressions to be equals. This is typically used to specify type
@@ -364,7 +364,7 @@ expressions.</p><h4 class="subsubsection" id="sss:class-initializers"><a class="
 <p><a id="hevea_manual.kwd142"></a></p><p>A class initializer <span class="c005">initializer</span> <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a> specifies an expression that
 will be evaluated whenever an object is created from the class, once
 all its instance variables have been initialized.</p>
-<h3 class="subsection" id="ss:class-def"><a class="section-anchor" href="#ss:class-def" aria-hidden="true">﻿</a>7.9.3 Class definitions</h3>
+<h3 class="subsection" id="ss:class-def"><a class="section-anchor" href="#ss:class-def" aria-hidden="true">﻿</a><span class="number">9.3</span>Class definitions</h3>
 <p>
 <a id="s:classdef"></a></p><p><a id="hevea_manual.kwd143"></a>
 <a id="hevea_manual.kwd144"></a></p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -392,7 +392,7 @@ the type of the class, and defines two type abbreviations :
 <a class="syntax" href="names.html#class-name"><span class="c011">class-name</span></a> and <span class="c005">#</span> <a class="syntax" href="names.html#class-name"><span class="c011">class-name</span></a>. The first one is the type of
 objects of this class, while the second is more general as it unifies
 with the type of any object belonging to a subclass (see
-section ‍<a href="types.html#sss%3Atypexpr-sharp-types">7.4</a>).</p><h4 class="subsubsection" id="sss:class-virtual"><a class="section-anchor" href="#sss:class-virtual" aria-hidden="true">﻿</a>Virtual class</h4>
+section&nbsp;<a href="types.html#sss%3Atypexpr-sharp-types">7.4</a>).</p><h4 class="subsubsection" id="sss:class-virtual"><a class="section-anchor" href="#sss:class-virtual" aria-hidden="true">﻿</a>Virtual class</h4>
 <p>A class must be flagged virtual if one of its methods is virtual (that
 is, appears in the class type, but is not actually defined).
 Objects cannot be created from a virtual class.</p><h4 class="subsubsection" id="sss:class-type-params"><a class="section-anchor" href="#sss:class-type-params" aria-hidden="true">﻿</a>Type parameters</h4>
@@ -402,7 +402,7 @@ be bound to actual types in the class definition using type
 constraints. So that the abbreviations are well-formed, type
 variables of the inferred type of the class must either be type
 parameters or be bound in the constraint clause.</p>
-<h3 class="subsection" id="ss:class-spec"><a class="section-anchor" href="#ss:class-spec" aria-hidden="true">﻿</a>7.9.4 Class specifications</h3>
+<h3 class="subsection" id="ss:class-spec"><a class="section-anchor" href="#ss:class-spec" aria-hidden="true">﻿</a><span class="number">9.4</span>Class specifications</h3>
 <p><a id="hevea_manual.kwd145"></a>
 <a id="hevea_manual.kwd146"></a></p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" id="class-specification"><span class="c011">class-specification</span></a></td><td class="c016">::=</td><td class="c018">
@@ -418,7 +418,7 @@ parameters or be bound in the constraint clause.</p>
 </tbody></table></div><p>This is the counterpart in signatures of class definitions.
 A class specification matches a class definition if they have the same
 type parameters and their types match.</p>
-<h3 class="subsection" id="ss:classtype"><a class="section-anchor" href="#ss:classtype" aria-hidden="true">﻿</a>7.9.5 Class type definitions</h3>
+<h3 class="subsection" id="ss:classtype"><a class="section-anchor" href="#ss:classtype" aria-hidden="true">﻿</a><span class="number">9.5</span>Class type definitions</h3>
 <p><a id="hevea_manual.kwd147"></a>
 <a id="hevea_manual.kwd148"></a>
 <a id="hevea_manual.kwd149"></a></p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -442,7 +442,7 @@ and they expand to matching types.
 
 </p>
 
-<div class="bottom-navigation"><a class="previous" href="typedecl.html">« 7.8 Type and exception definitions</a><a class="next" href="modtypes.html">7.10 Module types (module specifications) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="typedecl.html">« Type and exception definitions</a><a class="next" href="modtypes.html">Module types (module specifications) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/comp.html
+++ b/site/releases/4.12/htmlman/comp.html
@@ -5,20 +5,20 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍9 Batch compilation (ocamlc)</title>
+<title>OCaml - Batch compilation (ocamlc)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li class="active"><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li class="active"><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec287">Chapter ‍9 Batch compilation (ocamlc)</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍9 Batch compilation (ocamlc)</a></li>
-<li><a href="comp.html#s%3Acomp-overview">9.1 Overview of the compiler</a>
-</li><li><a href="comp.html#s%3Acomp-options">9.2 Options</a>
-</li><li><a href="comp.html#s%3Amodules-file-system">9.3 Modules and the file system</a>
-</li><li><a href="comp.html#s%3Acomp-errors">9.4 Common errors</a>
-</li><li><a href="comp.html#s%3Acomp-warnings">9.5 Warning reference</a>
+<h1 class="chapter" id="sec287"><span class="number">Chapter 9</span>Batch compilation (ocamlc)</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Batch compilation (ocamlc)</a></li>
+<li><a href="comp.html#s%3Acomp-overview"><span class="number">1</span>Overview of the compiler</a>
+</li><li><a href="comp.html#s%3Acomp-options"><span class="number">2</span>Options</a>
+</li><li><a href="comp.html#s%3Amodules-file-system"><span class="number">3</span>Modules and the file system</a>
+</li><li><a href="comp.html#s%3Acomp-errors"><span class="number">4</span>Common errors</a>
+</li><li><a href="comp.html#s%3Acomp-warnings"><span class="number">5</span>Warning reference</a>
 </li></ul></nav></header>
 <p> <a id="c:camlc"></a>
 </p><p>This chapter describes the OCaml batch compiler <span class="c004">ocamlc</span>,
@@ -26,7 +26,7 @@ which compiles OCaml source files to bytecode object files and links
 these object files to produce standalone bytecode executable files.
 These executable files are then run by the bytecode interpreter
 <span class="c004">ocamlrun</span>.</p>
-<h2 class="section" id="s:comp-overview"><a class="section-anchor" href="#s:comp-overview" aria-hidden="true"></a>9.1 Overview of the compiler</h2>
+<h2 class="section" id="s:comp-overview"><a class="section-anchor" href="#s:comp-overview" aria-hidden="true"></a><span class="number">1</span>Overview of the compiler</h2>
 <p>The <span class="c004">ocamlc</span> command has a command-line interface similar to the one of
 most C compilers. It accepts several types of arguments and processes them
 sequentially, after all options have been processed:</p><ul class="itemize"><li class="li-itemize">
@@ -80,7 +80,7 @@ produced by the linking phase, the command
 </pre><p>
 executes the compiled code contained in <span class="c004">a.out</span>, passing it as
 arguments the character strings <span class="c010">arg</span><sub>1</sub> to <span class="c010">arg</span><sub><span class="c010">n</span></sub>.
-(See chapter ‍<a href="runtime.html#c%3Aruntime">11</a> for more details.)</p><p>On most systems, the file produced by the linking
+(See chapter&nbsp;<a href="runtime.html#c%3Aruntime">11</a> for more details.)</p><p>On most systems, the file produced by the linking
 phase can be run directly, as in:
 </p><pre>        ./a.out <span class="c010">arg</span><sub>1</sub> <span class="c010">arg</span><sub>2</sub> … <span class="c010">arg</span><sub><span class="c010">n</span></sub>
 </pre><p>
@@ -93,7 +93,7 @@ Each such file contains a typed abstract syntax tree (AST), that is produced
 during the type checking procedure. This tree contains all available information
 about the location and the specific type of each term in the source file.
 The AST is partial if type checking was unsuccessful.</p><p>These <span class="c004">.cmt</span> and <span class="c004">.cmti</span> files are typically useful for code inspection tools.</p>
-<h2 class="section" id="s:comp-options"><a class="section-anchor" href="#s:comp-options" aria-hidden="true">﻿</a>9.2 Options</h2>
+<h2 class="section" id="s:comp-options"><a class="section-anchor" href="#s:comp-options" aria-hidden="true">﻿</a><span class="number">2</span>Options</h2>
 <p>The following command-line options are recognized by <span class="c004">ocamlc</span>.
 The options <span class="c004">-pack</span>, <span class="c004">-a</span>, <span class="c004">-c</span> and <span class="c004">-output-obj</span> are mutually exclusive.
 </p><dl class="description"><dt class="dt-description">
@@ -184,7 +184,7 @@ and the bytecode for the program. The resulting file is larger, but it
 can be executed directly, even if the <span class="c004">ocamlrun</span> command is not
 installed. Moreover, the “custom runtime” mode enables static
 linking of OCaml code with user-defined C functions, as described in
-chapter ‍<a href="intfc.html#c%3Aintf-c">18</a>.
+chapter&nbsp;<a href="intfc.html#c%3Aintf-c">18</a>.
 <blockquote class="quote"><span class="c008">Unix:</span> 
 Never use the <span class="c004">strip</span> command on executables produced by <span class="c004">ocamlc -custom</span>,
 this would remove the bytecode part of the executable.
@@ -206,7 +206,7 @@ C libraries. At link-time, shared libraries are searched in the
 standard search path (the one corresponding to the <span class="c004">-I</span> option).
 The <span class="c004">-dllpath</span> option simply stores <span class="c010">dir</span> in the produced
 executable file, where <span class="c004">ocamlrun</span> can find it and use it as
-described in section ‍<a href="runtime.html#s%3Aocamlrun-dllpath">11.3</a>.
+described in section&nbsp;<a href="runtime.html#s%3Aocamlrun-dllpath">11.3</a>.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">-for-pack</span> <span class="c010">module-path</span></span></dt><dd class="dd-description">
 Generate an object file (<span class="c004">.cmo</span>)
 that can later be included
@@ -221,9 +221,9 @@ names.
 </dd><dt class="dt-description"><span class="c007">-g</span></dt><dd class="dd-description">
 Add debugging information while compiling and linking. This option is
 required in order to be able to debug the program with <span class="c004">ocamldebug</span>
-(see chapter ‍<a href="debugger.html#c%3Adebugger">16</a>), and to produce stack backtraces when
+(see chapter&nbsp;<a href="debugger.html#c%3Adebugger">16</a>), and to produce stack backtraces when
 the program terminates on an uncaught exception (see
-section ‍<a href="runtime.html#s%3Aocamlrun-options">11.2</a>).
+section&nbsp;<a href="runtime.html#s%3Aocamlrun-options">11.2</a>).
 </dd><dt class="dt-description"><span class="c007">-i</span></dt><dd class="dd-description">
 Cause the compiler to print all defined names (with their inferred
 types or their definitions) when compiling an implementation (<span class="c004">.ml</span>
@@ -269,7 +269,7 @@ incorporating the C object files and libraries given on the command
 line. This custom runtime system can be used later to execute
 bytecode executables produced with the
 <span class="c004">ocamlc -use-runtime</span> <span class="c010">runtime-name</span> option.
-See section ‍<a href="intfc.html#ss%3Acustom-runtime">18.1.6</a> for more information.
+See section&nbsp;<a href="intfc.html#ss%3Acustom-runtime">18.1.6</a> for more information.
 </dd><dt class="dt-description"><span class="c007">-match-context-rows</span></dt><dd class="dd-description">
 Set the number of rows of context used for optimization during
 pattern matching compilation. The default value is 32. Lower values
@@ -278,7 +278,7 @@ option is meant for use in the event that a pattern-match-heavy
 program leads to significant increases in compilation time.
 </dd><dt class="dt-description"><span class="c007">-no-alias-deps</span></dt><dd class="dd-description">
 Do not record dependencies for module aliases. See
-section ‍<a href="modulealias.html#s%3Amodule-alias">8.8</a> for more information.
+section&nbsp;<a href="modulealias.html#s%3Amodule-alias">8.8</a> for more information.
 </dd><dt class="dt-description"><span class="c007">-no-app-funct</span></dt><dd class="dd-description">
 Deactivates the applicative behaviour of functors. With this option,
 each functor application generates new types in its result and
@@ -345,8 +345,8 @@ were added at the top of each file.
 Cause the linker to produce a C object file instead of
 a bytecode executable file.
 This is useful to wrap OCaml code as a C library,
-callable from any C program. See chapter ‍<a href="intfc.html#c%3Aintf-c">18</a>,
-section ‍<a href="intfc.html#ss%3Ac-embedded-code">18.7.5</a>. The name of the output object file
+callable from any C program. See chapter&nbsp;<a href="intfc.html#c%3Aintf-c">18</a>,
+section&nbsp;<a href="intfc.html#ss%3Ac-embedded-code">18.7.5</a>. The name of the output object file
 must be set with the <span class="c004">-o</span> option.
 This option can also be used to produce a C source file (<span class="c004">.c</span> extension)
 or a compiled shared/dynamic library (<span class="c004">.so</span> extension, <span class="c004">.dll</span> under Windows).
@@ -376,7 +376,7 @@ errors, the intermediate file is deleted afterwards.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">-ppx</span> <span class="c010">command</span></span></dt><dd class="dd-description">
 After parsing, pipe the abstract syntax tree through the preprocessor
 <span class="c010">command</span>. The module <span class="c004">Ast_mapper</span>, described in
-chapter ‍<a href="parsing.html#c%3Aparsinglib">24</a>:
+chapter&nbsp;<a href="parsing.html#c%3Aparsinglib">24</a>:
 <a href="../api/compilerlibref/Ast_mapper.html"> <span class="c004">Ast_mapper</span> </a>
 ,
 implements the external interface of a preprocessor.</dd><dt class="dt-description"><span class="c007">-principal</span></dt><dd class="dd-description">
@@ -437,7 +437,7 @@ be used with new software.</dd><dt class="dt-description"><span class="c014"><sp
 Generate a bytecode executable file that can be executed on the custom
 runtime system <span class="c010">runtime-name</span>, built earlier with
 <span class="c004">ocamlc -make-runtime</span> <span class="c010">runtime-name</span>.
-See section ‍<a href="intfc.html#ss%3Acustom-runtime">18.1.6</a> for more information.
+See section&nbsp;<a href="intfc.html#ss%3Acustom-runtime">18.1.6</a> for more information.
 </dd><dt class="dt-description"><span class="c007">-v</span></dt><dd class="dd-description">
 Print the version number of the compiler and the location of the
 standard library directory, then exit.</dd><dt class="dt-description"><span class="c007">-verbose</span></dt><dd class="dd-description">
@@ -628,7 +628,7 @@ Alternative executable to use on native
 Windows for <span class="c004">flexlink</span> instead of the
 configured value. Primarily used for bootstrapping.
 </dd></dl>
-<h2 class="section" id="s:modules-file-system"><a class="section-anchor" href="#s:modules-file-system" aria-hidden="true">﻿</a>9.3 Modules and the file system</h2>
+<h2 class="section" id="s:modules-file-system"><a class="section-anchor" href="#s:modules-file-system" aria-hidden="true">﻿</a><span class="number">3</span>Modules and the file system</h2>
 <p>This short section is intended to clarify the relationship between the
 names of the modules corresponding to compilation units and the names
 of the files that contain their compiled interface and compiled
@@ -658,7 +658,7 @@ freely renamed once created. That’s because the linker never attempts
 to find by itself the <span class="c004">.cmo</span> file that implements a module with a
 given name: it relies instead on the user providing the list of <span class="c004">.cmo</span>
 files by hand.</p>
-<h2 class="section" id="s:comp-errors"><a class="section-anchor" href="#s:comp-errors" aria-hidden="true">﻿</a>9.4 Common errors</h2>
+<h2 class="section" id="s:comp-errors"><a class="section-anchor" href="#s:comp-errors" aria-hidden="true">﻿</a><span class="number">4</span>Common errors</h2>
 <p>This section describes and explains the most frequently encountered
 error messages.</p><dl class="description"><dt class="dt-description"><span class="c014">Cannot find file <span class="c010">filename</span></span></dt><dd class="dd-description">
 The named file could not be found in the current directory, nor in the
@@ -775,14 +775,14 @@ mod2.ml:    let g y = ... Mod1.f ...
 </pre></li></ul></dd><dt class="dt-description"><span class="c014">The external function <span class="c010">f</span> is not available</span></dt><dd class="dd-description">
 This error appears when trying to link code that calls external
 functions written in C. As explained in
-chapter ‍<a href="intfc.html#c%3Aintf-c">18</a>, such code must be linked with C libraries that
+chapter&nbsp;<a href="intfc.html#c%3Aintf-c">18</a>, such code must be linked with C libraries that
 implement the required <span class="c010">f</span> C function. If the C libraries in
 question are not shared libraries (DLLs), the code must be linked in
 “custom runtime” mode. Fix: add the required C libraries to the
 command line, and possibly the <span class="c004">-custom</span> option.</dd></dl>
-<h2 class="section" id="s:comp-warnings"><a class="section-anchor" href="#s:comp-warnings" aria-hidden="true">﻿</a>9.5 Warning reference</h2>
+<h2 class="section" id="s:comp-warnings"><a class="section-anchor" href="#s:comp-warnings" aria-hidden="true">﻿</a><span class="number">5</span>Warning reference</h2>
 <p>This section describes and explains in detail some warnings:</p>
-<h3 class="subsection" id="ss:warn9"><a class="section-anchor" href="#ss:warn9" aria-hidden="true">﻿</a>9.5.1 Warning 9: missing fields in a record pattern</h3>
+<h3 class="subsection" id="ss:warn9"><a class="section-anchor" href="#ss:warn9" aria-hidden="true">﻿</a><span class="number">5.1</span>Warning 9: missing fields in a record pattern</h3>
 <p>When pattern matching on records, it can be useful to match only few
 fields of a record. Eliding fields can be done either implicitly
 or explicitly by ending the record pattern with <span class="c004">; _</span>.
@@ -796,7 +796,7 @@ after the addition of new fields to a record type.</p><pre>type 'a point = {x : 
 let dx { x } = x (* implicit field elision: trigger warning 9 *)
 let dy { y; _ } = y (* explicit field elision: do not trigger warning 9 *)
 </pre>
-<h3 class="subsection" id="ss:warn52"><a class="section-anchor" href="#ss:warn52" aria-hidden="true">﻿</a>9.5.2 Warning 52: fragile constant pattern</h3>
+<h3 class="subsection" id="ss:warn52"><a class="section-anchor" href="#ss:warn52" aria-hidden="true">﻿</a><span class="number">5.2</span>Warning 52: fragile constant pattern</h3>
 <p>Some constructors, such as the exception constructors <span class="c004">Failure</span> and
 <span class="c004">Invalid_argument</span>, take as parameter a <span class="c004">string</span> value holding
 a text message intended for the user.</p><p>These text messages are usually not stable over time: call sites
@@ -857,7 +857,7 @@ those several cases.</p><p>For example,
   | Failure "int_of_string" -&gt; (0, true)
   | Failure "bool_of_string" -&gt; (-1, false)
 </pre><p> should be rewritten into more atomic tests. For example,
-using the <span class="c004">exception</span> patterns documented in Section ‍<a href="patterns.html#sss%3Aexception-match">7.6</a>,
+using the <span class="c004">exception</span> patterns documented in Section&nbsp;<a href="patterns.html#sss%3Aexception-match">7.6</a>,
 one can write:
 </p><pre>match int_of_string count_str with
   | exception (Failure _) -&gt; (0, true)
@@ -873,7 +873,7 @@ but different string values. In this case, you will have to check for
 specific string values. This is dangerous API design and it should be
 discouraged: it’s better to define more precise exception constructors
 than store useful information in strings.</p>
-<h3 class="subsection" id="ss:warn57"><a class="section-anchor" href="#ss:warn57" aria-hidden="true">﻿</a>9.5.3 Warning 57: Ambiguous or-pattern variables under guard</h3>
+<h3 class="subsection" id="ss:warn57"><a class="section-anchor" href="#ss:warn57" aria-hidden="true">﻿</a><span class="number">5.3</span>Warning 57: Ambiguous or-pattern variables under guard</h3>
 <p>The semantics of or-patterns in OCaml is specified with
 a left-to-right bias: a value <span class="c010">v</span> matches the pattern <span class="c010">p</span> <span class="c004">|</span> <span class="c010">q</span>
 if it matches <span class="c010">p</span> or <span class="c010">q</span>, but if it matches both,
@@ -881,18 +881,18 @@ the environment captured by the match is the environment captured by
 <span class="c010">p</span>, never the one captured by <span class="c010">q</span>.</p><p>While this property is generally intuitive, there is at least one specific
 case where a different semantics might be expected.
 Consider a pattern followed by a when-guard:
-<span class="c004">|</span> ‍<span class="c010">p</span> ‍<span class="c004">when</span> ‍<span class="c010">g</span> ‍<span class="c004">-&gt;</span> ‍<span class="c010">e</span>, for example:
+<span class="c004">|</span>&nbsp;<span class="c010">p</span>&nbsp;<span class="c004">when</span>&nbsp;<span class="c010">g</span>&nbsp;<span class="c004">-&gt;</span>&nbsp;<span class="c010">e</span>, for example:
 </p><pre>     | ((Const x, _) | (_, Const x)) when is_neutral x -&gt; branch
 </pre><p> The semantics is clear:
 match the scrutinee against the pattern, if it matches, test the guard,
 and if the guard passes, take the branch.
-In particular, consider the input <span class="c004">(Const</span> ‍<span class="c010">a</span><span class="c004">, Const</span> ‍<span class="c010">b</span><span class="c004">)</span>, where
-<span class="c010">a</span> fails the test <span class="c004">is_neutral</span> ‍<span class="c010">a</span>, while <span class="c010">b</span> passes the test
-<span class="c004">is_neutral</span> ‍<span class="c010">b</span>. With the left-to-right semantics, the clause above is
-<em>not</em> taken by its input: matching <span class="c004">(Const</span> ‍<span class="c010">a</span><span class="c004">, Const</span> ‍<span class="c010">b</span><span class="c004">)</span>
+In particular, consider the input <span class="c004">(Const</span>&nbsp;<span class="c010">a</span><span class="c004">, Const</span>&nbsp;<span class="c010">b</span><span class="c004">)</span>, where
+<span class="c010">a</span> fails the test <span class="c004">is_neutral</span>&nbsp;<span class="c010">a</span>, while <span class="c010">b</span> passes the test
+<span class="c004">is_neutral</span>&nbsp;<span class="c010">b</span>. With the left-to-right semantics, the clause above is
+<em>not</em> taken by its input: matching <span class="c004">(Const</span>&nbsp;<span class="c010">a</span><span class="c004">, Const</span>&nbsp;<span class="c010">b</span><span class="c004">)</span>
 against the or-pattern succeeds in the left branch, it returns the
-environment <span class="c010">x</span> ‍<span class="c004">-&gt;</span> ‍<span class="c010">a</span>, and then the guard
-<span class="c004">is_neutral</span> ‍<span class="c010">a</span> is tested and fails, the branch is not taken.</p><p>However, another semantics may be considered more natural here:
+environment <span class="c010">x</span>&nbsp;<span class="c004">-&gt;</span>&nbsp;<span class="c010">a</span>, and then the guard
+<span class="c004">is_neutral</span>&nbsp;<span class="c010">a</span> is tested and fails, the branch is not taken.</p><p>However, another semantics may be considered more natural here:
 any pair that has one side passing the test will take the branch. With this
 semantics the previous code fragment would be equivalent to
 </p><pre>     | (Const x, _) when is_neutral x -&gt; branch
@@ -905,7 +905,7 @@ to different parts of the scrutinees by different sides of a or-pattern.
 
 </p>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="extn.html">« Chapter ‍8 Language extensions</a><a class="next" href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="extn.html">« Language extensions</a><a class="next" href="toplevel.html">The toplevel system or REPL (ocaml) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/compunit.html
+++ b/site/releases/4.12/htmlman/compunit.html
@@ -5,31 +5,31 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
-<h2 class="section" id="s:compilation-units"><a class="section-anchor" href="#s:compilation-units" aria-hidden="true"></a>7.12 Compilation units</h2>
+<h2 class="section" id="s:compilation-units"><a class="section-anchor" href="#s:compilation-units" aria-hidden="true"></a><span class="number">12</span>Compilation units</h2>
 <div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" id="unit-interface"><span class="c011">unit-interface</span></a></td><td class="c016">::=</td><td class="c018"> { <a class="syntax" href="modtypes.html#specification"><span class="c011">specification</span></a>  [<span class="c005">;;</span>] }
  </td></tr>
@@ -47,7 +47,7 @@ definitions and expressions, just as the inside of a
 <span class="c005">struct</span> … <span class="c005">end</span> module
 expression. A compilation unit also has a name <span class="c011">unit-name</span>, derived
 from the names of the files containing the interface and the
-implementation (see chapter ‍<a href="comp.html#c%3Acamlc">9</a> for more details). A
+implementation (see chapter&nbsp;<a href="comp.html#c%3Acamlc">9</a> for more details). A
 compilation unit behaves roughly as the module definition
 </p><div class="center">
 <span class="c003"><span class="c004">module</span> <span class="c011">unit-name</span> <span class="c004">:</span> <span class="c004">sig</span></span>  <a class="syntax" href="#unit-interface"><span class="c011">unit-interface</span></a> <span class="c003"><span class="c004">end</span> <span class="c004">=</span>
@@ -66,11 +66,11 @@ implementation proceeds in the initial environment
 </div><p>
 where <span class="c011">name</span><sub>1</sub> …  <span class="c011">name</span><sub><span class="c010">n</span></sub> are the names of the other
 compilation units available in the search path (see
-chapter ‍<a href="comp.html#c%3Acamlc">9</a> for more details) and <a class="syntax" href="modtypes.html#specification"><span class="c011">specification</span></a><sub>1</sub> …
+chapter&nbsp;<a href="comp.html#c%3Acamlc">9</a> for more details) and <a class="syntax" href="modtypes.html#specification"><span class="c011">specification</span></a><sub>1</sub> …
  <a class="syntax" href="modtypes.html#specification"><span class="c011">specification</span></a><sub><span class="c010">n</span></sub> are their respective interfaces.
 
 </p>
-<div class="bottom-navigation"><a class="previous" href="modules.html">« 7.11 Module expressions (module implementations)</a><a class="next up" href="language.html">Chapter ‍7 The OCaml language</a></div>
+<div class="bottom-navigation"><a class="previous" href="modules.html">« Module expressions (module implementations)</a><a class="next up" href="language.html">The OCaml language</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/const.html
+++ b/site/releases/4.12/htmlman/const.html
@@ -5,32 +5,32 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:const"><a class="section-anchor" href="#s:const" aria-hidden="true"></a>7.5 Constants</h2>
+<h2 class="section" id="s:const"><a class="section-anchor" href="#s:const" aria-hidden="true"></a><span class="number">5</span>Constants</h2>
 <p><a id="hevea_manual.kwd11"></a>
 <a id="hevea_manual.kwd12"></a>
 <a id="hevea_manual.kwd13"></a>
@@ -79,7 +79,7 @@ constants <span class="c005">false</span>, <span class="c005">true</span>, <span
 
 </p>
 
-<div class="bottom-navigation"><a class="previous" href="types.html">« 7.4 Type expressions</a><a class="next" href="patterns.html">7.6 Patterns »</a></div>
+<div class="bottom-navigation"><a class="previous" href="types.html">« Type expressions</a><a class="next" href="patterns.html">Patterns »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/core.html
+++ b/site/releases/4.12/htmlman/core.html
@@ -5,17 +5,17 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍22 The core library</title>
+<title>OCaml - The core library</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍IV The OCaml library</nav><ul id="part-menu"><li class="active"><a href="core.html">Chapter ‍22 The core library</a></li><li><a href="stdlib.html">Chapter ‍23 The standard library</a></li><li><a href="parsing.html">Chapter ‍24 The compiler front-end</a></li><li><a href="libunix.html">Chapter ‍25 The unix library: Unix system calls</a></li><li><a href="libstr.html">Chapter ‍26 The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">Chapter ‍27 The threads library</a></li><li><a href="libdynlink.html">Chapter ‍28 The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li class="active"><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec563">Chapter ‍22 The core library</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍22 The core library</a></li>
-<li><a href="core.html#s%3Acore-builtins">22.1 Built-in types and predefined exceptions</a>
-</li><li><a href="core.html#s%3Astdlib-module">22.2 Module <span class="c004">Stdlib</span>: the initially opened module</a>
+<h1 class="chapter" id="sec563"><span class="number">Chapter 22</span>The core library</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The core library</a></li>
+<li><a href="core.html#s%3Acore-builtins"><span class="number">1</span>Built-in types and predefined exceptions</a>
+</li><li><a href="core.html#s%3Astdlib-module"><span class="number">2</span>Module <span class="c004">Stdlib</span>: the initially opened module</a>
 </li></ul></nav></header>
 <p> <a id="c:corelib"></a></p><p>This chapter describes the OCaml core library, which is
 composed of declarations for built-in types and exceptions, plus
@@ -24,12 +24,12 @@ built-in types. The <span class="c004">Stdlib</span> module is special in two
 ways:
 </p><ul class="itemize"><li class="li-itemize">
 It is automatically linked with the user’s object code files by
-the <span class="c004">ocamlc</span> command (chapter ‍<a href="comp.html#c%3Acamlc">9</a>).</li><li class="li-itemize">It is automatically “opened” when a compilation starts, or
+the <span class="c004">ocamlc</span> command (chapter&nbsp;<a href="comp.html#c%3Acamlc">9</a>).</li><li class="li-itemize">It is automatically “opened” when a compilation starts, or
 when the toplevel system is launched. Hence, it is possible to use
 unqualified identifiers to refer to the functions provided by the
 <span class="c004">Stdlib</span> module, without adding a <span class="c004">open Stdlib</span> directive.
 </li></ul>
-<h2 class="section" id="s:core-builtins"><a class="section-anchor" href="#s:core-builtins" aria-hidden="true"></a>22.1 Built-in types and predefined exceptions</h2>
+<h2 class="section" id="s:core-builtins"><a class="section-anchor" href="#s:core-builtins" aria-hidden="true"></a><span class="number">1</span>Built-in types and predefined exceptions</h2>
 <p>The following built-in types and predefined exceptions are always
 defined in the
 compilation environment, but are not part of any module. As a
@@ -188,17 +188,17 @@ on a non-blocking I/O channel.
 </pre><p><a id="hevea_manual33"></a>
 </p><blockquote class="quote">
 Exception raised when an ill-founded recursive module definition
-is evaluated. (See section ‍<a href="manual024.html#s%3Arecursive-modules">8.2</a>.)
+is evaluated. (See section&nbsp;<a href="manual024.html#s%3Arecursive-modules">8.2</a>.)
 The arguments are the location of the definition in the source code
 (file name, line number, column number).
 </blockquote>
-<h2 class="section" id="s:stdlib-module"><a class="section-anchor" href="#s:stdlib-module" aria-hidden="true">﻿</a>22.2 Module <span class="c004">Stdlib</span>: the initially opened module</h2>
+<h2 class="section" id="s:stdlib-module"><a class="section-anchor" href="#s:stdlib-module" aria-hidden="true">﻿</a><span class="number">2</span>Module <span class="c004">Stdlib</span>: the initially opened module</h2>
 <ul class="ftoc2"><li class="li-links">
 <a href="../api/Stdlib.html">Module <span class="c004">Stdlib</span>: the initially opened module</a>
 </li><li class="li-links">Module <span class="c004">Pervasives</span>: deprecated alias for Stdlib
 </li></ul>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="instrumented-runtime.html">« Chapter ‍21 Runtime tracing with the instrumented runtime</a><a class="next" href="stdlib.html">Chapter ‍23 The standard library »</a></div>
+<div class="bottom-navigation"><a class="previous" href="instrumented-runtime.html">« Runtime tracing with the instrumented runtime</a><a class="next" href="stdlib.html">The standard library »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/coreexamples.html
+++ b/site/releases/4.12/htmlman/coreexamples.html
@@ -5,38 +5,38 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍1 The core language</title>
+<title>OCaml - The core language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍I An introduction to OCaml</nav><ul id="part-menu"><li class="active"><a href="coreexamples.html">Chapter ‍1 The core language</a></li><li><a href="moduleexamples.html">Chapter ‍2 The module system</a></li><li><a href="objectexamples.html">Chapter ‍3 Objects in OCaml</a></li><li><a href="lablexamples.html">Chapter ‍4 Labels and variants</a></li><li><a href="polymorphism.html">Chapter ‍5 Polymorphism and its limitations</a></li><li><a href="advexamples.html">Chapter ‍6 Advanced examples with classes and modules</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li class="active"><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a></li><li><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec7">Chapter ‍1 The core language</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍1 The core language</a></li>
-<li><a href="coreexamples.html#s%3Abasics">1.1 Basics</a>
-</li><li><a href="coreexamples.html#s%3Adatatypes">1.2 Data types</a>
-</li><li><a href="coreexamples.html#s%3Afunctions-as-values">1.3 Functions as values</a>
-</li><li><a href="coreexamples.html#s%3Atut-recvariants">1.4 Records and variants</a>
-</li><li><a href="coreexamples.html#s%3Aimperative-features">1.5 Imperative features</a>
-</li><li><a href="coreexamples.html#s%3Aexceptions">1.6 Exceptions</a>
-</li><li><a href="coreexamples.html#s%3Alazy-expr">1.7 Lazy expressions</a>
-</li><li><a href="coreexamples.html#s%3Asymb-expr">1.8 Symbolic processing of expressions</a>
-</li><li><a href="coreexamples.html#s%3Apretty-printing">1.9 Pretty-printing</a>
-</li><li><a href="coreexamples.html#s%3Aprintf">1.10 Printf formats</a>
-</li><li><a href="coreexamples.html#s%3Astandalone-programs">1.11 Standalone OCaml programs</a>
+<h1 class="chapter" id="sec7"><span class="number">Chapter 1</span>The core language</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The core language</a></li>
+<li><a href="coreexamples.html#s%3Abasics"><span class="number">1</span>Basics</a>
+</li><li><a href="coreexamples.html#s%3Adatatypes"><span class="number">2</span>Data types</a>
+</li><li><a href="coreexamples.html#s%3Afunctions-as-values"><span class="number">3</span>Functions as values</a>
+</li><li><a href="coreexamples.html#s%3Atut-recvariants"><span class="number">4</span>Records and variants</a>
+</li><li><a href="coreexamples.html#s%3Aimperative-features"><span class="number">5</span>Imperative features</a>
+</li><li><a href="coreexamples.html#s%3Aexceptions"><span class="number">6</span>Exceptions</a>
+</li><li><a href="coreexamples.html#s%3Alazy-expr"><span class="number">7</span>Lazy expressions</a>
+</li><li><a href="coreexamples.html#s%3Asymb-expr"><span class="number">8</span>Symbolic processing of expressions</a>
+</li><li><a href="coreexamples.html#s%3Apretty-printing"><span class="number">9</span>Pretty-printing</a>
+</li><li><a href="coreexamples.html#s%3Aprintf"><span class="number">10</span>Printf formats</a>
+</li><li><a href="coreexamples.html#s%3Astandalone-programs"><span class="number">11</span>Standalone OCaml programs</a>
 </li></ul></nav></header>
 <p> <a id="c:core-xamples"></a>
 </p><p>This part of the manual is a tutorial introduction to the OCaml language. A
 good familiarity with programming in a conventional languages (say, C or Java)
 is assumed, but no prior exposure to functional languages is required. The
-present chapter introduces the core language. Chapter ‍<a href="moduleexamples.html#c%3Amoduleexamples">2</a>
-deals with the module system, chapter ‍<a href="objectexamples.html#c%3Aobjectexamples">3</a> with the
-object-oriented features, chapter ‍<a href="lablexamples.html#c%3Alabl-examples">4</a> with extensions to the
+present chapter introduces the core language. Chapter&nbsp;<a href="moduleexamples.html#c%3Amoduleexamples">2</a>
+deals with the module system, chapter&nbsp;<a href="objectexamples.html#c%3Aobjectexamples">3</a> with the
+object-oriented features, chapter&nbsp;<a href="lablexamples.html#c%3Alabl-examples">4</a> with extensions to the
 core language (labeled arguments and polymorphic variants),
-chapter ‍<a href="polymorphism.html#c%3Apolymorphism">5</a> with the limitations of polymorphism, and
-chapter ‍<a href="advexamples.html#c%3Aadvexamples">6</a> gives some advanced examples.</p>
-<h2 class="section" id="s:basics"><a class="section-anchor" href="#s:basics" aria-hidden="true"></a>1.1 Basics</h2>
+chapter&nbsp;<a href="polymorphism.html#c%3Apolymorphism">5</a> with the limitations of polymorphism, and
+chapter&nbsp;<a href="advexamples.html#c%3Aadvexamples">6</a> gives some advanced examples.</p>
+<h2 class="section" id="s:basics"><a class="section-anchor" href="#s:basics" aria-hidden="true"></a><span class="number">1</span>Basics</h2>
 <p>For this overview of OCaml, we use the interactive system, which is started by
 running <span class="c004">ocaml</span> from the Unix shell or Windows command prompt. This tutorial is
 presented as the transcript of a session with the interactive system: lines
@@ -133,7 +133,7 @@ integers, but <span class="c004">+.</span> and <span class="c004">*.</span> oper
 <div class="pre caml-output ok">- : int = 55</div></div>
 
 </div>
-<h2 class="section" id="s:datatypes"><a class="section-anchor" href="#s:datatypes" aria-hidden="true">﻿</a>1.2 Data types</h2>
+<h2 class="section" id="s:datatypes"><a class="section-anchor" href="#s:datatypes" aria-hidden="true">﻿</a><span class="number">2</span>Data types</h2>
 <p>In addition to integers and floating-point numbers, OCaml offers the
 usual basic data types:
 </p><ul class="itemize"><li class="li-itemize">booleans
@@ -342,7 +342,7 @@ the type inferred for <span class="c004">insert</span>, <span class="c004">'a -&
 takes two arguments, an element of any type <span class="c004">'a</span> and a list with elements of
 the same type <span class="c004">'a</span> and returns a list of the same type.
 </p>
-<h2 class="section" id="s:functions-as-values"><a class="section-anchor" href="#s:functions-as-values" aria-hidden="true">﻿</a>1.3 Functions as values</h2>
+<h2 class="section" id="s:functions-as-values"><a class="section-anchor" href="#s:functions-as-values" aria-hidden="true">﻿</a><span class="number">3</span>Functions as values</h2>
 <p>OCaml is a functional language: functions in the full mathematical
 sense are supported and can be passed around freely just as any other
 piece of data. For instance, here is a <span class="c004">deriv</span> function that takes any
@@ -445,7 +445,7 @@ nothing magic with it: it can easily be defined as follows.
 <div class="pre caml-output ok"><span class="ocamlkeyword">val</span> map : ('a -&gt; 'b) -&gt; 'a list -&gt; 'b list = &lt;<span class="ocamlkeyword">fun</span>&gt;</div></div>
 
 </div>
-<h2 class="section" id="s:tut-recvariants"><a class="section-anchor" href="#s:tut-recvariants" aria-hidden="true">﻿</a>1.4 Records and variants</h2>
+<h2 class="section" id="s:tut-recvariants"><a class="section-anchor" href="#s:tut-recvariants" aria-hidden="true">﻿</a><span class="number">4</span>Records and variants</h2>
 <p>User-defined data structures include records and variants. Both are
 defined with the <span class="c004">type</span> declaration. Here, we declare a record type to
 represent rational numbers.
@@ -776,7 +776,7 @@ ordered binary trees (elements increase from left to right):
 <div class="pre caml-output ok"><span class="ocamlkeyword">val</span> insert : 'a -&gt; 'a btree -&gt; 'a btree = &lt;<span class="ocamlkeyword">fun</span>&gt;</div></div>
 
 </div>
-<h3 class="subsection" id="ss:record-and-variant-disambiguation"><a class="section-anchor" href="#ss:record-and-variant-disambiguation" aria-hidden="true">﻿</a>1.4.1 Record and variant disambiguation</h3>
+<h3 class="subsection" id="ss:record-and-variant-disambiguation"><a class="section-anchor" href="#ss:record-and-variant-disambiguation" aria-hidden="true">﻿</a><span class="number">4.1</span>Record and variant disambiguation</h3>
 <p>
 ( This subsection can be skipped on the first reading )</p><p>Astute readers may have wondered what happens when two or more record
 fields or constructors share the same name</p><div class="caml-example toplevel">
@@ -916,7 +916,7 @@ may change surreptitiously after adding or moving around a type
 definition, or after opening a module (see chapter <a href="moduleexamples.html#c%3Amoduleexamples">2</a>).
 Consequently, adding explicit type annotations to guide disambiguation is
 more robust than relying on the last defined type disambiguation.</p>
-<h2 class="section" id="s:imperative-features"><a class="section-anchor" href="#s:imperative-features" aria-hidden="true">﻿</a>1.5 Imperative features</h2>
+<h2 class="section" id="s:imperative-features"><a class="section-anchor" href="#s:imperative-features" aria-hidden="true">﻿</a><span class="number">5</span>Imperative features</h2>
 <p>Though all examples so far were written in purely applicative style,
 OCaml is also equipped with full imperative features. This includes the
 usual <span class="c004">while</span> and <span class="c004">for</span> loops, as well as mutable data structures such
@@ -1152,7 +1152,7 @@ called id
 - : int * bool = (1, <span class="ocamlkeyword">true</span>)</div></div>
 
 </div>
-<h2 class="section" id="s:exceptions"><a class="section-anchor" href="#s:exceptions" aria-hidden="true">﻿</a>1.6 Exceptions</h2>
+<h2 class="section" id="s:exceptions"><a class="section-anchor" href="#s:exceptions" aria-hidden="true">﻿</a><span class="number">6</span>Exceptions</h2>
 <p>OCaml provides exceptions for signalling and handling exceptional
 conditions. Exceptions can also be used as a general-purpose non-local
 control structure, although this should not be overused since it can
@@ -1392,7 +1392,7 @@ For instance, with
 
 the function <span class="c004">f</span> cannot raise a <span class="c004">Done</span> exception, which removes an
 entire class of misbehaving functions.</p>
-<h2 class="section" id="s:lazy-expr"><a class="section-anchor" href="#s:lazy-expr" aria-hidden="true">﻿</a>1.7 Lazy expressions</h2>
+<h2 class="section" id="s:lazy-expr"><a class="section-anchor" href="#s:lazy-expr" aria-hidden="true">﻿</a><span class="number">7</span>Lazy expressions</h2>
 <p>OCaml allows us to defer some computation until later when we need the result of
 that computation. </p><p>We use <span class="c004">lazy (expr)</span> to delay the evaluation of some expression <span class="c004">expr</span>. For 
 example, we can defer the computation of <span class="c004">1+1</span> until we need the result of that
@@ -1496,7 +1496,7 @@ not printed. The result of the initial computation is simply returned. </p><p>La
 <span class="c004">true</span> once computed. Indeed, a simple wildcard pattern (not lazy) never forces 
 the lazy expression’s evaluation. However, a pattern with keyword <span class="c004">lazy</span>, even 
 if it is wildcard, always forces the evaluation of the deferred computation.</p>
-<h2 class="section" id="s:symb-expr"><a class="section-anchor" href="#s:symb-expr" aria-hidden="true">﻿</a>1.8 Symbolic processing of expressions</h2>
+<h2 class="section" id="s:symb-expr"><a class="section-anchor" href="#s:symb-expr" aria-hidden="true">﻿</a><span class="number">8</span>Symbolic processing of expressions</h2>
 <p>We finish this introduction with a more complete example
 representative of the use of OCaml for symbolic processing: formal
 manipulations of arithmetic expressions containing variables. The
@@ -1605,7 +1605,7 @@ Quot (Diff (Prod (Const 0., Var <span class="ocamlstring">"x"</span>), Prod (Con
  Prod (Var <span class="ocamlstring">"x"</span>, Var <span class="ocamlstring">"x"</span>))</div></div>
 
 </div>
-<h2 class="section" id="s:pretty-printing"><a class="section-anchor" href="#s:pretty-printing" aria-hidden="true">﻿</a>1.9 Pretty-printing</h2>
+<h2 class="section" id="s:pretty-printing"><a class="section-anchor" href="#s:pretty-printing" aria-hidden="true">﻿</a><span class="number">9</span>Pretty-printing</h2>
 <p>As shown in the examples above, the internal representation (also
 called <em>abstract syntax</em>) of expressions quickly becomes hard to
 read and write as the expressions get larger. We need a printer and a
@@ -1684,9 +1684,9 @@ less than the current precedence.
 - : unit = ()</div></div>
 
 </div>
-<h2 class="section" id="s:printf"><a class="section-anchor" href="#s:printf" aria-hidden="true">﻿</a>1.10 Printf formats</h2>
+<h2 class="section" id="s:printf"><a class="section-anchor" href="#s:printf" aria-hidden="true">﻿</a><span class="number">10</span>Printf formats</h2>
 <p>There is a <span class="c004">printf</span> function in the <a href="../api/Printf.html"><span class="c004">Printf</span></a> module
-(see chapter ‍<a href="moduleexamples.html#c%3Amoduleexamples">2</a>) that allows you to make formatted
+(see chapter&nbsp;<a href="moduleexamples.html#c%3Amoduleexamples">2</a>) that allows you to make formatted
 output more concisely.
 It follows the behavior of the <span class="c004">printf</span> function from the C standard library.
 The <span class="c004">printf</span> function takes a format string that describes the desired output
@@ -1881,7 +1881,7 @@ an explicit type annotation:
 - : unit = ()</div></div>
 
 </div>
-<h2 class="section" id="s:standalone-programs"><a class="section-anchor" href="#s:standalone-programs" aria-hidden="true">﻿</a>1.11 Standalone OCaml programs</h2>
+<h2 class="section" id="s:standalone-programs"><a class="section-anchor" href="#s:standalone-programs" aria-hidden="true">﻿</a><span class="number">11</span>Standalone OCaml programs</h2>
 <p>All examples given so far were executed under the interactive system.
 OCaml code can also be compiled separately and executed
 non-interactively using the batch compilers <span class="c004">ocamlc</span> and <span class="c004">ocamlopt</span>.
@@ -1920,14 +1920,14 @@ $ ./gcd 7 11
 </pre><p>
 More complex standalone OCaml programs are typically composed of
 multiple source files, and can link with precompiled libraries.
-Chapters ‍<a href="comp.html#c%3Acamlc">9</a> and ‍<a href="native.html#c%3Anativecomp">12</a> explain how to use the
+Chapters&nbsp;<a href="comp.html#c%3Acamlc">9</a> and&nbsp;<a href="native.html#c%3Anativecomp">12</a> explain how to use the
 batch compilers <span class="c004">ocamlc</span> and <span class="c004">ocamlopt</span>. Recompilation of
 multi-file OCaml projects can be automated using third-party
 build systems, such as <a href="https://github.com/ocaml/dune">dune</a>.
 
 </p>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="foreword.html">« Foreword</a><a class="next" href="moduleexamples.html">Chapter ‍2 The module system »</a></div>
+<div class="bottom-navigation"><a class="previous" href="foreword.html">« Foreword</a><a class="next" href="moduleexamples.html">The module system »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/debugger.html
+++ b/site/releases/4.12/htmlman/debugger.html
@@ -5,25 +5,25 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍16 The debugger (ocamldebug)</title>
+<title>OCaml - The debugger (ocamldebug)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li class="active"><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li class="active"><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec381">Chapter ‍16 The debugger (ocamldebug)</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍16 The debugger (ocamldebug)</a></li>
-<li><a href="debugger.html#s%3Adebugger-compilation">16.1 Compiling for debugging</a>
-</li><li><a href="debugger.html#s%3Adebugger-invocation">16.2 Invocation</a>
-</li><li><a href="debugger.html#s%3Adebugger-commands">16.3 Commands</a>
-</li><li><a href="debugger.html#s%3Adebugger-execution">16.4 Executing a program</a>
-</li><li><a href="debugger.html#s%3Abreakpoints">16.5 Breakpoints</a>
-</li><li><a href="debugger.html#s%3Adebugger-callstack">16.6 The call stack</a>
-</li><li><a href="debugger.html#s%3Adebugger-examining-values">16.7 Examining variable values</a>
-</li><li><a href="debugger.html#s%3Adebugger-control">16.8 Controlling the debugger</a>
-</li><li><a href="debugger.html#s%3Adebugger-misc-cmds">16.9 Miscellaneous commands</a>
-</li><li><a href="debugger.html#s%3Ainf-debugger">16.10 Running the debugger under Emacs</a>
+<h1 class="chapter" id="sec381"><span class="number">Chapter 16</span>The debugger (ocamldebug)</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The debugger (ocamldebug)</a></li>
+<li><a href="debugger.html#s%3Adebugger-compilation"><span class="number">1</span>Compiling for debugging</a>
+</li><li><a href="debugger.html#s%3Adebugger-invocation"><span class="number">2</span>Invocation</a>
+</li><li><a href="debugger.html#s%3Adebugger-commands"><span class="number">3</span>Commands</a>
+</li><li><a href="debugger.html#s%3Adebugger-execution"><span class="number">4</span>Executing a program</a>
+</li><li><a href="debugger.html#s%3Abreakpoints"><span class="number">5</span>Breakpoints</a>
+</li><li><a href="debugger.html#s%3Adebugger-callstack"><span class="number">6</span>The call stack</a>
+</li><li><a href="debugger.html#s%3Adebugger-examining-values"><span class="number">7</span>Examining variable values</a>
+</li><li><a href="debugger.html#s%3Adebugger-control"><span class="number">8</span>Controlling the debugger</a>
+</li><li><a href="debugger.html#s%3Adebugger-misc-cmds"><span class="number">9</span>Miscellaneous commands</a>
+</li><li><a href="debugger.html#s%3Ainf-debugger"><span class="number">10</span>Running the debugger under Emacs</a>
 </li></ul></nav></header>
 <p> <a id="c:debugger"></a>
 </p><p>This chapter describes the OCaml source-level replay debugger
@@ -32,7 +32,7 @@ BSD sockets.
 </blockquote><blockquote class="quote"><span class="c008">Windows:</span>  The debugger is available under the Cygwin port of
 OCaml, but not under the native Win32 ports.
 </blockquote>
-<h2 class="section" id="s:debugger-compilation"><a class="section-anchor" href="#s:debugger-compilation" aria-hidden="true"></a>16.1 Compiling for debugging</h2>
+<h2 class="section" id="s:debugger-compilation"><a class="section-anchor" href="#s:debugger-compilation" aria-hidden="true"></a><span class="number">1</span>Compiling for debugging</h2>
 <p>Before the debugger can be used, the program must be compiled and
 linked with the <span class="c004">-g</span> option: all <span class="c004">.cmo</span> and <span class="c004">.cma</span> files that are part
 of the program should have been created with <span class="c004">ocamlc -g</span>, and they
@@ -40,8 +40,8 @@ must be linked together with <span class="c004">ocamlc -g</span>.</p><p>Compilin
 programs: object files and bytecode executable files are bigger and
 take longer to produce, but the executable files run at
 exactly the same speed as if they had been compiled without <span class="c004">-g</span>.</p>
-<h2 class="section" id="s:debugger-invocation"><a class="section-anchor" href="#s:debugger-invocation" aria-hidden="true">﻿</a>16.2 Invocation</h2>
-<h3 class="subsection" id="ss:debugger-start"><a class="section-anchor" href="#ss:debugger-start" aria-hidden="true">﻿</a>16.2.1 Starting the debugger</h3>
+<h2 class="section" id="s:debugger-invocation"><a class="section-anchor" href="#s:debugger-invocation" aria-hidden="true">﻿</a><span class="number">2</span>Invocation</h2>
+<h3 class="subsection" id="ss:debugger-start"><a class="section-anchor" href="#ss:debugger-start" aria-hidden="true">﻿</a><span class="number">2.1</span>Starting the debugger</h3>
 <p>The OCaml debugger is invoked by running the program
 <span class="c004">ocamldebug</span> with the name of the bytecode executable file as first
 argument:
@@ -56,28 +56,28 @@ Set the maximum number of simultaneously live checkpoints to <span class="c010">
 Run the debugger program from the working directory <span class="c010">dir</span>,
 instead of the current directory. (See also the <span class="c004">cd</span> command.)</dd><dt class="dt-description"><span class="c007">-emacs</span></dt><dd class="dd-description">
 Tell the debugger it is executed under Emacs. (See
-section ‍<a href="#s%3Ainf-debugger">16.10</a> for information on how to run the
+section&nbsp;<a href="#s%3Ainf-debugger">16.10</a> for information on how to run the
 debugger under Emacs.)</dd><dt class="dt-description"><span class="c014"><span class="c004">-I </span><span class="c010">directory</span></span></dt><dd class="dd-description">
 Add <span class="c010">directory</span> to the list of directories searched for source
 files and compiled files. (See also the <span class="c004">directory</span> command.)</dd><dt class="dt-description"><span class="c014"><span class="c004">-s </span><span class="c010">socket</span></span></dt><dd class="dd-description">
 Use <span class="c010">socket</span> for communicating with the debugged program. See the
-description of the command <span class="c004">set socket</span> (section ‍<a href="#ss%3Adebugger-communication">16.8.8</a>)
+description of the command <span class="c004">set socket</span> (section&nbsp;<a href="#ss%3Adebugger-communication">16.8.8</a>)
 for the format of <span class="c010">socket</span>.</dd><dt class="dt-description"><span class="c007">-version</span></dt><dd class="dd-description">
 Print version string and exit.</dd><dt class="dt-description"><span class="c007">-vnum</span></dt><dd class="dd-description">
 Print short version number and exit.</dd><dt class="dt-description"><span class="c014"><span class="c004">-help</span> or <span class="c004">--help</span></span></dt><dd class="dd-description">
 Display a short usage summary and exit.
 </dd></dl>
-<h3 class="subsection" id="ss:debugger-init-file"><a class="section-anchor" href="#ss:debugger-init-file" aria-hidden="true">﻿</a>16.2.2 Initialization file</h3>
+<h3 class="subsection" id="ss:debugger-init-file"><a class="section-anchor" href="#ss:debugger-init-file" aria-hidden="true">﻿</a><span class="number">2.2</span>Initialization file</h3>
 <p>On start-up, the debugger will read commands from an initialization
 file before giving control to the user. The default file is
 <span class="c004">.ocamldebug</span> in the current directory if it exists, otherwise
 <span class="c004">.ocamldebug</span> in the user’s home directory.</p>
-<h3 class="subsection" id="ss:debugger-exut"><a class="section-anchor" href="#ss:debugger-exut" aria-hidden="true">﻿</a>16.2.3 Exiting the debugger</h3>
+<h3 class="subsection" id="ss:debugger-exut"><a class="section-anchor" href="#ss:debugger-exut" aria-hidden="true">﻿</a><span class="number">2.3</span>Exiting the debugger</h3>
 <p>The command <span class="c004">quit</span> exits the debugger. You can also exit the debugger
 by typing an end-of-file character (usually <span class="c004">ctrl-D</span>).</p><p>Typing an interrupt character (usually <span class="c004">ctrl-C</span>) will not exit the
 debugger, but will terminate the action of any debugger command that is in
 progress and return to the debugger command level.</p>
-<h2 class="section" id="s:debugger-commands"><a class="section-anchor" href="#s:debugger-commands" aria-hidden="true">﻿</a>16.3 Commands</h2>
+<h2 class="section" id="s:debugger-commands"><a class="section-anchor" href="#s:debugger-commands" aria-hidden="true">﻿</a><span class="number">3</span>Commands</h2>
 <p>A debugger command is a single line of input. It starts with a command
 name, which is followed by arguments depending on this name. Examples:
 </p><pre>        run
@@ -91,7 +91,7 @@ used commands, ambiguous abbreviations are allowed. For instance, <span class="c
 stands for <span class="c004">run</span> even though there are others commands starting with
 <span class="c004">r</span>. You can test the validity of an abbreviation using the <span class="c004">help</span> command.</p><p>If the previous command has been successful, a blank line (typing just
 <span class="c004">RET</span>) will repeat it.</p>
-<h3 class="subsection" id="ss:debugger-help"><a class="section-anchor" href="#ss:debugger-help" aria-hidden="true">﻿</a>16.3.1 Getting help</h3>
+<h3 class="subsection" id="ss:debugger-help"><a class="section-anchor" href="#ss:debugger-help" aria-hidden="true">﻿</a><span class="number">3.1</span>Getting help</h3>
 <p>The OCaml debugger has a simple on-line help system, which gives
 a brief description of each command and variable.</p><dl class="description"><dt class="dt-description">
 <span class="c007">help</span></dt><dd class="dd-description">
@@ -101,7 +101,7 @@ Give help about the variable <span class="c010">variable</span>. The list of all
 variables can be obtained with <span class="c004">help set</span>.</dd><dt class="dt-description"><span class="c014"><span class="c004">help info </span><span class="c010">topic</span></span></dt><dd class="dd-description">
 Give help about <span class="c010">topic</span>. Use <span class="c004">help info</span> to get a list of known topics.
 </dd></dl>
-<h3 class="subsection" id="ss:debugger-state"><a class="section-anchor" href="#ss:debugger-state" aria-hidden="true">﻿</a>16.3.2 Accessing the debugger state</h3>
+<h3 class="subsection" id="ss:debugger-state"><a class="section-anchor" href="#ss:debugger-state" aria-hidden="true">﻿</a><span class="number">3.2</span>Accessing the debugger state</h3>
 <dl class="description"><dt class="dt-description">
 <span class="c014"><span class="c004">set </span><span class="c010">variable value</span></span></dt><dd class="dd-description">
 Set the debugger variable <span class="c010">variable</span> to the value <span class="c010">value</span>.</dd><dt class="dt-description"><span class="c014"><span class="c004">show </span><span class="c010">variable</span></span></dt><dd class="dd-description">
@@ -109,8 +109,8 @@ Print the value of the debugger variable <span class="c010">variable</span>.</dd
 Give information about the given subject.
 For instance, <span class="c004">info breakpoints</span> will print the list of all breakpoints.
 </dd></dl>
-<h2 class="section" id="s:debugger-execution"><a class="section-anchor" href="#s:debugger-execution" aria-hidden="true">﻿</a>16.4 Executing a program</h2>
-<h3 class="subsection" id="ss:debugger-events"><a class="section-anchor" href="#ss:debugger-events" aria-hidden="true">﻿</a>16.4.1 Events</h3>
+<h2 class="section" id="s:debugger-execution"><a class="section-anchor" href="#s:debugger-execution" aria-hidden="true">﻿</a><span class="number">4</span>Executing a program</h2>
+<h3 class="subsection" id="ss:debugger-events"><a class="section-anchor" href="#ss:debugger-events" aria-hidden="true">﻿</a><span class="number">4.1</span>Events</h3>
 <p>Events are “interesting” locations in the source code, corresponding
 to the beginning or end of evaluation of “interesting”
 sub-expressions. Events are the unit of single-stepping (stepping goes
@@ -119,37 +119,37 @@ Also, breakpoints can only be set at events. Thus, events play the
 role of line numbers in debuggers for conventional languages.</p><p>During program execution, a counter is incremented at each event
 encountered. The value of this counter is referred as the <em>current
 time</em>. Thanks to reverse execution, it is possible to jump back and
-forth to any time of the execution.</p><p>Here is where the debugger events (written ǧ) are located in
+forth to any time of the execution.</p><p>Here is where the debugger events (written ⋈) are located in
 the source code:
 </p><ul class="itemize"><li class="li-itemize">
 Following a function application:
-<pre>(f arg)ǧ
+<pre>(f arg)⋈
 </pre>
 </li><li class="li-itemize">On entrance to a function:
-<pre>fun x y z -&gt; ǧ ...
+<pre>fun x y z -&gt; ⋈ ...
 </pre>
 </li><li class="li-itemize">On each case of a pattern-matching definition (function,
 <span class="c004">match</span>…<span class="c004">with</span> construct, <span class="c004">try</span>…<span class="c004">with</span> construct):
-<pre>function pat1 -&gt; ǧ expr1
+<pre>function pat1 -&gt; ⋈ expr1
        | ...
-       | patN -&gt; ǧ exprN
+       | patN -&gt; ⋈ exprN
 </pre>
 </li><li class="li-itemize">Between subexpressions of a sequence:
-<pre>expr1; ǧ expr2; ǧ ...; ǧ exprN
+<pre>expr1; ⋈ expr2; ⋈ ...; ⋈ exprN
 </pre>
 </li><li class="li-itemize">In the two branches of a conditional expression:
-<pre>if cond then ǧ expr1 else ǧ expr2
+<pre>if cond then ⋈ expr1 else ⋈ expr2
 </pre>
 </li><li class="li-itemize">At the beginning of each iteration of a loop:
-<pre>while cond do ǧ body done
-for i = a to b do ǧ body done
+<pre>while cond do ⋈ body done
+for i = a to b do ⋈ body done
 </pre>
 </li></ul><p>
 Exceptions: A function application followed by a function return is replaced
 by the compiler by a jump (tail-call optimization). In this case, no
 event is put after the function application.
 </p>
-<h3 class="subsection" id="ss:debugger-starting-program"><a class="section-anchor" href="#ss:debugger-starting-program" aria-hidden="true">﻿</a>16.4.2 Starting the debugged program</h3>
+<h3 class="subsection" id="ss:debugger-starting-program"><a class="section-anchor" href="#ss:debugger-starting-program" aria-hidden="true">﻿</a><span class="number">4.2</span>Starting the debugged program</h3>
 <p>The debugger starts executing the debugged program only when needed.
 This allows setting breakpoints or assigning debugger variables before
 execution starts. There are several ways to start execution:
@@ -160,7 +160,7 @@ terminates.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">goto </span><span class="c010">time</span></span></dt><dd class="dd-description"> Load the program and execute it until the
 given time. Useful when you already know approximately at what time
 the problem appears. Also useful to set breakpoints on function values
-that have not been computed at time 0 (see section ‍<a href="#s%3Abreakpoints">16.5</a>).
+that have not been computed at time 0 (see section&nbsp;<a href="#s%3Abreakpoints">16.5</a>).
 </dd></dl><p>The execution of a program is affected by certain information it
 receives when the debugger starts it, such as the command-line
 arguments to the program and its working directory. The debugger
@@ -168,7 +168,7 @@ provides commands to specify this information (<span class="c004">set arguments<
 These commands must be used before program execution starts. If you try
 to change the arguments or the working directory after starting your
 program, the debugger will kill the program (after asking for confirmation).</p>
-<h3 class="subsection" id="ss:debugger-running"><a class="section-anchor" href="#ss:debugger-running" aria-hidden="true">﻿</a>16.4.3 Running the program</h3>
+<h3 class="subsection" id="ss:debugger-running"><a class="section-anchor" href="#ss:debugger-running" aria-hidden="true">﻿</a><span class="number">4.3</span>Running the program</h3>
 <p>The following commands execute the program forward or backward,
 starting at the current time. The execution will stop either when
 specified by the command or when a breakpoint is encountered.</p><dl class="description"><dt class="dt-description">
@@ -192,7 +192,7 @@ it <span class="c010">count</span> times.
 </dd><dt class="dt-description"><span class="c007">start</span></dt><dd class="dd-description"> Run the program backward and stop at the first event
 before the current function invocation.
 </dd></dl>
-<h3 class="subsection" id="ss:debugger-time-travel"><a class="section-anchor" href="#ss:debugger-time-travel" aria-hidden="true">﻿</a>16.4.4 Time travel</h3>
+<h3 class="subsection" id="ss:debugger-time-travel"><a class="section-anchor" href="#ss:debugger-time-travel" aria-hidden="true">﻿</a><span class="number">4.4</span>Time travel</h3>
 <p>You can jump directly to a given time, without stopping on
 breakpoints, using the <span class="c004">goto</span> command.</p><p>As you move through the program, the debugger maintains an history of
 the successive times you stop at. The <span class="c004">last</span> command can be used to
@@ -207,17 +207,17 @@ argument, do it <span class="c010">count</span> times.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">set history </span><span class="c010">size</span></span></dt><dd class="dd-description">
 Set the size of the execution history.
 </dd></dl>
-<h3 class="subsection" id="ss:debugger-kill"><a class="section-anchor" href="#ss:debugger-kill" aria-hidden="true">﻿</a>16.4.5 Killing the program</h3>
+<h3 class="subsection" id="ss:debugger-kill"><a class="section-anchor" href="#ss:debugger-kill" aria-hidden="true">﻿</a><span class="number">4.5</span>Killing the program</h3>
 <dl class="description"><dt class="dt-description">
 <span class="c007">kill</span></dt><dd class="dd-description"> Kill the program being executed. This command is mainly
 useful if you wish to recompile the program without leaving the debugger.
 </dd></dl>
-<h2 class="section" id="s:breakpoints"><a class="section-anchor" href="#s:breakpoints" aria-hidden="true">﻿</a>16.5 Breakpoints</h2>
+<h2 class="section" id="s:breakpoints"><a class="section-anchor" href="#s:breakpoints" aria-hidden="true">﻿</a><span class="number">5</span>Breakpoints</h2>
 <p>A breakpoint causes the program to stop whenever a certain point in
 the program is reached. It can be set in several ways using the
 <span class="c004">break</span> command. Breakpoints are assigned numbers when set, for
 further reference. The most comfortable way to set breakpoints is
-through the Emacs interface (see section ‍<a href="#s%3Ainf-debugger">16.10</a>).</p><dl class="description"><dt class="dt-description">
+through the Emacs interface (see section&nbsp;<a href="#s%3Ainf-debugger">16.10</a>).</p><dl class="description"><dt class="dt-description">
 <span class="c007">break</span></dt><dd class="dd-description">
 Set a breakpoint at the current position in the program execution. The
 current position must be on an event (i.e., neither at the beginning,
@@ -244,7 +244,7 @@ the code fragment of the program loaded initially.</dd><dt class="dt-description
 Delete the specified breakpoints. Without argument, all breakpoints
 are deleted (after asking for confirmation).</dd><dt class="dt-description"><span class="c007">info breakpoints</span></dt><dd class="dd-description"> Print the list of all breakpoints.
 </dd></dl>
-<h2 class="section" id="s:debugger-callstack"><a class="section-anchor" href="#s:debugger-callstack" aria-hidden="true">﻿</a>16.6 The call stack</h2>
+<h2 class="section" id="s:debugger-callstack"><a class="section-anchor" href="#s:debugger-callstack" aria-hidden="true">﻿</a><span class="number">6</span>The call stack</h2>
 <p>Each time the program performs a function application, it saves the
 location of the application (the return address) in a block of data
 called a stack frame. The frame also contains the local variables of
@@ -273,7 +273,7 @@ Select and display the stack frame just “below” the selected frame,
 that is, the frame that was called by the selected frame. An argument
 says how many frames to go down.
 </dd></dl>
-<h2 class="section" id="s:debugger-examining-values"><a class="section-anchor" href="#s:debugger-examining-values" aria-hidden="true">﻿</a>16.7 Examining variable values</h2>
+<h2 class="section" id="s:debugger-examining-values"><a class="section-anchor" href="#s:debugger-examining-values" aria-hidden="true">﻿</a><span class="number">7</span>Examining variable values</h2>
 <p>The debugger can print the current value of simple expressions. The
 expressions can involve program variables: all the identifiers that
 are in scope at the selected program point can be accessed.</p><p>Expressions that can be printed are a subset of OCaml
@@ -328,8 +328,8 @@ Limit the printing of values to a maximal depth of <span class="c010">d</span>.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">set print_length</span> <span class="c010">l</span></span></dt><dd class="dd-description">
 Limit the printing of values to at most <span class="c010">l</span> nodes printed.
 </dd></dl>
-<h2 class="section" id="s:debugger-control"><a class="section-anchor" href="#s:debugger-control" aria-hidden="true">﻿</a>16.8 Controlling the debugger</h2>
-<h3 class="subsection" id="ss:debugger-name-and-arguments"><a class="section-anchor" href="#ss:debugger-name-and-arguments" aria-hidden="true">﻿</a>16.8.1 Setting the program name and arguments</h3>
+<h2 class="section" id="s:debugger-control"><a class="section-anchor" href="#s:debugger-control" aria-hidden="true">﻿</a><span class="number">8</span>Controlling the debugger</h2>
+<h3 class="subsection" id="ss:debugger-name-and-arguments"><a class="section-anchor" href="#ss:debugger-name-and-arguments" aria-hidden="true">﻿</a><span class="number">8.1</span>Setting the program name and arguments</h3>
 <dl class="description"><dt class="dt-description">
 <span class="c014"><span class="c004">set program</span> <span class="c010">file</span></span></dt><dd class="dd-description">
 Set the program name to <span class="c010">file</span>.
@@ -342,7 +342,7 @@ recommended to redirect their input from a file (using
 <span class="c004">set arguments &lt; input-file</span>), otherwise input to the program and
 input to the debugger are not properly separated, and inputs are not
 properly replayed when running the program backwards.</p>
-<h3 class="subsection" id="ss:debugger-loading"><a class="section-anchor" href="#ss:debugger-loading" aria-hidden="true">﻿</a>16.8.2 How programs are loaded</h3>
+<h3 class="subsection" id="ss:debugger-loading"><a class="section-anchor" href="#ss:debugger-loading" aria-hidden="true">﻿</a><span class="number">8.2</span>How programs are loaded</h3>
 <p>The <span class="c004">loadingmode</span> variable controls how the program is executed.</p><dl class="description"><dt class="dt-description">
 <span class="c007">set loadingmode direct</span></dt><dd class="dd-description">
 The program is run directly by the debugger. This is the default mode.
@@ -352,9 +352,9 @@ Rarely useful; moreover it prevents the debugging of programs compiled
 in “custom runtime” mode.
 </dd><dt class="dt-description"><span class="c007">set loadingmode manual</span></dt><dd class="dd-description">
 The user starts manually the program, when asked by the debugger.
-Allows remote debugging (see section ‍<a href="#ss%3Adebugger-communication">16.8.8</a>).
+Allows remote debugging (see section&nbsp;<a href="#ss%3Adebugger-communication">16.8.8</a>).
 </dd></dl>
-<h3 class="subsection" id="ss:debugger-search-path"><a class="section-anchor" href="#ss:debugger-search-path" aria-hidden="true">﻿</a>16.8.3 Search path for files</h3>
+<h3 class="subsection" id="ss:debugger-search-path"><a class="section-anchor" href="#ss:debugger-search-path" aria-hidden="true">﻿</a><span class="number">8.3</span>Search path for files</h3>
 <p>The debugger searches for source files and compiled interface files in
 a list of directories, the search path. The search path initially
 contains the current directory <span class="c004">.</span> and the standard library directory.
@@ -368,7 +368,7 @@ searched only when looking for the source file of a module that has
 been packed into <span class="c010">modulename</span>.</dd><dt class="dt-description"><span class="c007">directory</span></dt><dd class="dd-description">
 Reset the search path. This requires confirmation.
 </dd></dl>
-<h3 class="subsection" id="ss:debugger-working-dir"><a class="section-anchor" href="#ss:debugger-working-dir" aria-hidden="true">﻿</a>16.8.4 Working directory</h3>
+<h3 class="subsection" id="ss:debugger-working-dir"><a class="section-anchor" href="#ss:debugger-working-dir" aria-hidden="true">﻿</a><span class="number">8.4</span>Working directory</h3>
 <p>Each time a program is started in the debugger, it inherits its working
 directory from the current working directory of the debugger. This
 working directory is initially whatever it inherited from its parent
@@ -379,7 +379,7 @@ command-line option.</p><dl class="description"><dt class="dt-description">
 Set the working directory for <span class="c004">ocamldebug</span> to <span class="c010">directory</span>.</dd><dt class="dt-description"><span class="c007">pwd</span></dt><dd class="dd-description">
 Print the working directory for <span class="c004">ocamldebug</span>.
 </dd></dl>
-<h3 class="subsection" id="ss:debugger-reverse-execution"><a class="section-anchor" href="#ss:debugger-reverse-execution" aria-hidden="true">﻿</a>16.8.5 Turning reverse execution on and off</h3>
+<h3 class="subsection" id="ss:debugger-reverse-execution"><a class="section-anchor" href="#ss:debugger-reverse-execution" aria-hidden="true">﻿</a><span class="number">8.5</span>Turning reverse execution on and off</h3>
 <p>In some cases, you may want to turn reverse execution off. This speeds
 up the program execution, and is also sometimes useful for interactive
 programs.</p><p>Normally, the debugger takes checkpoints of the program state from
@@ -390,7 +390,7 @@ checkpoints.</p><dl class="description"><dt class="dt-description">
 <span class="c014"><span class="c004">set checkpoints</span> <span class="c010">on/off</span></span></dt><dd class="dd-description">
 Select whether the debugger makes checkpoints or not.
 </dd></dl>
-<h3 class="subsection" id="ss:debugger-fork"><a class="section-anchor" href="#ss:debugger-fork" aria-hidden="true">﻿</a>16.8.6 Behavior of the debugger with respect to <span class="c004">fork</span></h3>
+<h3 class="subsection" id="ss:debugger-fork"><a class="section-anchor" href="#ss:debugger-fork" aria-hidden="true">﻿</a><span class="number">8.6</span>Behavior of the debugger with respect to <span class="c004">fork</span></h3>
 <p>When the program issues a call to <span class="c004">fork</span>, the debugger can either
 follow the child or the parent. By default, the debugger follows the
 parent process. The variable <span class="c010">follow_fork_mode</span> controls this
@@ -399,7 +399,7 @@ behavior:</p><dl class="description"><dt class="dt-description">
 Select whether to follow the child or the parent in case of a call to
 <span class="c004">fork</span>.
 </dd></dl>
-<h3 class="subsection" id="ss:debugger-stop-at-new-load"><a class="section-anchor" href="#ss:debugger-stop-at-new-load" aria-hidden="true">﻿</a>16.8.7 Stopping execution when new code is loaded</h3>
+<h3 class="subsection" id="ss:debugger-stop-at-new-load"><a class="section-anchor" href="#ss:debugger-stop-at-new-load" aria-hidden="true">﻿</a><span class="number">8.7</span>Stopping execution when new code is loaded</h3>
 <p>The debugger is compatible with the <span class="c004">Dynlink</span> module. However, when an
 external module is not yet loaded, it is impossible to set a
 breakpoint in its code. In order to facilitate setting breakpoints in
@@ -409,7 +409,7 @@ modules are loaded. This behavior can be disabled using the
 <span class="c014"><span class="c004">set break_on_load</span> <span class="c010">on/off</span></span></dt><dd class="dd-description">
 Select whether to stop after loading new code.
 </dd></dl>
-<h3 class="subsection" id="ss:debugger-communication"><a class="section-anchor" href="#ss:debugger-communication" aria-hidden="true">﻿</a>16.8.8 Communication between the debugger and the program</h3>
+<h3 class="subsection" id="ss:debugger-communication"><a class="section-anchor" href="#ss:debugger-communication" aria-hidden="true">﻿</a><span class="number">8.8</span>Communication between the debugger and the program</h3>
 <p>The debugger communicate with the program being debugged through a
 Unix socket. You may need to change the socket name, for example if
 you need to run the debugger on a machine and your program on another.</p><dl class="description"><dt class="dt-description">
@@ -420,7 +420,7 @@ either a file name, or an Internet port specification
 address in dot notation, and <span class="c010">port</span> is a port number on the host.
 </dd></dl><p>On the debugged program side, the socket name is passed through the
 <span class="c004">CAML_DEBUG_SOCKET</span> environment variable.</p>
-<h3 class="subsection" id="ss:debugger-fine-tuning"><a class="section-anchor" href="#ss:debugger-fine-tuning" aria-hidden="true">﻿</a>16.8.9 Fine-tuning the debugger</h3>
+<h3 class="subsection" id="ss:debugger-fine-tuning"><a class="section-anchor" href="#ss:debugger-fine-tuning" aria-hidden="true">﻿</a><span class="number">8.9</span>Fine-tuning the debugger</h3>
 <p>Several variables enables to fine-tune the debugger. Reasonable
 defaults are provided, and you should normally not have to change them.</p><dl class="description"><dt class="dt-description">
 <span class="c014"><span class="c004">set processcount</span> <span class="c010">count</span></span></dt><dd class="dd-description">
@@ -447,8 +447,8 @@ Print a list of checkpoints.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">info events</span> [<span class="c010">module</span>]</span></dt><dd class="dd-description">
 Print the list of events in the given module (the current module, by default).
 </dd></dl>
-<h3 class="subsection" id="ss:debugger-printers"><a class="section-anchor" href="#ss:debugger-printers" aria-hidden="true">﻿</a>16.8.10 User-defined printers</h3>
-<p>Just as in the toplevel system (section ‍<a href="toplevel.html#s%3Atoplevel-directives">10.2</a>),
+<h3 class="subsection" id="ss:debugger-printers"><a class="section-anchor" href="#ss:debugger-printers" aria-hidden="true">﻿</a><span class="number">8.10</span>User-defined printers</h3>
+<p>Just as in the toplevel system (section&nbsp;<a href="toplevel.html#s%3Atoplevel-directives">10.2</a>),
 the user can register functions for printing values of certain types.
 For technical reasons, the debugger cannot call printing functions
 that reside in the program being debugged. The code for the printing
@@ -472,7 +472,7 @@ defined by the object files loaded using <span class="c004">load_printer</span>.
 reference the functions of the program being debugged.</p></dd><dt class="dt-description"><span class="c014"><span class="c004">remove_printer </span><span class="c010">printer-name</span></span></dt><dd class="dd-description">
 Remove the named function from the table of value printers.
 </dd></dl>
-<h2 class="section" id="s:debugger-misc-cmds"><a class="section-anchor" href="#s:debugger-misc-cmds" aria-hidden="true">﻿</a>16.9 Miscellaneous commands</h2>
+<h2 class="section" id="s:debugger-misc-cmds"><a class="section-anchor" href="#s:debugger-misc-cmds" aria-hidden="true">﻿</a><span class="number">9</span>Miscellaneous commands</h2>
 <dl class="description"><dt class="dt-description">
 <span class="c014"><span class="c004">list</span> [<span class="c010">module</span>] [<span class="c010">beginning</span>] [<span class="c010">end</span>]</span></dt><dd class="dd-description">
 List the source of module <span class="c010">module</span>, from line number
@@ -482,7 +482,7 @@ position.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">source</span> <span class="c010">filename</span></span></dt><dd class="dd-description">
 Read debugger commands from the script <span class="c010">filename</span>.
 </dd></dl>
-<h2 class="section" id="s:inf-debugger"><a class="section-anchor" href="#s:inf-debugger" aria-hidden="true">﻿</a>16.10 Running the debugger under Emacs</h2>
+<h2 class="section" id="s:inf-debugger"><a class="section-anchor" href="#s:inf-debugger" aria-hidden="true">﻿</a><span class="number">10</span>Running the debugger under Emacs</h2>
 <p>The most user-friendly way to use the debugger is to run it under Emacs with
 the OCaml mode available through MELPA and also at
 <a href="https://github.com/ocaml/caml-mode"><span class="c004">https://github.com/ocaml/caml-mode</span></a>.</p><p>The OCaml debugger is started under Emacs by the command <span class="c004">M-x camldebug</span>, with argument the name of the executable file
@@ -523,7 +523,7 @@ to point
 </dd><dt class="dt-description"><span class="c007">C-x C-a C-d</span></dt><dd class="dd-description"> (command <span class="c004">display</span>): display value of identifier at point
 </dd></dl>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="ocamldoc.html">« Chapter ‍15 The documentation generator (ocamldoc)</a><a class="next" href="profil.html">Chapter ‍17 Profiling (ocamlprof) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="ocamldoc.html">« The documentation generator (ocamldoc)</a><a class="next" href="profil.html">Profiling (ocamlprof) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/depend.html
+++ b/site/releases/4.12/htmlman/depend.html
@@ -5,17 +5,17 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍14 Dependency generator (ocamldep)</title>
+<title>OCaml - Dependency generator (ocamldep)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li class="active"><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li class="active"><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec341">Chapter ‍14 Dependency generator (ocamldep)</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍14 Dependency generator (ocamldep)</a></li>
-<li><a href="depend.html#s%3Aocamldep-options">14.1 Options</a>
-</li><li><a href="depend.html#s%3Aocamldep-makefile">14.2 A typical Makefile</a>
+<h1 class="chapter" id="sec341"><span class="number">Chapter 14</span>Dependency generator (ocamldep)</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Dependency generator (ocamldep)</a></li>
+<li><a href="depend.html#s%3Aocamldep-options"><span class="number">1</span>Options</a>
+</li><li><a href="depend.html#s%3Aocamldep-makefile"><span class="number">2</span>A typical Makefile</a>
 </li></ul></nav></header>
 <p> <a id="c:camldep"></a>
 </p><p>The <span class="c004">ocamldep</span> command scans a set of OCaml source files
@@ -30,7 +30,7 @@ where <span class="c004">*.mli *.ml</span> expands to all source files in the cu
 directory and <span class="c004">.depend</span> is the file that should contain the
 dependencies. (See below for a typical <span class="c004">Makefile</span>.)</p><p>Dependencies are generated both for compiling with the bytecode
 compiler <span class="c004">ocamlc</span> and with the native-code compiler <span class="c004">ocamlopt</span>.</p>
-<h2 class="section" id="s:ocamldep-options"><a class="section-anchor" href="#s:ocamldep-options" aria-hidden="true"></a>14.1 Options</h2>
+<h2 class="section" id="s:ocamldep-options"><a class="section-anchor" href="#s:ocamldep-options" aria-hidden="true"></a><span class="number">1</span>Options</h2>
 <p>The following command-line options are recognized by <span class="c004">ocamldep</span>.</p><dl class="description"><dt class="dt-description"><span class="c007">-absname</span></dt><dd class="dd-description">
 Show absolute filenames in error messages.</dd><dt class="dt-description"><span class="c007">-all</span></dt><dd class="dd-description">
 Generate dependencies on all required files, rather than assuming
@@ -95,7 +95,7 @@ Print version string and exit.</dd><dt class="dt-description"><span class="c007"
 Print short version number and exit.</dd><dt class="dt-description"><span class="c014"><span class="c004">-help</span> or <span class="c004">--help</span></span></dt><dd class="dd-description">
 Display a short usage summary and exit.
 </dd></dl>
-<h2 class="section" id="s:ocamldep-makefile"><a class="section-anchor" href="#s:ocamldep-makefile" aria-hidden="true">﻿</a>14.2 A typical Makefile</h2>
+<h2 class="section" id="s:ocamldep-makefile"><a class="section-anchor" href="#s:ocamldep-makefile" aria-hidden="true">﻿</a><span class="number">2</span>A typical Makefile</h2>
 <p>Here is a template <span class="c004">Makefile</span> for a OCaml program.</p><pre>OCAMLC=ocamlc
 OCAMLOPT=ocamlopt
 OCAMLDEP=ocamldep
@@ -162,7 +162,7 @@ If <span class="c004">mylib.mli</span> itself has dependencies, you should compu
 
 </p>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="lexyacc.html">« Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a><a class="next" href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="lexyacc.html">« Lexer and parser generators (ocamllex, ocamlyacc)</a><a class="next" href="ocamldoc.html">The documentation generator (ocamldoc) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/doccomments.html
+++ b/site/releases/4.12/htmlman/doccomments.html
@@ -5,47 +5,47 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:doc-comments"><a class="section-anchor" href="#s:doc-comments" aria-hidden="true"></a>8.18 Documentation comments</h2>
+<h2 class="section" id="s:doc-comments"><a class="section-anchor" href="#s:doc-comments" aria-hidden="true"></a><span class="number">18</span>Documentation comments</h2>
 <ul>
-<li><a href="doccomments.html#ss%3Afloating-comments">8.18.1 Floating comments</a>
-</li><li><a href="doccomments.html#ss%3Aitem-comments">8.18.2 Item comments</a>
-</li><li><a href="doccomments.html#ss%3Alabel-comments">8.18.3 Label comments</a>
+<li><a href="doccomments.html#ss%3Afloating-comments"><span class="number">18.1</span>Floating comments</a>
+</li><li><a href="doccomments.html#ss%3Aitem-comments"><span class="number">18.2</span>Item comments</a>
+</li><li><a href="doccomments.html#ss%3Alabel-comments"><span class="number">18.3</span>Label comments</a>
 </li></ul>
 <p>
 (Introduced in OCaml 4.03)</p><p>Comments which start with <span class="c004">**</span> are treated specially by the
@@ -58,7 +58,7 @@ warning 50.</p><p>Comments which start with <span class="c004">**</span> are als
 documentation generator (see <a href="ocamldoc.html#c%3Aocamldoc">15</a>). The three comment forms
 recognised by the compiler are a subset of the forms accepted by
 ocamldoc (see <a href="ocamldoc.html#s%3Aocamldoc-comments">15.2</a>).</p>
-<h3 class="subsection" id="ss:floating-comments"><a class="section-anchor" href="#ss:floating-comments" aria-hidden="true">﻿</a>8.18.1 Floating comments</h3>
+<h3 class="subsection" id="ss:floating-comments"><a class="section-anchor" href="#ss:floating-comments" aria-hidden="true">﻿</a><span class="number">18.1</span>Floating comments</h3>
 <p>Comments surrounded by blank lines that appear within structures,
 signatures, classes or class types are converted into
 <a class="syntax" href="attributes.html#floating-attribute"><span class="c011">floating-attribute</span></a>s. For example:</p><div class="caml-example verbatim">
@@ -86,7 +86,7 @@ signatures, classes or class types are converted into
 <span class="ocamlkeyword">let</span> mkT = T</div></div>
 
 </div>
-<h3 class="subsection" id="ss:item-comments"><a class="section-anchor" href="#ss:item-comments" aria-hidden="true">﻿</a>8.18.2 Item comments</h3>
+<h3 class="subsection" id="ss:item-comments"><a class="section-anchor" href="#ss:item-comments" aria-hidden="true">﻿</a><span class="number">18.2</span>Item comments</h3>
 <p>Comments which appear <em>immediately before</em> or <em>immediately
 after</em> a structure item, signature item, class item or class type item
 are converted into <a class="syntax" href="attributes.html#item-attribute"><span class="c011">item-attribute</span></a>s. Immediately before or immediately
@@ -141,7 +141,7 @@ as in:</p><div class="caml-example verbatim">
 [@@ocaml.doc <span class="ocamlstring">" An ambiguous comment "</span>]</div></div>
 
 </div><p>and the compiler will emit warning 50.</p>
-<h3 class="subsection" id="ss:label-comments"><a class="section-anchor" href="#ss:label-comments" aria-hidden="true">﻿</a>8.18.3 Label comments</h3>
+<h3 class="subsection" id="ss:label-comments"><a class="section-anchor" href="#ss:label-comments" aria-hidden="true">﻿</a><span class="number">18.3</span>Label comments</h3>
 <p>Comments which appear <em>immediately after</em> a labelled argument,
 record field, variant constructor, object method or polymorphic variant
 constructor are are converted into <a class="syntax" href="attributes.html#attribute"><span class="c011">attribute</span></a>s. Immediately
@@ -229,7 +229,7 @@ comments between them. For example:</p><div class="caml-example verbatim">
 [@@ocaml.doc <span class="ocamlstring">" Attaches to t "</span>]</div></div>
 
 </div><p>In the absence of meaningful comment on the last constructor of
-a type, an empty comment ‍<span class="c004">(**)</span> can be used instead:</p><div class="caml-example verbatim">
+a type, an empty comment&nbsp;<span class="c004">(**)</span> can be used instead:</p><div class="caml-example verbatim">
 
 <div class="ocaml">
 
@@ -250,7 +250,7 @@ a type, an empty comment ‍<span class="c004">(**)</span> can be used instead
 
 </div>
 
-<div class="bottom-navigation"><a class="previous" href="inlinerecords.html">« 8.17 Inline records</a><a class="next" href="indexops.html">8.19 Extended indexing operators »</a></div>
+<div class="bottom-navigation"><a class="previous" href="inlinerecords.html">« Inline records</a><a class="next" href="indexops.html">Extended indexing operators »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/emptyvariants.html
+++ b/site/releases/4.12/htmlman/emptyvariants.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:empty-variants"><a class="section-anchor" href="#s:empty-variants" aria-hidden="true"></a>8.20 Empty variant types</h2>
+<h2 class="section" id="s:empty-variants"><a class="section-anchor" href="#s:empty-variants" aria-hidden="true"></a><span class="number">20</span>Empty variant types</h2>
 <p>
 (Introduced in 4.07.0)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="typedecl.html#type-representation"><span class="c011">type-representation</span></a></td><td class="c016">::=</td><td class="c018">
@@ -65,7 +65,7 @@ Empty variant type can be eliminated by refutation case of pattern matching.
 
 </div>
 
-<div class="bottom-navigation"><a class="previous" href="indexops.html">« 8.19 Extended indexing operators</a><a class="next" href="alerts.html">8.21 Alerts »</a></div>
+<div class="bottom-navigation"><a class="previous" href="indexops.html">« Extended indexing operators</a><a class="next" href="alerts.html">Alerts »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/expr.html
+++ b/site/releases/4.12/htmlman/expr.html
@@ -5,41 +5,41 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:value-expr"><a class="section-anchor" href="#s:value-expr" aria-hidden="true"></a>7.7 Expressions</h2>
+<h2 class="section" id="s:value-expr"><a class="section-anchor" href="#s:value-expr" aria-hidden="true"></a><span class="number">7</span>Expressions</h2>
 <ul>
-<li><a href="expr.html#ss%3Aprecedence-and-associativity">7.7.1 Precedence and associativity</a>
-</li><li><a href="expr.html#ss%3Aexpr-basic">7.7.2 Basic expressions</a>
-</li><li><a href="expr.html#ss%3Aexpr-control">7.7.3 Control structures</a>
-</li><li><a href="expr.html#ss%3Aexpr-ops-on-data">7.7.4 Operations on data structures</a>
-</li><li><a href="expr.html#ss%3Aexpr-operators">7.7.5 Operators</a>
-</li><li><a href="expr.html#ss%3Aexpr-obj">7.7.6 Objects</a>
-</li><li><a href="expr.html#ss%3Aexpr-coercions">7.7.7 Coercions</a>
-</li><li><a href="expr.html#ss%3Aexpr-other">7.7.8 Other</a>
+<li><a href="expr.html#ss%3Aprecedence-and-associativity"><span class="number">7.1</span>Precedence and associativity</a>
+</li><li><a href="expr.html#ss%3Aexpr-basic"><span class="number">7.2</span>Basic expressions</a>
+</li><li><a href="expr.html#ss%3Aexpr-control"><span class="number">7.3</span>Control structures</a>
+</li><li><a href="expr.html#ss%3Aexpr-ops-on-data"><span class="number">7.4</span>Operations on data structures</a>
+</li><li><a href="expr.html#ss%3Aexpr-operators"><span class="number">7.5</span>Operators</a>
+</li><li><a href="expr.html#ss%3Aexpr-obj"><span class="number">7.6</span>Objects</a>
+</li><li><a href="expr.html#ss%3Aexpr-coercions"><span class="number">7.7</span>Coercions</a>
+</li><li><a href="expr.html#ss%3Aexpr-other"><span class="number">7.8</span>Other</a>
 </li></ul>
 <p>
 <a id="hevea_manual.kwd20"></a>
@@ -238,7 +238,7 @@ See also the following language extensions:
 <a href="attributes.html#s%3Aattributes">attributes</a>,
 <a href="extensionnodes.html#s%3Aextension-nodes">extension nodes</a> and
 <a href="indexops.html#s%3Aindex-operators">extended indexing operators</a>.</p>
-<h3 class="subsection" id="ss:precedence-and-associativity"><a class="section-anchor" href="#ss:precedence-and-associativity" aria-hidden="true">﻿</a>7.7.1 Precedence and associativity</h3>
+<h3 class="subsection" id="ss:precedence-and-associativity"><a class="section-anchor" href="#ss:precedence-and-associativity" aria-hidden="true">﻿</a><span class="number">7.1</span>Precedence and associativity</h3>
 <p>
 The table below shows the relative precedences and associativity of
 operators and non-closed constructions. The constructions with higher
@@ -255,7 +255,7 @@ precedence come first. For infix and prefix symbols, we write
 <div class="center"><table class="c000 cellpadding1" border="1"><tbody><tr><td class="c015"><span class="c014">Construction or operator</span></td><td class="c015"><span class="c014">Associativity</span> </td></tr>
 <tr><td class="c017">
 prefix-symbol</td><td class="c017">– </td></tr>
-<tr><td class="c017"><span class="c004">.   .(   .[   .{</span> (see section ‍<a href="bigarray.html#s%3Abigarray-access">8.11</a>)</td><td class="c017">– </td></tr>
+<tr><td class="c017"><span class="c004">.   .(   .[   .{</span> (see section&nbsp;<a href="bigarray.html#s%3Abigarray-access">8.11</a>)</td><td class="c017">– </td></tr>
 <tr><td class="c017"><span class="c004">#</span>…</td><td class="c017">left </td></tr>
 <tr><td class="c017">function application, constructor application, tag
 application, <span class="c004">assert</span>,
@@ -275,7 +275,7 @@ application, <span class="c004">assert</span>,
 <tr><td class="c017"><span class="c004">;</span></td><td class="c017">right </td></tr>
 <tr><td class="c017"><span class="c004">let  match  fun  function  try</span></td><td class="c017">– </td></tr>
 </tbody></table></div></div>
-<h3 class="subsection" id="ss:expr-basic"><a class="section-anchor" href="#ss:expr-basic" aria-hidden="true">﻿</a>7.7.2 Basic expressions</h3>
+<h3 class="subsection" id="ss:expr-basic"><a class="section-anchor" href="#ss:expr-basic" aria-hidden="true">﻿</a><span class="number">7.2</span>Basic expressions</h3>
 <h4 class="subsubsection" id="sss:expr-constants"><a class="section-anchor" href="#sss:expr-constants" aria-hidden="true">﻿</a>Constants</h4>
 <p>An expression consisting in a constant evaluates to this constant.</p><h4 class="subsubsection" id="sss:expr-var"><a class="section-anchor" href="#sss:expr-var" aria-hidden="true">﻿</a>Value paths</h4>
 <p>An expression consisting in an access path evaluates to the value bound to
@@ -292,7 +292,7 @@ and <span class="c005">(</span> … <span class="c005">)</span> for the other gr
 <a class="syntax" href="#expr"><span class="c011">expr</span></a> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a> <span class="c005">)</span>. This constraint forces the type of <a class="syntax" href="#expr"><span class="c011">expr</span></a> to be
 compatible with <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a>.</p><p>Parenthesized expressions can also contain coercions
 <span class="c005">(</span> <a class="syntax" href="#expr"><span class="c011">expr</span></a>  [<span class="c005">:</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a>] <span class="c005">:&gt;</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a><span class="c005">)</span> (see
-subsection ‍<a href="#ss%3Aexpr-coercions">7.7.7</a> below).</p><h4 class="subsubsection" id="sss:expr-functions-application"><a class="section-anchor" href="#sss:expr-functions-application" aria-hidden="true">﻿</a>Function application</h4>
+subsection&nbsp;<a href="#ss%3Aexpr-coercions">7.7.7</a> below).</p><h4 class="subsubsection" id="sss:expr-functions-application"><a class="section-anchor" href="#sss:expr-functions-application" aria-hidden="true">﻿</a>Function application</h4>
 <p>Function application is denoted by juxtaposition of (possibly labeled)
 expressions. The expression <a class="syntax" href="#expr"><span class="c011">expr</span></a>  <a class="syntax" href="#argument"><span class="c011">argument</span></a><sub>1</sub> …  <a class="syntax" href="#argument"><span class="c011">argument</span></a><sub><span class="c010">n</span></sub>
 evaluates the expression <a class="syntax" href="#expr"><span class="c011">expr</span></a> and those appearing in <a class="syntax" href="#argument"><span class="c011">argument</span></a><sub>1</sub>
@@ -455,7 +455,7 @@ This defines <span class="c011">name</span><sub>1</sub> …  <span class="c011
 local to <a class="syntax" href="#expr"><span class="c011">expr</span></a>.</p><p>The behavior of other forms of <span class="c003"><span class="c004">let</span> <span class="c004">rec</span></span> definitions is
 implementation-dependent. The current implementation also supports
 a certain class of recursive definitions of non-functional values,
-as explained in section ‍<a href="letrecvalues.html#s%3Aletrecvalues">8.1</a>.
+as explained in section&nbsp;<a href="letrecvalues.html#s%3Aletrecvalues">8.1</a>.
 </p>
 <h4 class="subsubsection" id="sss:expr-explicit-polytype"><a class="section-anchor" href="#sss:expr-explicit-polytype" aria-hidden="true">﻿</a>Explicit polymorphic type annotations</h4>
 <p>
@@ -476,7 +476,7 @@ true:
 </p><pre>  let gen () = let exception A in A
   let () = assert(gen () &lt;&gt; gen ())
 </pre>
-<h3 class="subsection" id="ss:expr-control"><a class="section-anchor" href="#ss:expr-control" aria-hidden="true">﻿</a>7.7.3 Control structures</h3>
+<h3 class="subsection" id="ss:expr-control"><a class="section-anchor" href="#ss:expr-control" aria-hidden="true">﻿</a><span class="number">7.3</span>Control structures</h3>
 <h4 class="subsubsection" id="sss:expr-sequence"><a class="section-anchor" href="#sss:expr-sequence" aria-hidden="true">﻿</a>Sequence</h4>
 <p>The expression <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub> <span class="c005">;</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>2</sub> evaluates <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub> first, then
 <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>2</sub>, and returns the value of <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>2</sub>.</p><h4 class="subsubsection" id="sss:expr-conditional"><a class="section-anchor" href="#sss:expr-conditional" aria-hidden="true">﻿</a>Conditional</h4>
@@ -543,7 +543,7 @@ The loop body is never evaluated if <span class="c010">n</span> &lt; <span class
 value <span class="c005">()</span>.</p><h4 class="subsubsection" id="sss:expr-exception-handling"><a class="section-anchor" href="#sss:expr-exception-handling" aria-hidden="true">﻿</a>Exception handling</h4>
 <p>
 <a id="hevea_manual.kwd69"></a></p><p>The expression
-</p><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019"><span class="c005">try ‍</span></td><td class="c018"><span class="c013">expr</span> </td></tr>
+</p><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019"><span class="c005">try&nbsp;</span></td><td class="c018"><span class="c013">expr</span> </td></tr>
 <tr><td class="c019"><span class="c005">with</span></td><td class="c018"><span class="c013">pattern</span><sub>1</sub></td><td class="c018"><span class="c005">-&gt;</span></td><td class="c018"><span class="c013">expr</span><sub>1</sub> </td></tr>
 <tr><td class="c019"><span class="c005">|</span></td><td class="c018">… </td></tr>
 <tr><td class="c019"><span class="c005">|</span></td><td class="c018"><span class="c013">pattern</span><sub><span class="c010">n</span></sub></td><td class="c018"><span class="c005">-&gt;</span></td><td class="c018"><span class="c013">expr</span><sub><span class="c010">n</span></sub>
@@ -562,7 +562,7 @@ bindings performed during matching. If several patterns match the value of
 selected. If none of the patterns matches the value of <a class="syntax" href="#expr"><span class="c011">expr</span></a>, the
 exception value is raised again, thereby transparently “passing
 through” the <span class="c005">try</span> construct.</p>
-<h3 class="subsection" id="ss:expr-ops-on-data"><a class="section-anchor" href="#ss:expr-ops-on-data" aria-hidden="true">﻿</a>7.7.4 Operations on data structures</h3>
+<h3 class="subsection" id="ss:expr-ops-on-data"><a class="section-anchor" href="#ss:expr-ops-on-data" aria-hidden="true">﻿</a><span class="number">7.4</span>Operations on data structures</h3>
 <h4 class="subsubsection" id="sss:expr-products"><a class="section-anchor" href="#sss:expr-products" aria-hidden="true">﻿</a>Products</h4>
 <p>The expression <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub> <span class="c005">,</span> … <span class="c005">,</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub><span class="c010">n</span></sub> evaluates to the
 <span class="c010">n</span>-tuple of the values of expressions <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub> to <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub><span class="c010">n</span></sub>. The
@@ -640,7 +640,7 @@ the access is out of bounds. The value of the whole expression is <span class="c
 compatibility with older versions of OCaml and will be removed in a
 future version. New code should use byte sequences and the <span class="c004">Bytes.set</span>
 function.</p>
-<h3 class="subsection" id="ss:expr-operators"><a class="section-anchor" href="#ss:expr-operators" aria-hidden="true">﻿</a>7.7.5 Operators</h3>
+<h3 class="subsection" id="ss:expr-operators"><a class="section-anchor" href="#ss:expr-operators" aria-hidden="true">﻿</a><span class="number">7.5</span>Operators</h3>
 <p>
 <a id="hevea_manual.kwd70"></a>
 <a id="hevea_manual.kwd71"></a>
@@ -661,7 +661,7 @@ interpreted as the application <span class="c005">(</span> <a class="syntax" hre
  <a class="syntax" href="#expr"><span class="c011">expr</span></a>. Similarly, the expression <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub>  <a class="syntax" href="lex.html#infix-symbol"><span class="c011">infix-symbol</span></a>  <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>2</sub> is
 interpreted as the application <span class="c005">(</span> <a class="syntax" href="lex.html#infix-symbol"><span class="c011">infix-symbol</span></a> <span class="c005">)</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub>  <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>2</sub>.</p><p>The table below lists the symbols defined in the initial environment
 and their initial meaning. (See the description of the core
-library module <span class="c004">Stdlib</span> in chapter ‍<a href="core.html#c%3Acorelib">22</a> for more
+library module <span class="c004">Stdlib</span> in chapter&nbsp;<a href="core.html#c%3Acorelib">22</a> for more
 details). Their meaning may be changed at any time using
 <span class="c003"><span class="c004">let</span> <span class="c004">(</span></span> <a class="syntax" href="names.html#infix-op"><span class="c011">infix-op</span></a> <span class="c005">)</span>  <span class="c011">name</span><sub>1</sub>  <span class="c011">name</span><sub>2</sub> <span class="c005">=</span> …</p><p>Note: the operators <span class="c005">&amp;&amp;</span>, <span class="c005">||</span>, and <span class="c005">~-</span> are handled specially
 and it is not advisable to change their meaning.</p><p>The keywords <span class="c005">-</span> and <span class="c005">-.</span> can appear both as infix and
@@ -707,7 +707,7 @@ argument). </td></tr>
 <tr><td class="c023"><span class="c004">&amp;&amp;   &amp;</span></td><td class="c022">Boolean conjunction. </td></tr>
 <tr><td class="c023"><span class="c004">||   or</span></td><td class="c022">Boolean disjunction. </td></tr>
 </tbody></table></div></div>
-<h3 class="subsection" id="ss:expr-obj"><a class="section-anchor" href="#ss:expr-obj" aria-hidden="true">﻿</a>7.7.6 Objects</h3>
+<h3 class="subsection" id="ss:expr-obj"><a class="section-anchor" href="#ss:expr-obj" aria-hidden="true">﻿</a><span class="number">7.6</span>Objects</h3>
 <p> <a id="s:objects"></a></p><h4 class="subsubsection" id="sss:expr-obj-creation"><a class="section-anchor" href="#sss:expr-obj-creation" aria-hidden="true">﻿</a>Object creation</h4>
 <p><a id="hevea_manual.kwd84"></a></p><p>When <a class="syntax" href="names.html#class-path"><span class="c011">class-path</span></a> evaluates to a class body, <span class="c005">new</span> <a class="syntax" href="names.html#class-path"><span class="c011">class-path</span></a>
 evaluates to a new object containing the instance variables and
@@ -743,7 +743,7 @@ returns a copy of self with the given instance variables replaced by
 the values of the associated expressions. A single instance variable
 name <span class="c011">id</span> stands for <span class="c011">id</span> <span class="c005">=</span>  <span class="c011">id</span>. Other instance variables have the same
 value in the returned object as in self.</p>
-<h3 class="subsection" id="ss:expr-coercions"><a class="section-anchor" href="#ss:expr-coercions" aria-hidden="true">﻿</a>7.7.7 Coercions</h3>
+<h3 class="subsection" id="ss:expr-coercions"><a class="section-anchor" href="#ss:expr-coercions" aria-hidden="true">﻿</a><span class="number">7.7</span>Coercions</h3>
 <p>Expressions whose type contains object or polymorphic variant types
 can be explicitly coerced (weakened) to a supertype.
 The expression <span class="c005">(</span><a class="syntax" href="#expr"><span class="c011">expr</span></a> <span class="c005">:&gt;</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a><span class="c005">)</span> coerces the expression <a class="syntax" href="#expr"><span class="c011">expr</span></a>
@@ -780,7 +780,7 @@ is a supertype of
 </p><div class="center">
  <span class="c005">&lt;</span> <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub>1</sub> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>1</sub> <span class="c005">;</span> … <span class="c005">;</span> <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub><span class="c010">n</span></sub> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">n</span></sub> <span class="c005">;</span>
 <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub><span class="c010">n</span>+1</sub> <span class="c005">:</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">n</span>+1</sub> <span class="c005">;</span> … <span class="c005">;</span> <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub><span class="c010">n</span>+<span class="c010">m</span></sub> <span class="c005">:</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">n</span>+<span class="c010">m</span></sub>
- ‍[<span class="c003"><span class="c004">;</span> <span class="c004">..</span></span>] <span class="c005">&gt;</span> 
+&nbsp;[<span class="c003"><span class="c004">;</span> <span class="c004">..</span></span>] <span class="c005">&gt;</span> 
 </div><p>
 which may contain an ellipsis <span class="c004">..</span> if every <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub><span class="c010">i</span></sub> is a supertype of
 the corresponding <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">i</span></sub>.</p><p>A monomorphic method type can be a supertype of a polymorphic method
@@ -812,7 +812,7 @@ subtyping of their arguments. For instance, <a class="syntax" href="types.html#t
 subtype of <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>1</sub> <span class="c005">*</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>2</sub> when <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>1</sub> and <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>2</sub> are
 respectively subtypes of <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>1</sub> and <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>2</sub>.
 For function types, the relation is more subtle:
-<a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>1</sub> <span class="c005">-&gt;</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>2</sub> is a subtype of <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>1</sub> ‍<span class="c005">-&gt;</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>2</sub>
+<a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>1</sub> <span class="c005">-&gt;</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>2</sub> is a subtype of <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>1</sub>&nbsp;<span class="c005">-&gt;</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>2</sub>
 if <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>1</sub> is a supertype of <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>1</sub> and <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>2</sub> is a
 subtype of <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>2</sub>. For this reason, function types are covariant in
 their second argument (like tuples), but contravariant in their first
@@ -825,10 +825,10 @@ variance-free if it has no occurrences, and nonvariant otherwise.
 A variance-free parameter may change freely through subtyping, it does
 not have to be a subtype or a supertype.
 For abstract and private types, the variance must be given explicitly
-(see section ‍<a href="typedecl.html#ss%3Atypedefs">7.8.1</a>),
+(see section&nbsp;<a href="typedecl.html#ss%3Atypedefs">7.8.1</a>),
 otherwise the default is nonvariant. This is also the case for
 constrained arguments in type definitions.</p>
-<h3 class="subsection" id="ss:expr-other"><a class="section-anchor" href="#ss:expr-other" aria-hidden="true">﻿</a>7.7.8 Other</h3>
+<h3 class="subsection" id="ss:expr-other"><a class="section-anchor" href="#ss:expr-other" aria-hidden="true">﻿</a><span class="number">7.8</span>Other</h3>
 <h4 class="subsubsection" id="sss:expr-assertion"><a class="section-anchor" href="#sss:expr-assertion" aria-hidden="true">﻿</a>Assertion checking</h4>
 <p><a id="hevea_manual.kwd86"></a></p><p>OCaml supports the <span class="c005">assert</span> construct to check debugging assertions.
 The expression <span class="c005">assert</span> <a class="syntax" href="#expr"><span class="c011">expr</span></a> evaluates the expression <a class="syntax" href="#expr"><span class="c011">expr</span></a> and
@@ -851,7 +851,7 @@ evaluated at this point in the program. Instead, its evaluation will
 be performed the first time the function <span class="c004">Lazy.force</span> is applied to the value
 <span class="c010">v</span>, returning the actual value of <a class="syntax" href="#expr"><span class="c011">expr</span></a>. Subsequent applications
 of <span class="c004">Lazy.force</span> to <span class="c010">v</span> do not evaluate <a class="syntax" href="#expr"><span class="c011">expr</span></a> again. Applications
-of <span class="c004">Lazy.force</span> may be implicit through pattern matching (see ‍<a href="patterns.html#sss%3Apat-lazy">7.6</a>).</p><h4 class="subsubsection" id="sss:expr-local-modules"><a class="section-anchor" href="#sss:expr-local-modules" aria-hidden="true">﻿</a>Local modules</h4>
+of <span class="c004">Lazy.force</span> may be implicit through pattern matching (see&nbsp;<a href="patterns.html#sss%3Apat-lazy">7.6</a>).</p><h4 class="subsubsection" id="sss:expr-local-modules"><a class="section-anchor" href="#sss:expr-local-modules" aria-hidden="true">﻿</a>Local modules</h4>
 <p>
 <a id="hevea_manual.kwd88"></a>
 <a id="hevea_manual.kwd89"></a></p><p>The expression
@@ -891,7 +891,7 @@ For example, <a class="syntax" href="names.html#module-path"><span class="c011">
 <a class="syntax" href="names.html#module-path"><span class="c011">module-path</span></a><span class="c005">.([</span> <a class="syntax" href="#expr"><span class="c011">expr</span></a><span class="c005">])</span>, and <a class="syntax" href="names.html#module-path"><span class="c011">module-path</span></a><span class="c005">.[|</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a> <span class="c005">|]</span> is
 equivalent to <a class="syntax" href="names.html#module-path"><span class="c011">module-path</span></a><span class="c005">.([|</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a> <span class="c005">|])</span>.</p>
 
-<div class="bottom-navigation"><a class="previous" href="patterns.html">« 7.6 Patterns</a><a class="next" href="typedecl.html">7.8 Type and exception definitions »</a></div>
+<div class="bottom-navigation"><a class="previous" href="patterns.html">« Patterns</a><a class="next" href="typedecl.html">Type and exception definitions »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/extensiblevariants.html
+++ b/site/releases/4.12/htmlman/extensiblevariants.html
@@ -5,45 +5,45 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:extensible-variants"><a class="section-anchor" href="#s:extensible-variants" aria-hidden="true"></a>8.14 Extensible variant types</h2>
+<h2 class="section" id="s:extensible-variants"><a class="section-anchor" href="#s:extensible-variants" aria-hidden="true"></a><span class="number">14</span>Extensible variant types</h2>
 <ul>
-<li><a href="extensiblevariants.html#ss%3Aprivate-extensible">8.14.1 Private extensible variant types</a>
+<li><a href="extensiblevariants.html#ss%3Aprivate-extensible"><span class="number">14.1</span>Private extensible variant types</a>
 </li></ul>
 <p>(Introduced in OCaml 4.02)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="typedecl.html#type-representation"><span class="c011">type-representation</span></a></td><td class="c016">::=</td><td class="c018">
@@ -210,7 +210,7 @@ pattern-matching.
 <div class="pre caml-output error"><span class="ocamlerror">Error</span>: Cannot use private constructor Bool to create values of type Expr.attr</div></div>
 
 </div>
-<h3 class="subsection" id="ss:private-extensible"><a class="section-anchor" href="#ss:private-extensible" aria-hidden="true">﻿</a>8.14.1 Private extensible variant types</h3>
+<h3 class="subsection" id="ss:private-extensible"><a class="section-anchor" href="#ss:private-extensible" aria-hidden="true">﻿</a><span class="number">14.1</span>Private extensible variant types</h3>
 <p>(Introduced in OCaml 4.06)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="typedecl.html#type-representation"><span class="c011">type-representation</span></a></td><td class="c016">::=</td><td class="c018">
 ...
@@ -243,7 +243,7 @@ constructors to be referred to in interfaces.
 
 </div>
 
-<div class="bottom-navigation"><a class="previous" href="extensionnodes.html">« 8.13 Extension nodes</a><a class="next" href="generativefunctors.html">8.15 Generative functors »</a></div>
+<div class="bottom-navigation"><a class="previous" href="extensionnodes.html">« Extension nodes</a><a class="next" href="generativefunctors.html">Generative functors »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/extensionnodes.html
+++ b/site/releases/4.12/htmlman/extensionnodes.html
@@ -5,45 +5,45 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:extension-nodes"><a class="section-anchor" href="#s:extension-nodes" aria-hidden="true"></a>8.13 Extension nodes</h2>
+<h2 class="section" id="s:extension-nodes"><a class="section-anchor" href="#s:extension-nodes" aria-hidden="true"></a><span class="number">13</span>Extension nodes</h2>
 <ul>
-<li><a href="extensionnodes.html#ss%3Abuiltin-extension-nodes">8.13.1 Built-in extension nodes</a>
+<li><a href="extensionnodes.html#ss%3Abuiltin-extension-nodes"><span class="number">13.1</span>Built-in extension nodes</a>
 </li></ul>
 <p>(Introduced in OCaml 4.02,
 infix notations for constructs other than expressions added in 4.03,
@@ -51,7 +51,7 @@ infix notation (e1 ;%ext e2) added in 4.04.
 )</p><p>Extension nodes are generic placeholders in the syntax tree. They are
 rejected by the type-checker and are intended to be “expanded” by external
 tools such as <span class="c004">-ppx</span> rewriters.</p><p>Extension nodes share the same notion of identifier and payload as
-attributes ‍<a href="attributes.html#s%3Aattributes">8.12</a>.</p><p>The first form of extension node is used for “algebraic” categories:</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
+attributes&nbsp;<a href="attributes.html#s%3Aattributes">8.12</a>.</p><p>The first form of extension node is used for “algebraic” categories:</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" id="extension"><span class="c011">extension</span></a></td><td class="c016">::=</td><td class="c018">
 <span class="c005">[%</span> <a class="syntax" href="attributes.html#attr-id"><span class="c011">attr-id</span></a>  <a class="syntax" href="attributes.html#attr-payload"><span class="c011">attr-payload</span></a> <span class="c005">]</span>
  </td></tr>
@@ -156,7 +156,7 @@ Indeed, the user cannot see from the code whether this string literal has
 different semantics than they expect. Moreover, giving semantics to a
 specific delimiter limits the freedom to change the delimiter to avoid
 escaping issues.</p>
-<h3 class="subsection" id="ss:builtin-extension-nodes"><a class="section-anchor" href="#ss:builtin-extension-nodes" aria-hidden="true">﻿</a>8.13.1 Built-in extension nodes</h3>
+<h3 class="subsection" id="ss:builtin-extension-nodes"><a class="section-anchor" href="#ss:builtin-extension-nodes" aria-hidden="true">﻿</a><span class="number">13.1</span>Built-in extension nodes</h3>
 <p>(Introduced in OCaml 4.03)</p><p>Some extension nodes are understood by the compiler itself:
 </p><ul class="itemize"><li class="li-itemize">
 “ocaml.extension_constructor” or “extension_constructor”
@@ -188,7 +188,7 @@ constructor slot.
 
 </div>
 
-<div class="bottom-navigation"><a class="previous" href="attributes.html">« 8.12 Attributes</a><a class="next" href="extensiblevariants.html">8.14 Extensible variant types »</a></div>
+<div class="bottom-navigation"><a class="previous" href="attributes.html">« Attributes</a><a class="next" href="extensiblevariants.html">Extensible variant types »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/extensionsyntax.html
+++ b/site/releases/4.12/htmlman/extensionsyntax.html
@@ -5,46 +5,46 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:extension-syntax"><a class="section-anchor" href="#s:extension-syntax" aria-hidden="true"></a>8.16 Extension-only syntax</h2>
+<h2 class="section" id="s:extension-syntax"><a class="section-anchor" href="#s:extension-syntax" aria-hidden="true"></a><span class="number">16</span>Extension-only syntax</h2>
 <ul>
-<li><a href="extensionsyntax.html#ss%3Aextension-operators">8.16.1 Extension operators</a>
-</li><li><a href="extensionsyntax.html#ss%3Aextension-literals">8.16.2 Extension literals</a>
+<li><a href="extensionsyntax.html#ss%3Aextension-operators"><span class="number">16.1</span>Extension operators</a>
+</li><li><a href="extensionsyntax.html#ss%3Aextension-literals"><span class="number">16.2</span>Extension literals</a>
 </li></ul>
 <p>
 (Introduced in OCaml 4.02.2, extended in 4.03)</p><p>Some syntactic constructions are accepted during parsing and rejected
@@ -54,7 +54,7 @@ external tools can exploit this parser leniency to extend the language
 with these new syntactic constructions by rewriting them to
 vanilla constructions.
 </p>
-<h3 class="subsection" id="ss:extension-operators"><a class="section-anchor" href="#ss:extension-operators" aria-hidden="true">﻿</a>8.16.1 Extension operators</h3>
+<h3 class="subsection" id="ss:extension-operators"><a class="section-anchor" href="#ss:extension-operators" aria-hidden="true">﻿</a><span class="number">16.1</span>Extension operators</h3>
 <p> <a id="s:ext-ops"></a>
 (Introduced in OCaml 4.02.2)
 </p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -67,7 +67,7 @@ vanilla constructions.
 </tbody></table></td></tr>
 </tbody></table></div><p>Operator names starting with a <span class="c004">#</span> character and containing more than
 one <span class="c004">#</span> character are reserved for extensions.</p>
-<h3 class="subsection" id="ss:extension-literals"><a class="section-anchor" href="#ss:extension-literals" aria-hidden="true">﻿</a>8.16.2 Extension literals</h3>
+<h3 class="subsection" id="ss:extension-literals"><a class="section-anchor" href="#ss:extension-literals" aria-hidden="true">﻿</a><span class="number">16.2</span>Extension literals</h3>
 <p>
 (Introduced in OCaml 4.03)
 </p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -108,7 +108,7 @@ one <span class="c004">#</span> character are reserved for extensions.</p>
 Int and float literals followed by an one-letter identifier in the
 range [<span class="c005">g</span>..<span class="c005">z</span>∣ <span class="c005">G</span>..<span class="c005">Z</span>] are extension-only literals.</p>
 
-<div class="bottom-navigation"><a class="previous" href="generativefunctors.html">« 8.15 Generative functors</a><a class="next" href="inlinerecords.html">8.17 Inline records »</a></div>
+<div class="bottom-navigation"><a class="previous" href="generativefunctors.html">« Generative functors</a><a class="next" href="inlinerecords.html">Inline records »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/extn.html
+++ b/site/releases/4.12/htmlman/extn.html
@@ -5,68 +5,68 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1>
 <p> <a id="c:extensions"></a>
 </p><p>This chapter describes language extensions and convenience features
-that are implemented in OCaml, but not described in chapter <a href="language.html#c%3Arefman">7</a>.</p><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html">8.3 Private types</a>
-</li><li><a href="locallyabstract.html">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html">8.17 Inline records</a>
-</li><li><a href="doccomments.html">8.18 Documentation comments</a>
-</li><li><a href="indexops.html">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html">8.20 Empty variant types</a>
-</li><li><a href="alerts.html">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html">8.23 Binding operators</a>
+that are implemented in OCaml, but not described in chapter <a href="language.html#c%3Arefman">7</a>.</p><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><ul class="ul-content">
-<li><a href="letrecvalues.html">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html">8.3 Private types</a>
-</li><li><a href="locallyabstract.html">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html">8.17 Inline records</a>
-</li><li><a href="doccomments.html">8.18 Documentation comments</a>
-</li><li><a href="indexops.html">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html">8.20 Empty variant types</a>
-</li><li><a href="alerts.html">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html">8.23 Binding operators</a>
+<li><a href="letrecvalues.html"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html"><span class="number">23</span>Binding operators</a>
 </li></ul>
 
 <hr>
-<div class="bottom-navigation"><a class="previous" href="language.html">« Chapter ‍7 The OCaml language</a><a class="next" href="comp.html">Chapter ‍9 Batch compilation (ocamlc) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="language.html">« The OCaml language</a><a class="next" href="comp.html">Batch compilation (ocamlc) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/firstclassmodules.html
+++ b/site/releases/4.12/htmlman/firstclassmodules.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:first-class-modules"><a class="section-anchor" href="#s:first-class-modules" aria-hidden="true"></a>8.5 First-class modules</h2>
+<h2 class="section" id="s:first-class-modules"><a class="section-anchor" href="#s:first-class-modules" aria-hidden="true"></a><span class="number">5</span>First-class modules</h2>
 <p>
 <a id="hevea_manual.kwd212"></a>
 <a id="hevea_manual.kwd213"></a>
@@ -119,7 +119,7 @@ Since OCaml 4.02, this is relaxed in two ways:
 if <a class="syntax" href="#package-type"><span class="c011">package-type</span></a> does not contain nominal type declarations (<em>i.e.</em> types that are created with a proper identity), then this
 expression can be used anywhere, and even if it contains such types
 it can be used inside the body of a generative
-functor, described in section ‍<a href="generativefunctors.html#s%3Agenerative-functors">8.15</a>.
+functor, described in section&nbsp;<a href="generativefunctors.html#s%3Agenerative-functors">8.15</a>.
 It can also be used anywhere in the context of a local module binding
 <span class="c003"><span class="c004">let</span> <span class="c004">module</span></span> <a class="syntax" href="names.html#module-name"><span class="c011">module-name</span></a> <span class="c003"><span class="c004">=</span> <span class="c004">(</span> <span class="c004">val</span></span>  <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a><sub>1</sub> <span class="c005">:</span>  <a class="syntax" href="#package-type"><span class="c011">package-type</span></a> <span class="c003"><span class="c004">)</span>
 <span class="c004">in</span></span>  <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a><sub>2</sub>.</p>
@@ -219,7 +219,7 @@ implementation of a module without using a functor.</p><div class="caml-example 
 
 </div>
 
-<div class="bottom-navigation"><a class="previous" href="locallyabstract.html">« 8.4 Locally abstract types</a><a class="next" href="moduletypeof.html">8.6 Recovering the type of a module »</a></div>
+<div class="bottom-navigation"><a class="previous" href="locallyabstract.html">« Locally abstract types</a><a class="next" href="moduletypeof.html">Recovering the type of a module »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/flambda.html
+++ b/site/releases/4.12/htmlman/flambda.html
@@ -5,34 +5,34 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍19 Optimisation with Flambda</title>
+<title>OCaml - Optimisation with Flambda</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li class="active"><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li class="active"><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec495">Chapter ‍19 Optimisation with Flambda</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍19 Optimisation with Flambda</a></li>
-<li><a href="flambda.html#s%3Aflambda-overview">19.1 Overview</a>
-</li><li><a href="flambda.html#s%3Aflambda-cli">19.2 Command-line flags</a>
-</li><li><a href="flambda.html#s%3Aflambda-inlining">19.3 Inlining</a>
-</li><li><a href="flambda.html#s%3Aflambda-specialisation">19.4 Specialisation</a>
-</li><li><a href="flambda.html#s%3Aflambda-defaults">19.5 Default settings of parameters</a>
-</li><li><a href="flambda.html#s%3Aflambda-manual-control">19.6 Manual control of inlining and specialisation</a>
-</li><li><a href="flambda.html#s%3Aflambda-simplification">19.7 Simplification</a>
-</li><li><a href="flambda.html#s%3Aflambda-other-transfs">19.8 Other code motion transformations</a>
-</li><li><a href="flambda.html#s%3Aflambda-unboxing">19.9 Unboxing transformations</a>
-</li><li><a href="flambda.html#s%3Aflambda-remove-unused">19.10 Removal of unused code and values</a>
-</li><li><a href="flambda.html#s%3Aflambda-other">19.11 Other code transformations</a>
-</li><li><a href="flambda.html#s%3Aflambda-effects">19.12 Treatment of effects</a>
-</li><li><a href="flambda.html#s%3Aflambda-static-modules">19.13 Compilation of statically-allocated modules</a>
-</li><li><a href="flambda.html#s%3Aflambda-inhibition">19.14 Inhibition of optimisation</a>
-</li><li><a href="flambda.html#s%3Aflambda-unsafe">19.15 Use of unsafe operations</a>
-</li><li><a href="flambda.html#s%3Aflambda-glossary">19.16 Glossary</a>
+<h1 class="chapter" id="sec495"><span class="number">Chapter 19</span>Optimisation with Flambda</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Optimisation with Flambda</a></li>
+<li><a href="flambda.html#s%3Aflambda-overview"><span class="number">1</span>Overview</a>
+</li><li><a href="flambda.html#s%3Aflambda-cli"><span class="number">2</span>Command-line flags</a>
+</li><li><a href="flambda.html#s%3Aflambda-inlining"><span class="number">3</span>Inlining</a>
+</li><li><a href="flambda.html#s%3Aflambda-specialisation"><span class="number">4</span>Specialisation</a>
+</li><li><a href="flambda.html#s%3Aflambda-defaults"><span class="number">5</span>Default settings of parameters</a>
+</li><li><a href="flambda.html#s%3Aflambda-manual-control"><span class="number">6</span>Manual control of inlining and specialisation</a>
+</li><li><a href="flambda.html#s%3Aflambda-simplification"><span class="number">7</span>Simplification</a>
+</li><li><a href="flambda.html#s%3Aflambda-other-transfs"><span class="number">8</span>Other code motion transformations</a>
+</li><li><a href="flambda.html#s%3Aflambda-unboxing"><span class="number">9</span>Unboxing transformations</a>
+</li><li><a href="flambda.html#s%3Aflambda-remove-unused"><span class="number">10</span>Removal of unused code and values</a>
+</li><li><a href="flambda.html#s%3Aflambda-other"><span class="number">11</span>Other code transformations</a>
+</li><li><a href="flambda.html#s%3Aflambda-effects"><span class="number">12</span>Treatment of effects</a>
+</li><li><a href="flambda.html#s%3Aflambda-static-modules"><span class="number">13</span>Compilation of statically-allocated modules</a>
+</li><li><a href="flambda.html#s%3Aflambda-inhibition"><span class="number">14</span>Inhibition of optimisation</a>
+</li><li><a href="flambda.html#s%3Aflambda-unsafe"><span class="number">15</span>Use of unsafe operations</a>
+</li><li><a href="flambda.html#s%3Aflambda-glossary"><span class="number">16</span>Glossary</a>
 </li></ul></nav></header>
 
-<h2 class="section" id="s:flambda-overview"><a class="section-anchor" href="#s:flambda-overview" aria-hidden="true"></a>19.1 Overview</h2>
+<h2 class="section" id="s:flambda-overview"><a class="section-anchor" href="#s:flambda-overview" aria-hidden="true"></a><span class="number">1</span>Overview</h2>
 <p><em>Flambda</em> is the term used to describe a series of optimisation passes
 provided by the native code compilers as of OCaml 4.03.</p><p>Flambda aims to make it easier to write idiomatic OCaml code without
 incurring performance penalties.</p><p>To use the Flambda optimisers it is necessary to pass the <span class="c004">-flambda</span>
@@ -56,7 +56,7 @@ behaviour of code using unsafe operations (see section <a href="#s%3Aflambda-uns
 does it take hints for optimisation from any assertions written by the
 user in the code.</p><p>Consult the <em>Glossary</em> at the end of this chapter for definitions of
 technical terms used below.</p>
-<h2 class="section" id="s:flambda-cli"><a class="section-anchor" href="#s:flambda-cli" aria-hidden="true">﻿</a>19.2 Command-line flags</h2>
+<h2 class="section" id="s:flambda-cli"><a class="section-anchor" href="#s:flambda-cli" aria-hidden="true">﻿</a><span class="number">2</span>Command-line flags</h2>
 <p>The Flambda optimisers provide a variety of command-line flags that may
 be used to control their behaviour. Detailed descriptions of each flag
 are given in the referenced sections. Those sections also describe any
@@ -157,7 +157,7 @@ in effect.
 </li><li class="li-itemize">Some of the Flambda flags may be subject to change in future
 releases.
 </li></ul>
-<h3 class="subsection" id="ss:flambda-rounds"><a class="section-anchor" href="#ss:flambda-rounds" aria-hidden="true">﻿</a>19.2.1 Specification of optimisation parameters by round</h3>
+<h3 class="subsection" id="ss:flambda-rounds"><a class="section-anchor" href="#ss:flambda-rounds" aria-hidden="true">﻿</a><span class="number">2.1</span>Specification of optimisation parameters by round</h3>
 <p>Flambda operates in <em>rounds</em>: one round consists of a certain sequence
 of transformations that may then be repeated in order to achieve more
 satisfactory results. The number of rounds can be set manually using the
@@ -176,7 +176,7 @@ values which are to be used only for those rounds.
 other flags, meaning that certain parameters may be overridden without
 having to specify every parameter usually invoked by the given optimisation
 level.</p>
-<h2 class="section" id="s:flambda-inlining"><a class="section-anchor" href="#s:flambda-inlining" aria-hidden="true">﻿</a>19.3 Inlining</h2>
+<h2 class="section" id="s:flambda-inlining"><a class="section-anchor" href="#s:flambda-inlining" aria-hidden="true">﻿</a><span class="number">3</span>Inlining</h2>
 <p><em>Inlining</em> refers to the copying of the code of a function to a
 place where the function is called.
 The code of the function will be surrounded by bindings of its parameters
@@ -231,7 +231,7 @@ known. Similarly,
 it becomes more straightforward to control which variables end up
 in which closures, helping to avoid closure bloat.
 </li></ul>
-<h3 class="subsection" id="ss:flambda-classic"><a class="section-anchor" href="#ss:flambda-classic" aria-hidden="true">﻿</a>19.3.1 Classic inlining heuristic</h3>
+<h3 class="subsection" id="ss:flambda-classic"><a class="section-anchor" href="#ss:flambda-classic" aria-hidden="true">﻿</a><span class="number">3.1</span>Classic inlining heuristic</h3>
 <p>In <span class="c004">-Oclassic</span> mode the behaviour of the Flambda inliner
 mimics previous versions
 of the compiler. (Code may still be subject to further optimisations not
@@ -269,7 +269,7 @@ the inlining decision is made at the <span class="c014">call site</span>; and
 below).
 </li></ul><p>
 The Flambda mode is described in the next section.</p>
-<h3 class="subsection" id="ss:flambda-inlining-overview"><a class="section-anchor" href="#ss:flambda-inlining-overview" aria-hidden="true">﻿</a>19.3.2 Overview of “Flambda” inlining heuristics</h3>
+<h3 class="subsection" id="ss:flambda-inlining-overview"><a class="section-anchor" href="#ss:flambda-inlining-overview" aria-hidden="true">﻿</a><span class="number">3.2</span>Overview of “Flambda” inlining heuristics</h3>
 <p>The Flambda inlining heuristics, used whenever the compiler is configured
 for Flambda and <span class="c004">-Oclassic</span> was not specified, make inlining decisions
 at call sites. This helps in situations where the context is important.
@@ -316,7 +316,7 @@ not unrolled to excess. (Unrolling is only enabled
 if <span class="c004">-O3</span> optimisation level is selected and/or the
 <span class="c004">-inline-max-unroll</span>
 flag is passed with an argument greater than zero.)</p>
-<h3 class="subsection" id="ss:flambda-by-constructs"><a class="section-anchor" href="#ss:flambda-by-constructs" aria-hidden="true">﻿</a>19.3.3 Handling of specific language constructs</h3>
+<h3 class="subsection" id="ss:flambda-by-constructs"><a class="section-anchor" href="#ss:flambda-by-constructs" aria-hidden="true">﻿</a><span class="number">3.3</span>Handling of specific language constructs</h3>
 <h4 class="subsubsection" id="sss:flambda-functors"><a class="section-anchor" href="#sss:flambda-functors" aria-hidden="true">﻿</a>Functors</h4>
 <p>There is nothing particular about functors that inhibits inlining compared
 to normal functions. To the inliner, these both look the same, except
@@ -332,7 +332,7 @@ The presence of the first-class module record that wraps the set of functions
 in the module does not per se inhibit inlining.</p>
 <h4 class="subsubsection" id="sss:flambda-objects"><a class="section-anchor" href="#sss:flambda-objects" aria-hidden="true">﻿</a>Objects</h4>
 <p>Method calls to objects are not at present inlined by Flambda.</p>
-<h3 class="subsection" id="ss:flambda-inlining-reports"><a class="section-anchor" href="#ss:flambda-inlining-reports" aria-hidden="true">﻿</a>19.3.4 Inlining reports</h3>
+<h3 class="subsection" id="ss:flambda-inlining-reports"><a class="section-anchor" href="#ss:flambda-inlining-reports" aria-hidden="true">﻿</a><span class="number">3.4</span>Inlining reports</h3>
 <p>If the <span class="c004">-inlining-report</span> option is provided to the compiler then a file
 will be emitted corresponding to each round of optimisation. For the
 OCaml source file <em>basename</em><span class="c004">.ml</span> the files
@@ -340,7 +340,7 @@ are named <em>basename</em><span class="c004">.</span><em>round</em><span class=
 with <em>round</em> a
 zero-based integer. Inside the files, which are formatted as “org mode”,
 will be found English prose describing the decisions that the inliner took.</p>
-<h3 class="subsection" id="ss:flambda-assessment-inlining"><a class="section-anchor" href="#ss:flambda-assessment-inlining" aria-hidden="true">﻿</a>19.3.5 Assessment of inlining benefit</h3>
+<h3 class="subsection" id="ss:flambda-assessment-inlining"><a class="section-anchor" href="#ss:flambda-assessment-inlining" aria-hidden="true">﻿</a><span class="number">3.5</span>Assessment of inlining benefit</h3>
 <p>Inlining typically
 results in an increase in code size, which if left unchecked, may not only
 lead to grossly large executables and excessive compilation times but also
@@ -393,7 +393,7 @@ inlined.</p><p>Applications of functors at toplevel will be given
 an additional benefit (which may be controlled by the
 <span class="c004">-inline-lifting-benefit</span> flag) to bias inlining in such situations
 towards keeping the inlined version.</p>
-<h3 class="subsection" id="ss:flambda-speculation"><a class="section-anchor" href="#ss:flambda-speculation" aria-hidden="true">﻿</a>19.3.6 Control of speculation</h3>
+<h3 class="subsection" id="ss:flambda-speculation"><a class="section-anchor" href="#ss:flambda-speculation" aria-hidden="true">﻿</a><span class="number">3.6</span>Control of speculation</h3>
 <p>As described above, there are three parameters that restrict the search
 for inlining opportunities during speculation:
 </p><ul class="itemize"><li class="li-itemize">
@@ -430,7 +430,7 @@ group of functions. Each time an inlining of such a call is performed
 the depth is incremented by one when examining the resulting body. If the
 depth reaches the limit set by <span class="c004">-inline-max-unroll</span> then speculation
 stops.</p>
-<h2 class="section" id="s:flambda-specialisation"><a class="section-anchor" href="#s:flambda-specialisation" aria-hidden="true">﻿</a>19.4 Specialisation</h2>
+<h2 class="section" id="s:flambda-specialisation"><a class="section-anchor" href="#s:flambda-specialisation" aria-hidden="true">﻿</a><span class="number">4</span>Specialisation</h2>
 <p>The inliner may discover a call site to a recursive function where
 something is known about the arguments: for example, they may be equal to
 some other variables currently in scope. In this situation it may be
@@ -526,14 +526,14 @@ detect invariance in cases such as the following.
     f h;
     iter_swap f g t
 </pre>
-<h3 class="subsection" id="ss:flambda-assessment-specialisation"><a class="section-anchor" href="#ss:flambda-assessment-specialisation" aria-hidden="true">﻿</a>19.4.1 Assessment of specialisation benefit</h3>
+<h3 class="subsection" id="ss:flambda-assessment-specialisation"><a class="section-anchor" href="#ss:flambda-assessment-specialisation" aria-hidden="true">﻿</a><span class="number">4.1</span>Assessment of specialisation benefit</h3>
 <p>The benefit of specialisation is assessed in a similar way as for inlining.
 Specialised argument information may mean that the body of the function
 being specialised can be simplified: the removed operations are accumulated
 into a benefit. This, together with the size of the duplicated (specialised)
 function declaration, is then assessed against the size of the call to the
 original function.</p>
-<h2 class="section" id="s:flambda-defaults"><a class="section-anchor" href="#s:flambda-defaults" aria-hidden="true">﻿</a>19.5 Default settings of parameters</h2>
+<h2 class="section" id="s:flambda-defaults"><a class="section-anchor" href="#s:flambda-defaults" aria-hidden="true">﻿</a><span class="number">5</span>Default settings of parameters</h2>
 <p>The default settings (when not using <span class="c004">-Oclassic</span>) are for one
 round of optimisation using the following parameters.
 </p><div class="tableau">
@@ -552,7 +552,7 @@ round of optimisation using the following parameters.
 <tr><td class="c017"><span class="c004">-inline-max-unroll</span></td><td class="c017">0 </td></tr>
 <tr><td class="c017"><span class="c004">-unbox-closures-factor</span></td><td class="c017">10 </td></tr>
 </tbody></table></div></div>
-<h3 class="subsection" id="ss:flambda-o2"><a class="section-anchor" href="#ss:flambda-o2" aria-hidden="true">﻿</a>19.5.1 Settings at -O2 optimisation level</h3>
+<h3 class="subsection" id="ss:flambda-o2"><a class="section-anchor" href="#ss:flambda-o2" aria-hidden="true">﻿</a><span class="number">5.1</span>Settings at -O2 optimisation level</h3>
 <p>When <span class="c004">-O2</span> is specified two rounds of optimisation are performed.
 The first round uses the default parameters (see above). The second uses
 the following parameters.</p><div class="tableau">
@@ -571,7 +571,7 @@ the following parameters.</p><div class="tableau">
 <tr><td class="c017"><span class="c004">-inline-max-unroll</span></td><td class="c017">Same as default </td></tr>
 <tr><td class="c017"><span class="c004">-unbox-closures-factor</span></td><td class="c017">Same as default </td></tr>
 </tbody></table></div></div>
-<h3 class="subsection" id="ss:flambda-o3"><a class="section-anchor" href="#ss:flambda-o3" aria-hidden="true">﻿</a>19.5.2 Settings at -O3 optimisation level</h3>
+<h3 class="subsection" id="ss:flambda-o3"><a class="section-anchor" href="#ss:flambda-o3" aria-hidden="true">﻿</a><span class="number">5.2</span>Settings at -O3 optimisation level</h3>
 <p>When <span class="c004">-O3</span> is specified three rounds of optimisation are performed.
 The first two rounds are as for <span class="c004">-O2</span>. The third round uses
 the following parameters.</p><div class="tableau">
@@ -590,7 +590,7 @@ the following parameters.</p><div class="tableau">
 <tr><td class="c017"><span class="c004">-inline-max-unroll</span></td><td class="c017">1 </td></tr>
 <tr><td class="c017"><span class="c004">-unbox-closures-factor</span></td><td class="c017">Same as default </td></tr>
 </tbody></table></div></div>
-<h2 class="section" id="s:flambda-manual-control"><a class="section-anchor" href="#s:flambda-manual-control" aria-hidden="true">﻿</a>19.6 Manual control of inlining and specialisation</h2>
+<h2 class="section" id="s:flambda-manual-control"><a class="section-anchor" href="#s:flambda-manual-control" aria-hidden="true">﻿</a><span class="number">6</span>Manual control of inlining and specialisation</h2>
 <p>Should the inliner prove recalcitrant and refuse to inline a particular
 function, or if the observed inlining decisions are not to the programmer’s
 satisfaction for some other reason, inlining behaviour can be dictated by the
@@ -661,7 +661,7 @@ end [@@inline never]
 
 module X = F [@inlined] (struct type t = int end)
 </pre>
-<h2 class="section" id="s:flambda-simplification"><a class="section-anchor" href="#s:flambda-simplification" aria-hidden="true">﻿</a>19.7 Simplification</h2>
+<h2 class="section" id="s:flambda-simplification"><a class="section-anchor" href="#s:flambda-simplification" aria-hidden="true">﻿</a><span class="number">7</span>Simplification</h2>
 <p>Simplification, which is run in conjunction with inlining,
 propagates information (known as <em>approximations</em>) about which
 variables hold what values at runtime. Certain relationships between
@@ -681,8 +681,8 @@ the transformation of such call sites into direct call sites, which makes
 them eligible for an inlining transformation.</p><p>Note that no information is propagated about the contents of strings,
 even in <span class="c004">safe-string</span> mode, because it cannot yet be guaranteed
 that they are immutable throughout a given program.</p>
-<h2 class="section" id="s:flambda-other-transfs"><a class="section-anchor" href="#s:flambda-other-transfs" aria-hidden="true">﻿</a>19.8 Other code motion transformations</h2>
-<h3 class="subsection" id="ss:flambda-lift-const"><a class="section-anchor" href="#ss:flambda-lift-const" aria-hidden="true">﻿</a>19.8.1 Lifting of constants</h3>
+<h2 class="section" id="s:flambda-other-transfs"><a class="section-anchor" href="#s:flambda-other-transfs" aria-hidden="true">﻿</a><span class="number">8</span>Other code motion transformations</h2>
+<h3 class="subsection" id="ss:flambda-lift-const"><a class="section-anchor" href="#ss:flambda-lift-const" aria-hidden="true">﻿</a><span class="number">8.1</span>Lifting of constants</h3>
 <p>Expressions found to be constant will be lifted to symbol
 bindings—that is to say, they will be statically allocated in the
 object file—when
@@ -715,7 +715,7 @@ creation of the array consists of bulk copying the initialising array
 into a fresh value on the OCaml heap.
 </li></ul>
 </li></ul>
-<h3 class="subsection" id="ss:flambda-lift-toplevel-let"><a class="section-anchor" href="#ss:flambda-lift-toplevel-let" aria-hidden="true">﻿</a>19.8.2 Lifting of toplevel let bindings</h3>
+<h3 class="subsection" id="ss:flambda-lift-toplevel-let"><a class="section-anchor" href="#ss:flambda-lift-toplevel-let" aria-hidden="true">﻿</a><span class="number">8.2</span>Lifting of toplevel let bindings</h3>
 <p>Toplevel <span class="c004">let</span>-expressions may be lifted to symbol bindings to ensure
 that the corresponding bound variables are not captured by closures. If the
 defining expression of a given binding is found to be constant, it is bound
@@ -736,12 +736,12 @@ with the application point of that function (perhaps at toplevel)—or
 indeed the function declaration itself—marked
 as to never be inlined. This technique prevents lifting of the definition
 of the value in question (assuming of course that it is not constant).</p>
-<h2 class="section" id="s:flambda-unboxing"><a class="section-anchor" href="#s:flambda-unboxing" aria-hidden="true">﻿</a>19.9 Unboxing transformations</h2>
+<h2 class="section" id="s:flambda-unboxing"><a class="section-anchor" href="#s:flambda-unboxing" aria-hidden="true">﻿</a><span class="number">9</span>Unboxing transformations</h2>
 <p>The transformations in this section relate to the splitting apart of
 <em>boxed</em> (that is to say, non-immediate) values. They are largely
 intended to reduce allocation, which tends to result in a runtime
 performance profile with lower variance and smaller tails.</p>
-<h3 class="subsection" id="ss:flambda-unbox-fvs"><a class="section-anchor" href="#ss:flambda-unbox-fvs" aria-hidden="true">﻿</a>19.9.1 Unboxing of closure variables</h3>
+<h3 class="subsection" id="ss:flambda-unbox-fvs"><a class="section-anchor" href="#ss:flambda-unbox-fvs" aria-hidden="true">﻿</a><span class="number">9.1</span>Unboxing of closure variables</h3>
 <p>This transformation is enabled unless
 <span class="c004">-no-unbox-free-vars-of-closures</span> is provided.</p><p>Variables that appear in closure environments may themselves be boxed
 values. As such, they may be split into further closure variables, each
@@ -775,7 +775,7 @@ the closure returned from the function <span class="c004">f</span> contains a va
     x0 + x1 + y
 </pre><p>The allocation of the pair has been eliminated.</p><p>This transformation does not operate if it would cause the closure to
 contain more than twice as many closure variables as it did beforehand.</p>
-<h3 class="subsection" id="ss:flambda-unbox-spec-args"><a class="section-anchor" href="#ss:flambda-unbox-spec-args" aria-hidden="true">﻿</a>19.9.2 Unboxing of specialised arguments</h3>
+<h3 class="subsection" id="ss:flambda-unbox-spec-args"><a class="section-anchor" href="#ss:flambda-unbox-spec-args" aria-hidden="true">﻿</a><span class="number">9.2</span>Unboxing of specialised arguments</h3>
 <p>This transformation is enabled unless
 <span class="c004">-no-unbox-specialised-args</span> is provided.</p><p>It may become the case during compilation that one or more invariant arguments
 to a function become specialised to a particular value. When such values are
@@ -836,7 +836,7 @@ arguments; in this case there may be indirect calls and these will incur
 a small penalty owing to having to bounce through the wrapper. The technique
 of <em>direct call surrogates</em> used for <span class="c004">-unbox-closures</span> is not
 used by the transformation to unbox specialised arguments.)</p>
-<h3 class="subsection" id="ss:flambda-unbox-closures"><a class="section-anchor" href="#ss:flambda-unbox-closures" aria-hidden="true">﻿</a>19.9.3 Unboxing of closures</h3>
+<h3 class="subsection" id="ss:flambda-unbox-closures"><a class="section-anchor" href="#ss:flambda-unbox-closures" aria-hidden="true">﻿</a><span class="number">9.3</span>Unboxing of closures</h3>
 <p>This transformation is <em>not</em> enabled by default. It may be enabled
 using the <span class="c004">-unbox-closures</span> flag.</p><p>The transformation replaces closure variables by specialised arguments.
 The aim is to cause more closures to become closed. It is particularly
@@ -909,17 +909,17 @@ too large to inline.
 passes the free variables via function arguments in
 order to eliminate all closure allocation in this example (aside from any
 that might be performed inside <span class="c004">printf</span>).</p>
-<h2 class="section" id="s:flambda-remove-unused"><a class="section-anchor" href="#s:flambda-remove-unused" aria-hidden="true">﻿</a>19.10 Removal of unused code and values</h2>
-<h3 class="subsection" id="ss:flambda-redundant-let"><a class="section-anchor" href="#ss:flambda-redundant-let" aria-hidden="true">﻿</a>19.10.1 Removal of redundant let expressions</h3>
+<h2 class="section" id="s:flambda-remove-unused"><a class="section-anchor" href="#s:flambda-remove-unused" aria-hidden="true">﻿</a><span class="number">10</span>Removal of unused code and values</h2>
+<h3 class="subsection" id="ss:flambda-redundant-let"><a class="section-anchor" href="#ss:flambda-redundant-let" aria-hidden="true">﻿</a><span class="number">10.1</span>Removal of redundant let expressions</h3>
 <p>The simplification pass removes unused <span class="c004">let</span> bindings so long as
 their corresponding defining expressions have “no effects”. See
 the section “Treatment of effects” below for the precise definition of
 this term.</p>
-<h3 class="subsection" id="ss:flambda-redundant"><a class="section-anchor" href="#ss:flambda-redundant" aria-hidden="true">﻿</a>19.10.2 Removal of redundant program constructs</h3>
+<h3 class="subsection" id="ss:flambda-redundant"><a class="section-anchor" href="#ss:flambda-redundant" aria-hidden="true">﻿</a><span class="number">10.2</span>Removal of redundant program constructs</h3>
 <p>This transformation is analogous to the removal of <span class="c004">let</span>-expressions
 whose defining expressions have no effects. It operates instead on symbol
 bindings, removing those that have no effects.</p>
-<h3 class="subsection" id="ss:flambda-remove-unused-args"><a class="section-anchor" href="#ss:flambda-remove-unused-args" aria-hidden="true">﻿</a>19.10.3 Removal of unused arguments</h3>
+<h3 class="subsection" id="ss:flambda-remove-unused-args"><a class="section-anchor" href="#ss:flambda-remove-unused-args" aria-hidden="true">﻿</a><span class="number">10.3</span>Removal of unused arguments</h3>
 <p>This transformation is only enabled by default for specialised arguments.
 It may be enabled for all arguments using the <span class="c004">-remove-unused-arguments</span>
 flag.</p><p>The pass analyses functions to determine which arguments are unused.
@@ -931,26 +931,26 @@ function is usually indirectly called, since such calls will now bounce
 through the wrapper. (The technique of <em>direct call surrogates</em> used
 to reduce this penalty during unboxing of closure variables (see above)
 does not yet apply to the pass that removes unused arguments.)</p>
-<h3 class="subsection" id="ss:flambda-removal-closure-vars"><a class="section-anchor" href="#ss:flambda-removal-closure-vars" aria-hidden="true">﻿</a>19.10.4 Removal of unused closure variables</h3>
+<h3 class="subsection" id="ss:flambda-removal-closure-vars"><a class="section-anchor" href="#ss:flambda-removal-closure-vars" aria-hidden="true">﻿</a><span class="number">10.4</span>Removal of unused closure variables</h3>
 <p>This transformation performs an analysis across
 the whole compilation unit to determine whether there exist closure variables
 that are never used. Such closure variables are then eliminated. (Note that
 this has to be a whole-unit analysis because a projection of a closure
 variable from some particular closure may have propagated to an arbitrary
 location within the code due to inlining.)</p>
-<h2 class="section" id="s:flambda-other"><a class="section-anchor" href="#s:flambda-other" aria-hidden="true">﻿</a>19.11 Other code transformations</h2>
-<h3 class="subsection" id="ss:flambda-non-escaping-refs"><a class="section-anchor" href="#ss:flambda-non-escaping-refs" aria-hidden="true">﻿</a>19.11.1 Transformation of non-escaping references into mutable variables</h3>
+<h2 class="section" id="s:flambda-other"><a class="section-anchor" href="#s:flambda-other" aria-hidden="true">﻿</a><span class="number">11</span>Other code transformations</h2>
+<h3 class="subsection" id="ss:flambda-non-escaping-refs"><a class="section-anchor" href="#ss:flambda-non-escaping-refs" aria-hidden="true">﻿</a><span class="number">11.1</span>Transformation of non-escaping references into mutable variables</h3>
 <p>Flambda performs a simple analysis analogous to that performed elsewhere
 in the compiler that can transform <span class="c004">ref</span>s into mutable variables
 that may then be held in registers (or on the stack as appropriate) rather
 than being allocated on the OCaml heap. This only happens so long as the
 reference concerned can be shown to not escape from its defining scope.</p>
-<h3 class="subsection" id="ss:flambda-subst-closure-vars"><a class="section-anchor" href="#ss:flambda-subst-closure-vars" aria-hidden="true">﻿</a>19.11.2 Substitution of closure variables for specialised arguments</h3>
+<h3 class="subsection" id="ss:flambda-subst-closure-vars"><a class="section-anchor" href="#ss:flambda-subst-closure-vars" aria-hidden="true">﻿</a><span class="number">11.2</span>Substitution of closure variables for specialised arguments</h3>
 <p>This transformation discovers closure variables that are known to be
 equal to specialised arguments. Such closure variables are replaced by
 the specialised arguments; the closure variables may then be removed by
 the “removal of unused closure variables” pass (see below).</p>
-<h2 class="section" id="s:flambda-effects"><a class="section-anchor" href="#s:flambda-effects" aria-hidden="true">﻿</a>19.12 Treatment of effects</h2>
+<h2 class="section" id="s:flambda-effects"><a class="section-anchor" href="#s:flambda-effects" aria-hidden="true">﻿</a><span class="number">12</span>Treatment of effects</h2>
 <p>The Flambda optimisers classify expressions in order to determine whether
 an expression:
 </p><ul class="itemize"><li class="li-itemize">
@@ -996,7 +996,7 @@ read from any mutable storage or call arbitrary external functions.
 </dd></dl><p>It is assumed in the compiler that, subject to data dependencies,
 expressions with neither effects nor coeffects may be reordered with
 respect to other expressions.</p>
-<h2 class="section" id="s:flambda-static-modules"><a class="section-anchor" href="#s:flambda-static-modules" aria-hidden="true">﻿</a>19.13 Compilation of statically-allocated modules</h2>
+<h2 class="section" id="s:flambda-static-modules"><a class="section-anchor" href="#s:flambda-static-modules" aria-hidden="true">﻿</a><span class="number">13</span>Compilation of statically-allocated modules</h2>
 <p>Compilation of modules that are able to be statically allocated (for example,
 the module corresponding to an entire compilation unit, as opposed to a first
 class module dependent on values computed at runtime) initially follows the
@@ -1004,14 +1004,14 @@ strategy used for bytecode. A sequence of <span class="c004">let</span>-bindings
 interspersed with arbitrary effects, surrounds a record creation that becomes
 the module block. The Flambda-specific transformation follows: these bindings
 are lifted to toplevel symbols, as described above.</p>
-<h2 class="section" id="s:flambda-inhibition"><a class="section-anchor" href="#s:flambda-inhibition" aria-hidden="true">﻿</a>19.14 Inhibition of optimisation</h2>
+<h2 class="section" id="s:flambda-inhibition"><a class="section-anchor" href="#s:flambda-inhibition" aria-hidden="true">﻿</a><span class="number">14</span>Inhibition of optimisation</h2>
 <p>Especially when writing benchmarking suites that run non-side-effecting
 algorithms in loops, it may be found that the optimiser entirely
 elides the code being benchmarked. This behaviour can be prevented by
 using the <span class="c004">Sys.opaque_identity</span> function (which indeed behaves as a
 normal OCaml function and does not possess any “magic” semantics). The
 documentation of the <span class="c004">Sys</span> module should be consulted for further details.</p>
-<h2 class="section" id="s:flambda-unsafe"><a class="section-anchor" href="#s:flambda-unsafe" aria-hidden="true">﻿</a>19.15 Use of unsafe operations</h2>
+<h2 class="section" id="s:flambda-unsafe"><a class="section-anchor" href="#s:flambda-unsafe" aria-hidden="true">﻿</a><span class="number">15</span>Use of unsafe operations</h2>
 <p>The behaviour of the Flambda simplification pass means that certain unsafe
 operations, which may without Flambda or when using previous versions of
 the compiler be safe, must not be used. This specifically refers to
@@ -1050,7 +1050,7 @@ thought previously to be correct. Take care, for example, not
 to add type annotations that claim some mutable value is always immediate
 if it might be possible for an unsafe operation to update it to a boxed
 value.</p>
-<h2 class="section" id="s:flambda-glossary"><a class="section-anchor" href="#s:flambda-glossary" aria-hidden="true">﻿</a>19.16 Glossary</h2>
+<h2 class="section" id="s:flambda-glossary"><a class="section-anchor" href="#s:flambda-glossary" aria-hidden="true">﻿</a><span class="number">16</span>Glossary</h2>
 <p>The following terminology is used in this chapter of the manual.</p><dl class="description"><dt class="dt-description">
 <span class="c014">Call site</span></dt><dd class="dd-description"> See <em>direct call site</em> and <em>indirect call site</em> below.
 </dd><dt class="dt-description"><span class="c014">Closed function</span></dt><dd class="dd-description"> A function whose body has no free variables
@@ -1101,7 +1101,7 @@ enclosed within any function declaration.
 <span class="c004">let</span> expression, pattern-matching construction, or similar.
 </dd></dl>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="intfc.html">« Chapter ‍18 Interfacing C with OCaml</a><a class="next" href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz »</a></div>
+<div class="bottom-navigation"><a class="previous" href="intfc.html">« Interfacing C with OCaml</a><a class="next" href="afl-fuzz.html">Fuzzing with afl-fuzz »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/foreword.html
+++ b/site/releases/4.12/htmlman/foreword.html
@@ -11,7 +11,7 @@
 <body><div class="index content manual"><div id="sidebar-button"><span>☰</span></div><ul id="part-menu"></ul>
 
 
-<div class="maintitle"><h1><span>The OCaml system</span> &nbsp;release 4.12 </h1><h3>February ‍24, 2021</h3></div><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Select another version</a></div><ul><li class="top"><a href="#">The OCaml Manual</a></li>
+<div class="maintitle"><h1><span>The OCaml system</span> &nbsp;release 4.12 </h1><h3>April&nbsp;7, 2021</h3></div><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Select another version</a></div><ul><li class="top"><a href="#">The OCaml Manual</a></li>
 <li><a href="manual001.html#start-section">Contents</a>
 </li><li><a href="foreword.html#start-section">Foreword</a>
 </li><li><a href="manual067.html#start-section">Index of keywords</a></li><li><a href="../api/index.html">OCaml API</a></li><li><a href="../api/compilerlibref/index.html">OCaml Compiler API</a></li></ul></nav></header><a id="start-section"></a><section id="section">
@@ -28,13 +28,13 @@
 <p>This manual documents the release 4.12 of the OCaml
 system. It is organized as follows.
 </p><ul class="itemize"><li class="li-itemize">
-Part ‍<a href="index.html#p%3Atutorials">I</a>, “An introduction to OCaml”,
+Part&nbsp;<a href="index.html#p%3Atutorials">I</a>, “An introduction to OCaml”,
 gives an overview of the language.
-</li><li class="li-itemize">Part ‍<a href="index.html#p%3Arefman">II</a>, “The OCaml language”, is the
+</li><li class="li-itemize">Part&nbsp;<a href="index.html#p%3Arefman">II</a>, “The OCaml language”, is the
 reference description of the language.
-</li><li class="li-itemize">Part ‍<a href="index.html#p%3Acommands">III</a>, “The OCaml tools”, documents
+</li><li class="li-itemize">Part&nbsp;<a href="index.html#p%3Acommands">III</a>, “The OCaml tools”, documents
 the compilers, toplevel system, and programming utilities.
-</li><li class="li-itemize">Part ‍<a href="index.html#p%3Alibrary">IV</a>, “The OCaml library”, describes the
+</li><li class="li-itemize">Part&nbsp;<a href="index.html#p%3Alibrary">IV</a>, “The OCaml library”, describes the
 modules provided in the standard library.
 
 </li></ul><h2 class="section" id="conventions"><a class="section-anchor" href="#conventions" aria-hidden="true"></a>Conventions</h2>
@@ -66,7 +66,7 @@ This site contains a lot of additional information on OCaml.
 
 </p>
 
-<div class="bottom-navigation"><a class="previous" href="manual001.html">« Contents</a><a class="next" href="coreexamples.html">Chapter ‍1 The core language »</a></div>
+<div class="bottom-navigation"><a class="previous" href="manual001.html">« Contents</a><a class="next" href="coreexamples.html">The core language »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/gadts.html
+++ b/site/releases/4.12/htmlman/gadts.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:gadts"><a class="section-anchor" href="#s:gadts" aria-hidden="true"></a>8.10 Generalized algebraic datatypes</h2>
+<h2 class="section" id="s:gadts"><a class="section-anchor" href="#s:gadts" aria-hidden="true"></a><span class="number">10</span>Generalized algebraic datatypes</h2>
 <p> <a id="hevea_manual.kwd225"></a>
 <a id="hevea_manual.kwd226"></a>
 </p><p>(Introduced in OCaml 4.00)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -147,7 +147,7 @@ function, and thus escapes its scope. In the above example, this happens
 in the branch <span class="c004">App(f,x)</span> when <span class="c004">eval</span> is called with <span class="c004">f</span> as an argument.
 In this branch, the type of <span class="c004">f</span> is <span class="c004">($App_ 'b-&gt; a)</span>. The prefix <span class="c004">$</span> in
 <span class="c004">$App_ 'b</span> denotes an existential type named by the compiler
-(see ‍<a href="#p%3Aexistential-names">8.10</a>). Since the type of <span class="c004">eval</span> is
+(see&nbsp;<a href="#p%3Aexistential-names">8.10</a>). Since the type of <span class="c004">eval</span> is
 <span class="c004">'a term -&gt; 'a</span>, the call <span class="c004">eval f</span> makes the existential type <span class="c004">$App_'b</span>
 flow to the type variable <span class="c004">'a</span> and escape its scope. This triggers the
 above error.</p>
@@ -439,7 +439,7 @@ defined by the compiler itself, such as <span class="c004">int</span> or <span c
 abstract types defined by the local module, are non-instantiable, and
 as such cause a type error rather than introduce an equation.</p>
 
-<div class="bottom-navigation"><a class="previous" href="overridingopen.html">« 8.9 Overriding in open statements</a><a class="next" href="bigarray.html">8.11 Syntax for Bigarray access »</a></div>
+<div class="bottom-navigation"><a class="previous" href="overridingopen.html">« Overriding in open statements</a><a class="next" href="bigarray.html">Syntax for Bigarray access »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/generalizedopens.html
+++ b/site/releases/4.12/htmlman/generalizedopens.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:generalized-open"><a class="section-anchor" href="#s:generalized-open" aria-hidden="true"></a>8.22 Generalized open statements</h2>
+<h2 class="section" id="s:generalized-open"><a class="section-anchor" href="#s:generalized-open" aria-hidden="true"></a><span class="number">22</span>Generalized open statements</h2>
 <p>(Introduced in 4.08)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="modules.html#definition"><span class="c011">definition</span></a></td><td class="c016">::=</td><td class="c018">
 ...
@@ -211,7 +211,7 @@ can be used instead.</p><p>Beware that this extension is not available inside cl
   ...
 </pre>
 
-<div class="bottom-navigation"><a class="previous" href="alerts.html">« 8.21 Alerts</a><a class="next" href="bindingops.html">8.23 Binding operators »</a></div>
+<div class="bottom-navigation"><a class="previous" href="alerts.html">« Alerts</a><a class="next" href="bindingops.html">Binding operators »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/generativefunctors.html
+++ b/site/releases/4.12/htmlman/generativefunctors.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:generative-functors"><a class="section-anchor" href="#s:generative-functors" aria-hidden="true"></a>8.15 Generative functors</h2>
+<h2 class="section" id="s:generative-functors"><a class="section-anchor" href="#s:generative-functors" aria-hidden="true"></a><span class="number">15</span>Generative functors</h2>
 <p>(Introduced in OCaml 4.02)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="modules.html#module-expr"><span class="c011">module-expr</span></a></td><td class="c016">::=</td><td class="c018">
 ...
@@ -86,7 +86,7 @@ latter case, applying twice to the same module would return identical
 types).</p><p>As a side-effect of this generativity, one is allowed to unpack
 first-class modules in the body of generative functors.</p>
 
-<div class="bottom-navigation"><a class="previous" href="extensiblevariants.html">« 8.14 Extensible variant types</a><a class="next" href="extensionsyntax.html">8.16 Extension-only syntax »</a></div>
+<div class="bottom-navigation"><a class="previous" href="extensiblevariants.html">« Extensible variant types</a><a class="next" href="extensionsyntax.html">Extension-only syntax »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/index.html
+++ b/site/releases/4.12/htmlman/index.html
@@ -11,8 +11,9 @@
 <body><div class="index content manual"><div id="sidebar-button"><span>☰</span></div><ul id="part-menu"></ul>
 
 
-<div class="maintitle"><h1><span>The OCaml system</span> &nbsp;release 4.12 </h1><h3>February ‍24, 2021</h3></div><blockquote class="quote">
-<svg height="0px" width="0px"><rect class="rule-rect" height="100%" width="100%"></rect></svg>
+<div class="maintitle"><h1><span>The OCaml system</span> &nbsp;release 4.12 </h1><h3>April&nbsp;7, 2021</h3></div><div class="maintitle">
+<br>
+
 This manual is also available in
 <a href="https://ocaml.org/releases/4.12/ocaml-4.12-refman.pdf">PDF</a>,
 <a href="https://ocaml.org/releases/4.12/ocaml-4.12-refman.txt">plain text</a>,
@@ -20,76 +21,70 @@ as a
 <a href="https://ocaml.org/releases/4.12/ocaml-4.12-refman-html.tar.gz">bundle of HTML files</a>,
 and as a
 <a href="https://ocaml.org/releases/4.12/ocaml-4.12-refman.info.tar.gz">bundle of Emacs Info files</a>.
-<svg height="0px" width="0px"><rect class="rule-rect" height="100%" width="100%"></rect></svg>
-</blockquote><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Select another version</a></div><ul><li class="top"><a href="#">The OCaml Manual</a></li>
+</div><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Select another version</a></div><ul><li class="top"><a href="#">The OCaml Manual</a></li>
 <li><a href="manual001.html">Contents</a>
 </li><li><a href="foreword.html">Foreword</a>
 </li><li><a href="manual067.html">Index of keywords</a></li><li><a href="../api/index.html">OCaml API</a></li><li><a href="../api/compilerlibref/index.html">OCaml Compiler API</a></li></ul></nav></header><ul class="ul-content">
 <li><a href="manual001.html">Contents</a>
 </li><li><a href="foreword.html">Foreword</a>
 </li></ul>
-<table class="center"><tbody><tr><td><h1 class="part" id="sec6">Part ‍I<br>
-An introduction to OCaml</h1></td></tr>
+<table class="center"><tbody><tr><td><h1 class="part" id="sec6"><span class="number">I.</span>An introduction to OCaml</h1></td></tr>
 </tbody></table>
 <p>
 <a id="p:tutorials"></a>
 </p>
 <ul>
-<li><a href="coreexamples.html">Chapter ‍1 The core language</a>
-</li><li><a href="moduleexamples.html">Chapter ‍2 The module system</a>
-</li><li><a href="objectexamples.html">Chapter ‍3 Objects in OCaml</a>
-</li><li><a href="lablexamples.html">Chapter ‍4 Labels and variants</a>
-</li><li><a href="polymorphism.html">Chapter ‍5 Polymorphism and its limitations</a>
-</li><li><a href="advexamples.html">Chapter ‍6 Advanced examples with classes and modules</a>
+<li><a href="coreexamples.html"><span class="number">1.</span>The core language</a>
+</li><li><a href="moduleexamples.html"><span class="number">2.</span>The module system</a>
+</li><li><a href="objectexamples.html"><span class="number">3.</span>Objects in OCaml</a>
+</li><li><a href="lablexamples.html"><span class="number">4.</span>Labels and variants</a>
+</li><li><a href="polymorphism.html"><span class="number">5.</span>Polymorphism and its limitations</a>
+</li><li><a href="advexamples.html"><span class="number">6.</span>Advanced examples with classes and modules</a>
 </li></ul>
-<table class="center"><tbody><tr><td><h1 class="part" id="sec72">Part ‍II<br>
-The OCaml language</h1></td></tr>
+<table class="center"><tbody><tr><td><h1 class="part" id="sec72"><span class="number">II.</span>The OCaml language</h1></td></tr>
 </tbody></table>
 <p>
 <a id="p:refman"></a>
 </p>
 <ul>
-<li><a href="language.html">Chapter ‍7 The OCaml language</a>
-</li><li><a href="extn.html">Chapter ‍8 Language extensions</a>
+<li><a href="language.html"><span class="number">7.</span>The OCaml language</a>
+</li><li><a href="extn.html"><span class="number">8.</span>Language extensions</a>
 </li></ul>
-<table class="center"><tbody><tr><td><h1 class="part" id="sec286">Part ‍III<br>
-The OCaml tools</h1></td></tr>
+<table class="center"><tbody><tr><td><h1 class="part" id="sec286"><span class="number">III.</span>The OCaml tools</h1></td></tr>
 </tbody></table>
 <p>
 <a id="p:commands"></a></p>
 <ul>
-<li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a>
-</li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a>
-</li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a>
-</li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a>
-</li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a>
-</li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a>
-</li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a>
-</li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a>
-</li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a>
-</li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a>
-</li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a>
-</li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a>
-</li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a>
+<li><a href="comp.html"><span class="number">9.</span>Batch compilation (ocamlc)</a>
+</li><li><a href="toplevel.html"><span class="number">10.</span>The toplevel system or REPL (ocaml)</a>
+</li><li><a href="runtime.html"><span class="number">11.</span>The runtime system (ocamlrun)</a>
+</li><li><a href="native.html"><span class="number">12.</span>Native-code compilation (ocamlopt)</a>
+</li><li><a href="lexyacc.html"><span class="number">13.</span>Lexer and parser generators (ocamllex, ocamlyacc)</a>
+</li><li><a href="depend.html"><span class="number">14.</span>Dependency generator (ocamldep)</a>
+</li><li><a href="ocamldoc.html"><span class="number">15.</span>The documentation generator (ocamldoc)</a>
+</li><li><a href="debugger.html"><span class="number">16.</span>The debugger (ocamldebug)</a>
+</li><li><a href="profil.html"><span class="number">17.</span>Profiling (ocamlprof)</a>
+</li><li><a href="intfc.html"><span class="number">18.</span>Interfacing C with OCaml</a>
+</li><li><a href="flambda.html"><span class="number">19.</span>Optimisation with Flambda</a>
+</li><li><a href="afl-fuzz.html"><span class="number">20.</span>Fuzzing with afl-fuzz</a>
+</li><li><a href="instrumented-runtime.html"><span class="number">21.</span>Runtime tracing with the instrumented runtime</a>
 </li></ul>
-<table class="center"><tbody><tr><td><h1 class="part" id="sec562">Part ‍IV<br>
-The OCaml library</h1></td></tr>
+<table class="center"><tbody><tr><td><h1 class="part" id="sec562"><span class="number">IV.</span>The OCaml library</h1></td></tr>
 </tbody></table>
 <p>
 <a id="p:library"></a>
 </p>
 <ul>
-<li><a href="core.html">Chapter ‍22 The core library</a>
-</li><li><a href="stdlib.html">Chapter ‍23 The standard library</a>
-</li><li><a href="parsing.html">Chapter ‍24 The compiler front-end</a>
-</li><li><a href="libunix.html">Chapter ‍25 The unix library: Unix system calls</a>
-</li><li><a href="libstr.html">Chapter ‍26 The str library: regular expressions and string processing</a>
-</li><li><a href="libthreads.html">Chapter ‍27 The threads library</a>
-</li><li><a href="libdynlink.html">Chapter ‍28 The dynlink library: dynamic loading and linking of object files</a>
-</li><li><a href="old.html">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a>
+<li><a href="core.html"><span class="number">22.</span>The core library</a>
+</li><li><a href="stdlib.html"><span class="number">23.</span>The standard library</a>
+</li><li><a href="parsing.html"><span class="number">24.</span>The compiler front-end</a>
+</li><li><a href="libunix.html"><span class="number">25.</span>The unix library: Unix system calls</a>
+</li><li><a href="libstr.html"><span class="number">26.</span>The str library: regular expressions and string processing</a>
+</li><li><a href="libthreads.html"><span class="number">27.</span>The threads library</a>
+</li><li><a href="libdynlink.html"><span class="number">28.</span>The dynlink library: dynamic loading and linking of object files</a>
+</li><li><a href="old.html"><span class="number">29.</span>Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a>
 </li></ul>
-<table class="center"><tbody><tr><td><h1 class="part" id="sec579">Part ‍V<br>
-Indexes</h1></td></tr>
+<table class="center"><tbody><tr><td><h1 class="part" id="sec579"><span class="number">V.</span>Indexes</h1></td></tr>
 </tbody></table>
 <p>
 <a id="p:indexes"></a></p><ul class="ftoc2"><li class="li-links">

--- a/site/releases/4.12/htmlman/indexops.html
+++ b/site/releases/4.12/htmlman/indexops.html
@@ -5,45 +5,45 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:index-operators"><a class="section-anchor" href="#s:index-operators" aria-hidden="true"></a>8.19 Extended indexing operators </h2>
+<h2 class="section" id="s:index-operators"><a class="section-anchor" href="#s:index-operators" aria-hidden="true"></a><span class="number">19</span>Extended indexing operators </h2>
 <ul>
-<li><a href="indexops.html#ss%3Amultiindexing">8.19.1 Multi-index notation</a>
+<li><a href="indexops.html#ss%3Amultiindexing"><span class="number">19.1</span>Multi-index notation</a>
 </li></ul>
 <p>
 (Introduced in 4.06)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019"><a class="syntax" id="dot-ext"><span class="c011">dot-ext</span></a></td><td class="c016">::=</td><td class="c018">
@@ -116,7 +116,7 @@ dictionaries with
 <div class="pre caml-output ok">- : int = 2</div></div>
 
 </div>
-<h3 class="subsection" id="ss:multiindexing"><a class="section-anchor" href="#ss:multiindexing" aria-hidden="true">﻿</a>8.19.1 Multi-index notation</h3>
+<h3 class="subsection" id="ss:multiindexing"><a class="section-anchor" href="#ss:multiindexing" aria-hidden="true">﻿</a><span class="number">19.1</span>Multi-index notation</h3>
 <div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a></td><td class="c016">::=</td><td class="c018">
 ...
@@ -219,7 +219,7 @@ to define conjointly a single index variant
 
 to handle both cases uniformly.</p>
 
-<div class="bottom-navigation"><a class="previous" href="doccomments.html">« 8.18 Documentation comments</a><a class="next" href="emptyvariants.html">8.20 Empty variant types »</a></div>
+<div class="bottom-navigation"><a class="previous" href="doccomments.html">« Documentation comments</a><a class="next" href="emptyvariants.html">Empty variant types »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/inlinerecords.html
+++ b/site/releases/4.12/htmlman/inlinerecords.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:inline-records"><a class="section-anchor" href="#s:inline-records" aria-hidden="true"></a>8.17 Inline records</h2>
+<h2 class="section" id="s:inline-records"><a class="section-anchor" href="#s:inline-records" aria-hidden="true"></a><span class="number">17</span>Inline records</h2>
 <p>
 (Introduced in OCaml 4.03)
 </p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -99,7 +99,7 @@ extract or modify fields or to build new constructor values.</p><div class="caml
 
 </div>
 
-<div class="bottom-navigation"><a class="previous" href="extensionsyntax.html">« 8.16 Extension-only syntax</a><a class="next" href="doccomments.html">8.18 Documentation comments »</a></div>
+<div class="bottom-navigation"><a class="previous" href="extensionsyntax.html">« Extension-only syntax</a><a class="next" href="doccomments.html">Documentation comments »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/instrumented-runtime.html
+++ b/site/releases/4.12/htmlman/instrumented-runtime.html
@@ -5,19 +5,19 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍21 Runtime tracing with the instrumented runtime</title>
+<title>OCaml - Runtime tracing with the instrumented runtime</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li class="active"><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li class="active"><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec551">Chapter ‍21 Runtime tracing with the instrumented runtime</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li>
-<li><a href="instrumented-runtime.html#s%3Ainstr-runtime-overview">21.1 Overview</a>
-</li><li><a href="instrumented-runtime.html#s%3Ainstr-runtime-enabling">21.2 Enabling runtime instrumentation</a>
-</li><li><a href="instrumented-runtime.html#s%3Ainstr-runtime-read">21.3 Reading traces</a>
-</li><li><a href="instrumented-runtime.html#s%3Ainstr-runtime-more">21.4 Controlling instrumentation and limitations</a>
+<h1 class="chapter" id="sec551"><span class="number">Chapter 21</span>Runtime tracing with the instrumented runtime</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Runtime tracing with the instrumented runtime</a></li>
+<li><a href="instrumented-runtime.html#s%3Ainstr-runtime-overview"><span class="number">1</span>Overview</a>
+</li><li><a href="instrumented-runtime.html#s%3Ainstr-runtime-enabling"><span class="number">2</span>Enabling runtime instrumentation</a>
+</li><li><a href="instrumented-runtime.html#s%3Ainstr-runtime-read"><span class="number">3</span>Reading traces</a>
+</li><li><a href="instrumented-runtime.html#s%3Ainstr-runtime-more"><span class="number">4</span>Controlling instrumentation and limitations</a>
 </li></ul></nav></header>
 <p>This chapter describes the OCaml instrumented runtime, a runtime variant
 allowing the collection of events and metrics.</p><p>Collected metrics include time spent executing the <em>garbage collector</em>.
@@ -26,7 +26,7 @@ down to the time spent in specific parts of the garbage collection.
 Insight is also given on memory allocation and motion by recording
 the size of allocated memory blocks, as well as value promotions from the
 <em>minor heap</em> to the <em>major heap</em>.</p>
-<h2 class="section" id="s:instr-runtime-overview"><a class="section-anchor" href="#s:instr-runtime-overview" aria-hidden="true"></a>21.1 Overview</h2>
+<h2 class="section" id="s:instr-runtime-overview"><a class="section-anchor" href="#s:instr-runtime-overview" aria-hidden="true"></a><span class="number">1</span>Overview</h2>
 <p>Once compiled and linked with the instrumented runtime, any OCaml program
 can generate <em>trace files</em> that can then be read
 and analyzed by users in order to understand specific runtime behaviors.</p><p>The generated trace files are stored using the <em>Common Trace Format</em>, which
@@ -38,7 +38,7 @@ a <em>metadata file</em>, part of the OCaml distribution
  in the program being traced.
 </li></ul><p>For more information on the <em>Common Trace Format</em>, see
 <a href="https://diamon.org/ctf/">https://diamon.org/ctf/</a>.</p>
-<h2 class="section" id="s:instr-runtime-enabling"><a class="section-anchor" href="#s:instr-runtime-enabling" aria-hidden="true">﻿</a>21.2 Enabling runtime instrumentation</h2>
+<h2 class="section" id="s:instr-runtime-enabling"><a class="section-anchor" href="#s:instr-runtime-enabling" aria-hidden="true">﻿</a><span class="number">2</span>Enabling runtime instrumentation</h2>
 <p>For the following examples, we will use the following example program:</p><div class="caml-example verbatim">
 
 <div class="ocaml">
@@ -82,19 +82,19 @@ This can be done by either using the
 bytecode through <span class="c004">ocamlruni</span>:</p><pre>       ocamlc program.ml -o program.byte
        OCAML_EVENTLOG_ENABLED=1 ocamlruni program.byte
 </pre><p>
-See chapter ‍<a href="comp.html#c%3Acamlc">9</a> and chapter ‍<a href="runtime.html#c%3Aruntime">11</a> for more information about
+See chapter&nbsp;<a href="comp.html#c%3Acamlc">9</a> and chapter&nbsp;<a href="runtime.html#c%3Aruntime">11</a> for more information about
 <span class="c004">ocamlc</span> and <span class="c004">ocamlrun</span>.</p>
-<h2 class="section" id="s:instr-runtime-read"><a class="section-anchor" href="#s:instr-runtime-read" aria-hidden="true">﻿</a>21.3 Reading traces</h2>
+<h2 class="section" id="s:instr-runtime-read"><a class="section-anchor" href="#s:instr-runtime-read" aria-hidden="true">﻿</a><span class="number">3</span>Reading traces</h2>
 <p>Traces generated by the instrumented runtime can be analyzed with tooling
 available outside of the OCaml distribution.</p><p>A complete trace consists of a <em>metadata file</em> and a <em>trace file</em>.
 Two simple ways to work with the traces are the <em>eventlog-tools</em> and
 <em>babeltrace</em> libraries.</p>
-<h3 class="subsection" id="ss:instr-runtime-tools"><a class="section-anchor" href="#ss:instr-runtime-tools" aria-hidden="true">﻿</a>21.3.1 eventlog-tools</h3>
+<h3 class="subsection" id="ss:instr-runtime-tools"><a class="section-anchor" href="#ss:instr-runtime-tools" aria-hidden="true">﻿</a><span class="number">3.1</span>eventlog-tools</h3>
 <p>
 <em>eventlog-tools</em> is a library implementing a parser, as well as a
 a set of tools that allows to perform basic format conversions and analysis.</p><p>For more information about <em>eventlog-tools</em>, refer to the project’s
 main page: <a href="https://github.com/ocaml-multicore/eventlog-tools">https://github.com/ocaml-multicore/eventlog-tools</a></p>
-<h3 class="subsection" id="ss:instr-runtime-babeltrace"><a class="section-anchor" href="#ss:instr-runtime-babeltrace" aria-hidden="true">﻿</a>21.3.2 babeltrace</h3>
+<h3 class="subsection" id="ss:instr-runtime-babeltrace"><a class="section-anchor" href="#ss:instr-runtime-babeltrace" aria-hidden="true">﻿</a><span class="number">3.2</span>babeltrace</h3>
 <p><em>babeltrace</em> is a C library, as well as a Python binding and set of tools
 that serve as the reference implementation for the <em>Common Trace Format</em>.
 The <em>babeltrace</em> command line utility allows for a basic rendering
@@ -159,8 +159,8 @@ This script expect to receive as an argument the directory containing the
 trace file. It will then copy the <em>CTF</em> metadata file to the trace’s
 directory, and then decode the trace, printing each event in the process.</p><p>For more information on <em>babeltrace</em>, see the website at:
 <a href="https://babeltrace.org/">https://babeltrace.org/</a></p>
-<h2 class="section" id="s:instr-runtime-more"><a class="section-anchor" href="#s:instr-runtime-more" aria-hidden="true">﻿</a>21.4 Controlling instrumentation and limitations</h2>
-<h3 class="subsection" id="ss:instr-runtime-prefix"><a class="section-anchor" href="#ss:instr-runtime-prefix" aria-hidden="true">﻿</a>21.4.1 Trace filename</h3>
+<h2 class="section" id="s:instr-runtime-more"><a class="section-anchor" href="#s:instr-runtime-more" aria-hidden="true">﻿</a><span class="number">4</span>Controlling instrumentation and limitations</h2>
+<h3 class="subsection" id="ss:instr-runtime-prefix"><a class="section-anchor" href="#ss:instr-runtime-prefix" aria-hidden="true">﻿</a><span class="number">4.1</span>Trace filename</h3>
 <p>The default trace filename is <span class="c004">caml-{PID}.eventlog</span>, where <span class="c004">{PID}</span>
 is the process identifier of the traced program.</p><p>This filename can also be specified using the
 <span class="c004">OCAML_EVENTLOG_PREFIX</span> environment variable.
@@ -177,7 +177,7 @@ the generated files.</p><p>Note as well that parent directories in the given pat
 when opening the trace. The runtime assumes the path is
 accessible for creating and writing the trace. The program will
 fail to start if this requirement isn’t met.</p>
-<h3 class="subsection" id="ss:instr-runtime-pause"><a class="section-anchor" href="#ss:instr-runtime-pause" aria-hidden="true">﻿</a>21.4.2 Pausing and resuming tracing</h3>
+<h3 class="subsection" id="ss:instr-runtime-pause"><a class="section-anchor" href="#ss:instr-runtime-pause" aria-hidden="true">﻿</a><span class="number">4.2</span>Pausing and resuming tracing</h3>
 <p>
 Mechanisms are available to control event collection at runtime.</p><p><span class="c004">OCAML_EVENTLOG_ENABLED</span> can be set to the <span class="c004">p</span> flag in order
 to start the program with event collection paused.</p><pre>        OCAML_EVENTLOG_ENABLED=p ./program
@@ -222,7 +222,7 @@ the program’s execution:</p><pre>        $ ocaml-eventlog-report caml-{PID}.ev
         total flush time: 938.1us
         flush count: 5
 </pre>
-<h3 class="subsection" id="ss:instr-runtime-limitations"><a class="section-anchor" href="#ss:instr-runtime-limitations" aria-hidden="true">﻿</a>21.4.3 Limitations</h3>
+<h3 class="subsection" id="ss:instr-runtime-limitations"><a class="section-anchor" href="#ss:instr-runtime-limitations" aria-hidden="true">﻿</a><span class="number">4.3</span>Limitations</h3>
 <p>The instrumented runtime does not support the <span class="c004">fork</span> system call.
 A child process forked from an instrumented program will not be traced.</p><p>The instrumented runtime aims to provide insight into the runtime’s execution
 while maintaining a low overhead.
@@ -239,7 +239,7 @@ small sample of events is required, using the <em>eventlog_resume</em> and
 tracing induced performance impact.
 </p>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="afl-fuzz.html">« Chapter ‍20 Fuzzing with afl-fuzz</a><a class="next" href="core.html">Chapter ‍22 The core library »</a></div>
+<div class="bottom-navigation"><a class="previous" href="afl-fuzz.html">« Fuzzing with afl-fuzz</a><a class="next" href="core.html">The core library »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/intfc.html
+++ b/site/releases/4.12/htmlman/intfc.html
@@ -5,36 +5,36 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍18 Interfacing C with OCaml</title>
+<title>OCaml - Interfacing C with OCaml</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li class="active"><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li class="active"><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="c:intf-c">Chapter ‍18 Interfacing C with OCaml</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍18 Interfacing C with OCaml</a></li>
-<li><a href="intfc.html#s%3Ac-overview">18.1 Overview and compilation information</a>
-</li><li><a href="intfc.html#s%3Ac-value">18.2 The <span class="c004">value</span> type</a>
-</li><li><a href="intfc.html#s%3Ac-ocaml-datatype-repr">18.3 Representation of OCaml data types</a>
-</li><li><a href="intfc.html#s%3Ac-ops-on-values">18.4 Operations on values</a>
-</li><li><a href="intfc.html#s%3Ac-gc-harmony">18.5 Living in harmony with the garbage collector</a>
-</li><li><a href="intfc.html#s%3Ac-intf-example">18.6 A complete example</a>
-</li><li><a href="intfc.html#s%3Ac-callback">18.7 Advanced topic: callbacks from C to OCaml</a>
-</li><li><a href="intfc.html#s%3Ac-advexample">18.8 Advanced example with callbacks</a>
-</li><li><a href="intfc.html#s%3Ac-custom">18.9 Advanced topic: custom blocks</a>
-</li><li><a href="intfc.html#s%3AC-Bigarrays">18.10 Advanced topic: Bigarrays and the OCaml-C interface</a>
-</li><li><a href="intfc.html#s%3AC-cheaper-call">18.11 Advanced topic: cheaper C call</a>
-</li><li><a href="intfc.html#s%3AC-multithreading">18.12 Advanced topic: multithreading</a>
-</li><li><a href="intfc.html#s%3Ainterfacing-windows-unicode-apis">18.13 Advanced topic: interfacing with Windows Unicode APIs</a>
-</li><li><a href="intfc.html#s%3Aocamlmklib">18.14 Building mixed C/OCaml libraries: <span class="c004">ocamlmklib</span></a>
-</li><li><a href="intfc.html#s%3Ac-internal-guidelines">18.15 Cautionary words: the internal runtime API</a>
+<h1 class="chapter" id="c:intf-c"><span class="number">Chapter 18</span>Interfacing C with OCaml</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Interfacing C with OCaml</a></li>
+<li><a href="intfc.html#s%3Ac-overview"><span class="number">1</span>Overview and compilation information</a>
+</li><li><a href="intfc.html#s%3Ac-value"><span class="number">2</span>The <span class="c004">value</span> type</a>
+</li><li><a href="intfc.html#s%3Ac-ocaml-datatype-repr"><span class="number">3</span>Representation of OCaml data types</a>
+</li><li><a href="intfc.html#s%3Ac-ops-on-values"><span class="number">4</span>Operations on values</a>
+</li><li><a href="intfc.html#s%3Ac-gc-harmony"><span class="number">5</span>Living in harmony with the garbage collector</a>
+</li><li><a href="intfc.html#s%3Ac-intf-example"><span class="number">6</span>A complete example</a>
+</li><li><a href="intfc.html#s%3Ac-callback"><span class="number">7</span>Advanced topic: callbacks from C to OCaml</a>
+</li><li><a href="intfc.html#s%3Ac-advexample"><span class="number">8</span>Advanced example with callbacks</a>
+</li><li><a href="intfc.html#s%3Ac-custom"><span class="number">9</span>Advanced topic: custom blocks</a>
+</li><li><a href="intfc.html#s%3AC-Bigarrays"><span class="number">10</span>Advanced topic: Bigarrays and the OCaml-C interface</a>
+</li><li><a href="intfc.html#s%3AC-cheaper-call"><span class="number">11</span>Advanced topic: cheaper C call</a>
+</li><li><a href="intfc.html#s%3AC-multithreading"><span class="number">12</span>Advanced topic: multithreading</a>
+</li><li><a href="intfc.html#s%3Ainterfacing-windows-unicode-apis"><span class="number">13</span>Advanced topic: interfacing with Windows Unicode APIs</a>
+</li><li><a href="intfc.html#s%3Aocamlmklib"><span class="number">14</span>Building mixed C/OCaml libraries: <span class="c004">ocamlmklib</span></a>
+</li><li><a href="intfc.html#s%3Ac-internal-guidelines"><span class="number">15</span>Cautionary words: the internal runtime API</a>
 </li></ul></nav></header>
 <p>This chapter describes how user-defined primitives, written in C, can
 be linked with OCaml code and called from OCaml functions, and how
 these C functions can call back to OCaml code.</p>
-<h2 class="section" id="s:c-overview"><a class="section-anchor" href="#s:c-overview" aria-hidden="true"></a>18.1 Overview and compilation information</h2>
-<h3 class="subsection" id="ss:c-prim-decl"><a class="section-anchor" href="#ss:c-prim-decl" aria-hidden="true">﻿</a>18.1.1 Declaring primitives</h3>
+<h2 class="section" id="s:c-overview"><a class="section-anchor" href="#s:c-overview" aria-hidden="true"></a><span class="number">1</span>Overview and compilation information</h2>
+<h3 class="subsection" id="ss:c-prim-decl"><a class="section-anchor" href="#ss:c-prim-decl" aria-hidden="true">﻿</a><span class="number">1.1</span>Declaring primitives</h3>
 <div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="modules.html#definition"><span class="c011">definition</span></a></td><td class="c016">::=</td><td class="c018"> ...
  </td></tr>
@@ -85,12 +85,12 @@ return a functional value (as in the <span class="c004">f</span> example above):
 to name the functional return type in a type abbreviation.</p><p>The language accepts external declarations with one or two
 flag strings in addition to the C function’s name. These flags are
 reserved for the implementation of the standard library.</p>
-<h3 class="subsection" id="ss:c-prim-impl"><a class="section-anchor" href="#ss:c-prim-impl" aria-hidden="true">﻿</a>18.1.2 Implementing primitives</h3>
+<h3 class="subsection" id="ss:c-prim-impl"><a class="section-anchor" href="#ss:c-prim-impl" aria-hidden="true">﻿</a><span class="number">1.2</span>Implementing primitives</h3>
 <p>User primitives with arity <span class="c010">n</span> ≤ 5 are implemented by C functions
 that take <span class="c010">n</span> arguments of type <span class="c004">value</span>, and return a result of type
 <span class="c004">value</span>. The type <span class="c004">value</span> is the type of the representations for OCaml
 values. It encodes objects of several base types (integers,
-floating-point numbers, strings, ‍…) as well as OCaml data
+floating-point numbers, strings,&nbsp;…) as well as OCaml data
 structures. The type <span class="c004">value</span> and the associated conversion
 functions and macros are described in detail below. For instance,
 here is the declaration for the C function implementing the <span class="c004">input</span>
@@ -173,16 +173,16 @@ objects) </td></tr>
 <tr><td class="c023"><span class="c004">caml/memory.h</span></td><td class="c022">miscellaneous memory-related functions
 and macros (for GC interface, in-place modification of structures, etc). </td></tr>
 <tr><td class="c023"><span class="c004">caml/fail.h</span></td><td class="c022">functions for raising exceptions
-(see section ‍<a href="#ss%3Ac-exceptions">18.4.5</a>) </td></tr>
+(see section&nbsp;<a href="#ss%3Ac-exceptions">18.4.5</a>) </td></tr>
 <tr><td class="c023"><span class="c004">caml/callback.h</span></td><td class="c022">callback from C to OCaml (see
-section ‍<a href="#s%3Ac-callback">18.7</a>). </td></tr>
+section&nbsp;<a href="#s%3Ac-callback">18.7</a>). </td></tr>
 <tr><td class="c023"><span class="c004">caml/custom.h</span></td><td class="c022">operations on custom blocks (see
-section ‍<a href="#s%3Ac-custom">18.9</a>). </td></tr>
+section&nbsp;<a href="#s%3Ac-custom">18.9</a>). </td></tr>
 <tr><td class="c023"><span class="c004">caml/intext.h</span></td><td class="c022">operations for writing user-defined
 serialization and deserialization functions for custom blocks
-(see section ‍<a href="#s%3Ac-custom">18.9</a>). </td></tr>
+(see section&nbsp;<a href="#s%3Ac-custom">18.9</a>). </td></tr>
 <tr><td class="c023"><span class="c004">caml/threads.h</span></td><td class="c022">operations for interfacing in the presence
-of multiple threads (see section ‍<a href="#s%3AC-multithreading">18.12</a>). </td></tr>
+of multiple threads (see section&nbsp;<a href="#s%3AC-multithreading">18.12</a>). </td></tr>
 </tbody></table></div></div><p>
 Before including any of these files, you should define the <span class="c004">CAML_NAME_SPACE</span>
 macro. For instance,
@@ -197,7 +197,7 @@ introduces in scope short names for most functions.
 Those short names are deprecated, and may be removed in the future
 because they usually produce clashes with names defined by other
 C libraries.</p>
-<h3 class="subsection" id="ss:staticlink-c-code"><a class="section-anchor" href="#ss:staticlink-c-code" aria-hidden="true">﻿</a>18.1.3 Statically linking C code with OCaml code</h3>
+<h3 class="subsection" id="ss:staticlink-c-code"><a class="section-anchor" href="#ss:staticlink-c-code" aria-hidden="true">﻿</a><span class="number">1.3</span>Statically linking C code with OCaml code</h3>
 <p>The OCaml runtime system comprises three main parts: the bytecode
 interpreter, the memory manager, and a set of C functions that
 implement the primitive operations. Some bytecode instructions are
@@ -206,7 +206,7 @@ table of functions (the table of primitives).</p><p>In the default mode, the OCa
 standard runtime system, with a standard set of primitives. References
 to primitives that are not in this standard set result in the
 “unavailable C primitive” error. (Unless dynamic loading of C
-libraries is supported – see section ‍<a href="#ss%3Adynlink-c-code">18.1.4</a> below.)</p><p>In the “custom runtime” mode, the OCaml linker scans the
+libraries is supported – see section&nbsp;<a href="#ss%3Adynlink-c-code">18.1.4</a> below.)</p><p>In the “custom runtime” mode, the OCaml linker scans the
 object files and determines the set of required primitives. Then, it
 builds a suitable runtime system, by calling the native code linker with:
 </p><ul class="itemize"><li class="li-itemize">
@@ -262,7 +262,7 @@ options themselves at link-time:
 </pre><p>
 The former alternative is more convenient for the final users of the
 library, however.</p>
-<h3 class="subsection" id="ss:dynlink-c-code"><a class="section-anchor" href="#ss:dynlink-c-code" aria-hidden="true">﻿</a>18.1.4 Dynamically linking C code with OCaml code</h3>
+<h3 class="subsection" id="ss:dynlink-c-code"><a class="section-anchor" href="#ss:dynlink-c-code" aria-hidden="true">﻿</a><span class="number">1.4</span>Dynamically linking C code with OCaml code</h3>
 <p>Starting with Objective Caml 3.03, an alternative to static linking of C code
 using the <span class="c004">-custom</span> code is provided. In this mode, the OCaml linker
 generates a pure bytecode executable (no embedded custom runtime
@@ -278,7 +278,7 @@ operating system), and 2- building a
 shared library from the resulting object files. The resulting shared
 library or DLL file must be installed in a place where <span class="c004">ocamlrun</span> can
 find it later at program start-up time (see
-section ‍<a href="runtime.html#s%3Aocamlrun-dllpath">11.3</a>).
+section&nbsp;<a href="runtime.html#s%3Aocamlrun-dllpath">11.3</a>).
 Finally (step 3), execute the <span class="c004">ocamlc</span> command with
 </p><ul class="itemize"><li class="li-itemize">
 the names of the desired OCaml object files (<span class="c004">.cmo</span> and <span class="c004">.cma</span> files) ;
@@ -289,8 +289,8 @@ in one of the standard library directories can also be specified as
 <span class="c004">-dllib -l</span><span class="c010">name</span>.
 </li></ul><p>
 Do <em>not</em> set the <span class="c004">-custom</span> flag, otherwise you’re back to static linking
-as described in section ‍<a href="#ss%3Astaticlink-c-code">18.1.3</a>.
-The <span class="c004">ocamlmklib</span> tool (see section ‍<a href="#s%3Aocamlmklib">18.14</a>)
+as described in section&nbsp;<a href="#ss%3Astaticlink-c-code">18.1.3</a>.
+The <span class="c004">ocamlmklib</span> tool (see section&nbsp;<a href="#s%3Aocamlmklib">18.14</a>)
 automates steps 2 and 3.</p><p>As in the case of static linking, it is possible (and recommended) to
 record the names of C libraries in an OCaml <span class="c004">.cma</span> library archive.
 Consider again an OCaml library
@@ -309,7 +309,7 @@ achieving the same effect as
 Using this mechanism, users of the library <span class="c004">mylib.cma</span> do not need to
 known that it references C code, nor whether this C code must be
 statically linked (using <span class="c004">-custom</span>) or dynamically linked.</p>
-<h3 class="subsection" id="ss:c-static-vs-dynamic"><a class="section-anchor" href="#ss:c-static-vs-dynamic" aria-hidden="true">﻿</a>18.1.5 Choosing between static linking and dynamic linking</h3>
+<h3 class="subsection" id="ss:c-static-vs-dynamic"><a class="section-anchor" href="#ss:c-static-vs-dynamic" aria-hidden="true">﻿</a><span class="number">1.5</span>Choosing between static linking and dynamic linking</h3>
 <p>After having described two different ways of linking C code with OCaml
 code, we now review the pros and cons of each, to help developers of
 mixed OCaml/C libraries decide.</p><p>The main advantage of dynamic linking is that it preserves the
@@ -337,7 +337,7 @@ compile to position-independent code and build a shared library vary
 wildly between different Unix systems. Also, dynamic linking is not
 supported on all Unix systems, requiring a fall-back case to static
 linking in the Makefile for the library. The <span class="c004">ocamlmklib</span> command
-(see section ‍<a href="#s%3Aocamlmklib">18.14</a>) tries to hide some of these system
+(see section&nbsp;<a href="#s%3Aocamlmklib">18.14</a>) tries to hide some of these system
 dependencies.</p><p>In conclusion: dynamic linking is highly recommended under the native
 Windows port, because there are no portability problems and it is much
 more convenient for the end users. Under Unix, dynamic linking should
@@ -345,7 +345,7 @@ be considered for mature, frequently used libraries because it
 enhances platform-independence of bytecode executables. For new or
 rarely-used libraries, static linking is much simpler to set up in a
 portable way.</p>
-<h3 class="subsection" id="ss:custom-runtime"><a class="section-anchor" href="#ss:custom-runtime" aria-hidden="true">﻿</a>18.1.6 Building standalone custom runtime systems</h3>
+<h3 class="subsection" id="ss:custom-runtime"><a class="section-anchor" href="#ss:custom-runtime" aria-hidden="true">﻿</a><span class="number">1.6</span>Building standalone custom runtime systems</h3>
 <p>It is sometimes inconvenient to build a custom runtime system each
 time OCaml code is linked with C libraries, like <span class="c004">ocamlc -custom</span> does.
 For one thing, the building of the runtime system is slow on some
@@ -370,7 +370,7 @@ be given twice: when building the runtime system (so that <span class="c004">oca
 knows which C primitives are required) and also when building the
 bytecode executable (so that the bytecode from <span class="c004">unix.cma</span> and
 <span class="c004">threads.cma</span> is actually linked in).</p>
-<h2 class="section" id="s:c-value"><a class="section-anchor" href="#s:c-value" aria-hidden="true">﻿</a>18.2 The <span class="c004">value</span> type</h2>
+<h2 class="section" id="s:c-value"><a class="section-anchor" href="#s:c-value" aria-hidden="true">﻿</a><span class="number">2</span>The <span class="c004">value</span> type</h2>
 <p>All OCaml objects are represented by the C type <span class="c004">value</span>,
 defined in the include file <span class="c004">caml/mlvalues.h</span>, along with macros to
 manipulate values of that type. An object of type <span class="c004">value</span> is either:
@@ -378,12 +378,12 @@ manipulate values of that type. An object of type <span class="c004">value</span
 an unboxed integer;
 </li><li class="li-itemize">or a pointer to a block inside the heap,
 allocated through one of the <code class="verb">caml_alloc_*</code> functions described
-in section ‍<a href="#ss%3Ac-block-allocation">18.4.4</a>.
+in section&nbsp;<a href="#ss%3Ac-block-allocation">18.4.4</a>.
 </li></ul>
-<h3 class="subsection" id="ss:c-int"><a class="section-anchor" href="#ss:c-int" aria-hidden="true">﻿</a>18.2.1 Integer values</h3>
+<h3 class="subsection" id="ss:c-int"><a class="section-anchor" href="#ss:c-int" aria-hidden="true">﻿</a><span class="number">2.1</span>Integer values</h3>
 <p>Integer values encode 63-bit signed integers (31-bit on 32-bit
 architectures). They are unboxed (unallocated).</p>
-<h3 class="subsection" id="ss:c-blocks"><a class="section-anchor" href="#ss:c-blocks" aria-hidden="true">﻿</a>18.2.2 Blocks</h3>
+<h3 class="subsection" id="ss:c-blocks"><a class="section-anchor" href="#ss:c-blocks" aria-hidden="true">﻿</a><span class="number">2.2</span>Blocks</h3>
 <p>Blocks in the heap are garbage-collected, and therefore have strict
 structure constraints. Each block includes a header containing the
 size of the block (in words), and the tag of the block.
@@ -412,7 +412,7 @@ floating-point numbers. </td></tr>
 with user-defined finalization, comparison, hashing,
 serialization and deserialization functions attached. </td></tr>
 </tbody></table></div></div>
-<h3 class="subsection" id="ss:c-outside-head"><a class="section-anchor" href="#ss:c-outside-head" aria-hidden="true">﻿</a>18.2.3 Pointers outside the heap</h3>
+<h3 class="subsection" id="ss:c-outside-head"><a class="section-anchor" href="#ss:c-outside-head" aria-hidden="true">﻿</a><span class="number">2.3</span>Pointers outside the heap</h3>
 <p>In earlier versions of OCaml, it was possible to use
 word-aligned pointers to addresses outside the heap as OCaml values,
 just by casting the pointer to type <span class="c004">value</span>. Starting with OCaml
@@ -420,7 +420,7 @@ just by casting the pointer to type <span class="c004">value</span>. Starting wi
 OCaml is to store those pointers in OCaml blocks with tag
 <span class="c004">Abstract_tag</span> or <span class="c004">Custom_tag</span>, then use the blocks as the OCaml
 values.</p><p>Here is an example of encapsulation of out-of-heap pointers of C type
-<span class="c004">ty *</span> inside <span class="c004">Abstract_tag</span> blocks. Section ‍<a href="#s%3Ac-intf-example">18.6</a>
+<span class="c004">ty *</span> inside <span class="c004">Abstract_tag</span> blocks. Section&nbsp;<a href="#s%3Ac-intf-example">18.6</a>
 gives a more complete example using <span class="c004">Custom_tag</span> blocks.
 </p><pre>/* Create an OCaml value encapsulating the pointer p */
 static value val_of_typtr(ty * p)
@@ -465,10 +465,10 @@ static ty * typtr_of_val(value v)
   return (ty *) (v &amp; ~1);
 }
 </pre>
-<h2 class="section" id="s:c-ocaml-datatype-repr"><a class="section-anchor" href="#s:c-ocaml-datatype-repr" aria-hidden="true">﻿</a>18.3 Representation of OCaml data types</h2>
+<h2 class="section" id="s:c-ocaml-datatype-repr"><a class="section-anchor" href="#s:c-ocaml-datatype-repr" aria-hidden="true">﻿</a><span class="number">3</span>Representation of OCaml data types</h2>
 <p>This section describes how OCaml data types are encoded in the
 <span class="c004">value</span> type.</p>
-<h3 class="subsection" id="ss:c-atomic"><a class="section-anchor" href="#ss:c-atomic" aria-hidden="true">﻿</a>18.3.1 Atomic types</h3>
+<h3 class="subsection" id="ss:c-atomic"><a class="section-anchor" href="#ss:c-atomic" aria-hidden="true">﻿</a><span class="number">3.1</span>Atomic types</h3>
 <div class="tableau">
 <div class="center"><table class="c000 cellpadding1" border="1"><tbody><tr><td class="c015"><span class="c014">OCaml type</span></td><td class="c015"><span class="c014">Encoding</span> </td></tr>
 <tr><td class="c017">
@@ -481,12 +481,12 @@ static ty * typtr_of_val(value v)
 <tr><td class="c017"><span class="c004">int64</span></td><td class="c017">Blocks with tag <span class="c004">Custom_tag</span>. </td></tr>
 <tr><td class="c017"><span class="c004">nativeint</span></td><td class="c017">Blocks with tag <span class="c004">Custom_tag</span>. </td></tr>
 </tbody></table></div></div>
-<h3 class="subsection" id="ss:c-tuples-and-records"><a class="section-anchor" href="#ss:c-tuples-and-records" aria-hidden="true">﻿</a>18.3.2 Tuples and records</h3>
-<p>Tuples are represented by pointers to blocks, with tag ‍0.</p><p>Records are also represented by zero-tagged blocks. The ordering of
+<h3 class="subsection" id="ss:c-tuples-and-records"><a class="section-anchor" href="#ss:c-tuples-and-records" aria-hidden="true">﻿</a><span class="number">3.2</span>Tuples and records</h3>
+<p>Tuples are represented by pointers to blocks, with tag&nbsp;0.</p><p>Records are also represented by zero-tagged blocks. The ordering of
 labels in the record type declaration determines the layout of
 the record fields: the value associated to the label
-declared first is stored in field ‍0 of the block, the value associated
-to the second label goes in field ‍1, and so on.</p><p>As an optimization, records whose fields all have static type <span class="c004">float</span>
+declared first is stored in field&nbsp;0 of the block, the value associated
+to the second label goes in field&nbsp;1, and so on.</p><p>As an optimization, records whose fields all have static type <span class="c004">float</span>
 are represented as arrays of floating-point numbers, with tag
 <span class="c004">Double_array_tag</span>. (See the section below on arrays.)</p><p>As another optimization, unboxable record types are represented
 specially; unboxable record types are the immutable record types that
@@ -502,15 +502,15 @@ An attribute (<span class="c004">[@@boxed]</span> or <span class="c004">[@@unbox
 </li><li class="li-itemize">The default representation. In the present version of OCaml, the
 default is the boxed representation.
 </li></ul>
-<h3 class="subsection" id="ss:c-arrays"><a class="section-anchor" href="#ss:c-arrays" aria-hidden="true">﻿</a>18.3.3 Arrays</h3>
+<h3 class="subsection" id="ss:c-arrays"><a class="section-anchor" href="#ss:c-arrays" aria-hidden="true">﻿</a><span class="number">3.3</span>Arrays</h3>
 <p>Arrays of integers and pointers are represented like tuples,
-that is, as pointers to blocks tagged ‍0. They are accessed with the
+that is, as pointers to blocks tagged&nbsp;0. They are accessed with the
 <span class="c004">Field</span> macro for reading and the <span class="c004">caml_modify</span> function for writing.</p><p>Arrays of floating-point numbers (type <span class="c004">float array</span>)
 have a special, unboxed, more efficient representation.
 These arrays are represented by pointers to blocks with tag
 <span class="c004">Double_array_tag</span>. They should be accessed with the <span class="c004">Double_field</span>
 and <span class="c004">Store_double_field</span> macros.</p>
-<h3 class="subsection" id="ss:c-concrete-datatypes"><a class="section-anchor" href="#ss:c-concrete-datatypes" aria-hidden="true">﻿</a>18.3.4 Concrete data types</h3>
+<h3 class="subsection" id="ss:c-concrete-datatypes"><a class="section-anchor" href="#ss:c-concrete-datatypes" aria-hidden="true">﻿</a><span class="number">3.4</span>Concrete data types</h3>
 <p>Constructed terms are represented either by unboxed integers (for
 constant constructors) or by blocks whose tag encode the constructor
 (for non-constant constructors). The constant constructors and the
@@ -543,8 +543,8 @@ specially; a concrete data type is unboxable if it has exactly one
 constructor and this constructor has exactly one argument. Unboxable
 concrete data types are represented in the same ways as unboxable
 record types: see the description in
-section ‍<a href="#ss%3Ac-tuples-and-records">18.3.2</a>.</p>
-<h3 class="subsection" id="ss:c-objects"><a class="section-anchor" href="#ss:c-objects" aria-hidden="true">﻿</a>18.3.5 Objects</h3>
+section&nbsp;<a href="#ss%3Ac-tuples-and-records">18.3.2</a>.</p>
+<h3 class="subsection" id="ss:c-objects"><a class="section-anchor" href="#ss:c-objects" aria-hidden="true">﻿</a><span class="number">3.5</span>Objects</h3>
 <p>Objects are represented as blocks with tag <span class="c004">Object_tag</span>. The first
 field of the block refers to the object’s class and associated method
 suite, in a format that cannot easily be exploited from C. The second
@@ -560,7 +560,7 @@ and methods are functions taking self as first argument, if you want
 to do the method call <span class="c004">foo#bar</span> from the C side, you should call:
 </p><pre>  callback(caml_get_public_method(foo, hash_variant("bar")), foo);
 </pre>
-<h3 class="subsection" id="ss:c-polyvar"><a class="section-anchor" href="#ss:c-polyvar" aria-hidden="true">﻿</a>18.3.6 Polymorphic variants</h3>
+<h3 class="subsection" id="ss:c-polyvar"><a class="section-anchor" href="#ss:c-polyvar" aria-hidden="true">﻿</a><span class="number">3.6</span>Polymorphic variants</h3>
 <p>Like constructed terms, polymorphic variant values are represented either
 as integers (for polymorphic variants without argument), or as blocks
 (for polymorphic variants with an argument). Unlike constructed
@@ -578,8 +578,8 @@ That is, <span class="c004">`VConstr(</span><span class="c010">v</span><span cla
 of size 2, whose field number 1 contains the representation of the
 pair <span class="c004">(</span><span class="c010">v</span><span class="c004">, </span><span class="c010">w</span><span class="c004">)</span>, rather than a block of size 3
 containing <span class="c010">v</span> and <span class="c010">w</span> in fields 1 and 2.</p>
-<h2 class="section" id="s:c-ops-on-values"><a class="section-anchor" href="#s:c-ops-on-values" aria-hidden="true">﻿</a>18.4 Operations on values</h2>
-<h3 class="subsection" id="ss:c-kind-tests"><a class="section-anchor" href="#ss:c-kind-tests" aria-hidden="true">﻿</a>18.4.1 Kind tests</h3>
+<h2 class="section" id="s:c-ops-on-values"><a class="section-anchor" href="#s:c-ops-on-values" aria-hidden="true">﻿</a><span class="number">4</span>Operations on values</h2>
+<h3 class="subsection" id="ss:c-kind-tests"><a class="section-anchor" href="#ss:c-kind-tests" aria-hidden="true">﻿</a><span class="number">4.1</span>Kind tests</h3>
 <ul class="itemize"><li class="li-itemize">
 <span class="c004">Is_long(</span><span class="c010">v</span><span class="c004">)</span> is true if value <span class="c010">v</span> is an immediate integer,
 false otherwise
@@ -589,7 +589,7 @@ and false if it is an immediate integer.
 </li><li class="li-itemize"><span class="c004">Is_some(</span><span class="c010">v</span><span class="c004">)</span> is true if value <span class="c010">v</span> (assumed to be of option
 type) corresponds to the <span class="c004">Some</span> constructor.
 </li></ul>
-<h3 class="subsection" id="ss:c-int-ops"><a class="section-anchor" href="#ss:c-int-ops" aria-hidden="true">﻿</a>18.4.2 Operations on integers</h3>
+<h3 class="subsection" id="ss:c-int-ops"><a class="section-anchor" href="#ss:c-int-ops" aria-hidden="true">﻿</a><span class="number">4.2</span>Operations on integers</h3>
 <ul class="itemize"><li class="li-itemize">
 <span class="c004">Val_long(</span><span class="c010">l</span><span class="c004">)</span> returns the value encoding the <span class="c004">long int</span> <span class="c010">l</span>.
 </li><li class="li-itemize"><span class="c004">Long_val(</span><span class="c010">v</span><span class="c004">)</span> returns the <span class="c004">long int</span> encoded in value <span class="c010">v</span>.
@@ -602,7 +602,7 @@ truth value of the C integer <span class="c010">x</span>.
 </li><li class="li-itemize"><span class="c004">Val_true</span>, <span class="c004">Val_false</span> represent the OCaml booleans <span class="c004">true</span> and <span class="c004">false</span>.
 </li><li class="li-itemize"><span class="c004">Val_none</span> represents the OCaml value <span class="c004">None</span>.
 </li></ul>
-<h3 class="subsection" id="ss:c-block-access"><a class="section-anchor" href="#ss:c-block-access" aria-hidden="true">﻿</a>18.4.3 Accessing blocks</h3>
+<h3 class="subsection" id="ss:c-block-access"><a class="section-anchor" href="#ss:c-block-access" aria-hidden="true">﻿</a><span class="number">4.3</span>Accessing blocks</h3>
 <ul class="itemize"><li class="li-itemize">
 <span class="c004">Wosize_val(</span><span class="c010">v</span><span class="c004">)</span> returns the size of the block <span class="c010">v</span>, in words,
 excluding the header.
@@ -664,7 +664,7 @@ in-place modification of value <span class="c010">v</span>.
 Assigning directly to <span class="c004">Field(</span><span class="c010">v</span><span class="c004">, </span><span class="c010">n</span><span class="c004">)</span> must
 be done with care to avoid confusing the garbage collector (see
 below).</p>
-<h3 class="subsection" id="ss:c-block-allocation"><a class="section-anchor" href="#ss:c-block-allocation" aria-hidden="true">﻿</a>18.4.4 Allocating blocks</h3>
+<h3 class="subsection" id="ss:c-block-allocation"><a class="section-anchor" href="#ss:c-block-allocation" aria-hidden="true">﻿</a><span class="number">4.4</span>Allocating blocks</h3>
 <h4 class="subsubsection" id="sss:c-simple-allocation"><a class="section-anchor" href="#sss:c-simple-allocation" aria-hidden="true">﻿</a>Simple interface</h4>
 <ul class="itemize"><li class="li-itemize">
 <span class="c004">Atom(</span><span class="c010">t</span><span class="c004">)</span> returns an “atom” (zero-sized block) with tag <span class="c010">t</span>.
@@ -740,7 +740,7 @@ the fields of the block (initially containing garbage) must be initialized
 with legal values (using the <span class="c004">caml_initialize</span> function described below)
 before the next allocation.
 </li></ul>
-<h3 class="subsection" id="ss:c-exceptions"><a class="section-anchor" href="#ss:c-exceptions" aria-hidden="true">﻿</a>18.4.5 Raising exceptions</h3>
+<h3 class="subsection" id="ss:c-exceptions"><a class="section-anchor" href="#ss:c-exceptions" aria-hidden="true">﻿</a><span class="number">4.5</span>Raising exceptions</h3>
 <p>Two functions are provided to raise two standard exceptions:
 </p><ul class="itemize"><li class="li-itemize">
 <span class="c004">caml_failwith(</span><span class="c010">s</span><span class="c004">)</span>, where <span class="c010">s</span> is a null-terminated C string (with
@@ -751,7 +751,7 @@ with argument <span class="c010">s</span>.
 </li></ul><p>Raising arbitrary exceptions from C is more delicate: the
 exception identifier is dynamically allocated by the OCaml program, and
 therefore must be communicated to the C function using the
-registration facility described below in section ‍<a href="#ss%3Ac-register-exn">18.7.3</a>.
+registration facility described below in section&nbsp;<a href="#ss%3Ac-register-exn">18.7.3</a>.
 Once the exception identifier is recovered in C, the following
 functions actually raise the exception:
 </p><ul class="itemize"><li class="li-itemize">
@@ -766,13 +766,13 @@ raises the exception <span class="c010">id</span> with the OCaml values
 null-terminated C string, raises the exception <span class="c010">id</span> with a copy of
 the C string <span class="c010">s</span> as argument.
 </li></ul>
-<h2 class="section" id="s:c-gc-harmony"><a class="section-anchor" href="#s:c-gc-harmony" aria-hidden="true">﻿</a>18.5 Living in harmony with the garbage collector</h2>
+<h2 class="section" id="s:c-gc-harmony"><a class="section-anchor" href="#s:c-gc-harmony" aria-hidden="true">﻿</a><span class="number">5</span>Living in harmony with the garbage collector</h2>
 <p>Unused blocks in the heap are automatically reclaimed by the garbage
 collector. This requires some cooperation from C code that
 manipulates heap-allocated blocks.</p>
-<h3 class="subsection" id="ss:c-simple-gc-harmony"><a class="section-anchor" href="#ss:c-simple-gc-harmony" aria-hidden="true">﻿</a>18.5.1 Simple interface</h3>
+<h3 class="subsection" id="ss:c-simple-gc-harmony"><a class="section-anchor" href="#ss:c-simple-gc-harmony" aria-hidden="true">﻿</a><span class="number">5.1</span>Simple interface</h3>
 <p>All the macros described in this section are declared in the
-<span class="c004">memory.h</span> header file.</p><div class="theorem"><span class="c014">Rule ‍1</span> <em>
+<span class="c004">memory.h</span> header file.</p><div class="theorem"><span class="c014">Rule&nbsp;1</span> <em>
 A function that has parameters or local variables of type <span class="c004">value</span> must
 begin with a call to one of the <span class="c004">CAMLparam</span> macros and return with
 <span class="c004">CAMLreturn</span>, <span class="c004">CAMLreturn0</span>, or <span class="c004">CAMLreturnT</span>. In particular, <span class="c004">CAMLlocal</span>
@@ -807,7 +807,7 @@ variables <span class="c004">caml__dummy_xxx</span> at each use of <span class="
 <h5 class="paragraph" id="sec450"><a class="section-anchor" href="#sec450" aria-hidden="true">﻿</a>Note:</h5>
 <p> if your function is a primitive with more than 5 arguments
 for use with the byte-code runtime, its arguments are not <span class="c004">value</span>s and
-must not be declared (they have types <span class="c004">value *</span> and <span class="c004">int</span>).</p><div class="theorem"><span class="c014">Rule ‍2</span> <em>
+must not be declared (they have types <span class="c004">value *</span> and <span class="c004">int</span>).</p><div class="theorem"><span class="c014">Rule&nbsp;2</span> <em>
 Local variables of type <span class="c004">value</span> must be declared with one of the
 <span class="c004">CAMLlocal</span> macros. Arrays of <span class="c004">value</span>s are declared with
 <span class="c004">CAMLlocalN</span>. These macros must be used at the beginning of the
@@ -826,7 +826,7 @@ variables.</p><p>Example:
   ...
   CAMLreturn (result);
 }
-</pre><div class="theorem"><span class="c014">Rule ‍3</span> <em>
+</pre><div class="theorem"><span class="c014">Rule&nbsp;3</span> <em>
 Assignments to the fields of structured blocks must be done with the
 <span class="c004">Store_field</span> macro (for normal blocks) or <span class="c004">Store_double_field</span> macro
 (for arrays and records of floating-point numbers). Other assignments
@@ -854,7 +854,7 @@ invalidate the first argument after it is computed.</p>
 <h5 class="paragraph" id="sec452"><a class="section-anchor" href="#sec452" aria-hidden="true">﻿</a>Use with CAMLlocalN:</h5>
 <p> Arrays of values declared using
 <span class="c004">CAMLlocalN</span> must not be written to using <span class="c004">Store_field</span>.
-Use the normal C array syntax instead.</p><div class="theorem"><span class="c014">Rule ‍4</span> <em> Global variables containing values must be registered
+Use the normal C array syntax instead.</p><div class="theorem"><span class="c014">Rule&nbsp;4</span> <em> Global variables containing values must be registered
 with the garbage collector using the <span class="c004">caml_register_global_root</span> function,
 save that global variables and locations that will only ever contain OCaml
 integers (and never pointers) do not have to be registered.</em><p><em>The same is true for any memory location outside the OCaml heap that contains a
@@ -890,10 +890,10 @@ modifications of <span class="c004">v</span> happen less often than minor collec
 <p> The <span class="c004">CAML</span> macros use identifiers (local variables, type
 identifiers, structure tags) that start with <span class="c004">caml__</span>. Do not use any
 identifier starting with <span class="c004">caml__</span> in your programs.</p>
-<h3 class="subsection" id="ss:c-low-level-gc-harmony"><a class="section-anchor" href="#ss:c-low-level-gc-harmony" aria-hidden="true">﻿</a>18.5.2 Low-level interface</h3>
+<h3 class="subsection" id="ss:c-low-level-gc-harmony"><a class="section-anchor" href="#ss:c-low-level-gc-harmony" aria-hidden="true">﻿</a><span class="number">5.2</span>Low-level interface</h3>
 <p>We now give the GC rules corresponding to the low-level allocation
 functions <span class="c004">caml_alloc_small</span> and <span class="c004">caml_alloc_shr</span>. You can ignore those rules
-if you stick to the simplified allocation function <span class="c004">caml_alloc</span>.</p><div class="theorem"><span class="c014">Rule ‍5</span> <em> After a structured block (a block with tag less than
+if you stick to the simplified allocation function <span class="c004">caml_alloc</span>.</p><div class="theorem"><span class="c014">Rule&nbsp;5</span> <em> After a structured block (a block with tag less than
 <span class="c004">No_scan_tag</span>) is allocated with the low-level functions, all fields
 of this block must be filled with well-formed values before the next
 allocation operation. If the block has been allocated with
@@ -913,7 +913,7 @@ values. Newly created blocks contain random data, which generally do
 not represent well-formed values.</p><p>If you really need to allocate before the fields can receive their
 final value, first initialize with a constant value (e.g.
 <span class="c004">Val_unit</span>), then allocate, then modify the fields with the correct
-value (see rule ‍6).</p><div class="theorem"><span class="c014">Rule ‍6</span> <em> Direct assignment to a field of a block, as in
+value (see rule&nbsp;6).</p><div class="theorem"><span class="c014">Rule&nbsp;6</span> <em> Direct assignment to a field of a block, as in
 </em><pre><em>
         Field(<span class="c010">v</span>, <span class="c010">n</span>) = <span class="c010">w</span>;
 </em></pre><em>
@@ -985,7 +985,7 @@ illustrates the use of <span class="c004">caml_modify</span>.
 </pre><p>It would be incorrect to perform
 <span class="c004">Field(r, 1) = tail</span> directly, because the allocation of <span class="c004">tail</span>
 has taken place since <span class="c004">r</span> was allocated.</p>
-<h3 class="subsection" id="ss:c-process-pending-actions"><a class="section-anchor" href="#ss:c-process-pending-actions" aria-hidden="true">﻿</a>18.5.3 Pending actions and asynchronous exceptions</h3>
+<h3 class="subsection" id="ss:c-process-pending-actions"><a class="section-anchor" href="#ss:c-process-pending-actions" aria-hidden="true">﻿</a><span class="number">5.3</span>Pending actions and asynchronous exceptions</h3>
 <p>Since 4.10, allocation functions are guaranteed not to call any OCaml
 callbacks from C, including finalisers and signal handlers, and delay
 their execution instead.</p><p>The function <code class="verb">caml_process_pending_actions</code> from
@@ -1007,8 +1007,8 @@ used for clean up before re-raising:</p><pre>    CAMLlocal1(exn);
     }
 </pre><p>
 Correct use of exceptional return, in particular in the presence of
-garbage collection, is further detailed in Section ‍<a href="#ss%3Ac-callbacks">18.7.1</a>.</p>
-<h2 class="section" id="s:c-intf-example"><a class="section-anchor" href="#s:c-intf-example" aria-hidden="true">﻿</a>18.6 A complete example</h2>
+garbage collection, is further detailed in Section&nbsp;<a href="#ss%3Ac-callbacks">18.7.1</a>.</p>
+<h2 class="section" id="s:c-intf-example"><a class="section-anchor" href="#s:c-intf-example" aria-hidden="true">﻿</a><span class="number">6</span>A complete example</h2>
 <p>This section outlines how the functions from the Unix <span class="c004">curses</span> library
 can be made available to OCaml programs. First of all, here is
 the interface <span class="c004">curses.ml</span> that declares the <span class="c004">curses</span> primitives and
@@ -1150,17 +1150,17 @@ let small_window = newwin 10 5 20 10 in
 </pre><p>(On some machines, you may need to put
 <span class="c004">-cclib -lcurses -cclib -ltermcap</span> or <span class="c004">-cclib -ltermcap</span>
 instead of <span class="c004">-cclib -lcurses</span>.)</p>
-<h2 class="section" id="s:c-callback"><a class="section-anchor" href="#s:c-callback" aria-hidden="true">﻿</a>18.7 Advanced topic: callbacks from C to OCaml</h2>
+<h2 class="section" id="s:c-callback"><a class="section-anchor" href="#s:c-callback" aria-hidden="true">﻿</a><span class="number">7</span>Advanced topic: callbacks from C to OCaml</h2>
 <p>So far, we have described how to call C functions from OCaml. In this
 section, we show how C functions can call OCaml functions, either as
 callbacks (OCaml calls C which calls OCaml), or with the main program
 written in C.</p>
-<h3 class="subsection" id="ss:c-callbacks"><a class="section-anchor" href="#ss:c-callbacks" aria-hidden="true">﻿</a>18.7.1 Applying OCaml closures from C</h3>
+<h3 class="subsection" id="ss:c-callbacks"><a class="section-anchor" href="#ss:c-callbacks" aria-hidden="true">﻿</a><span class="number">7.1</span>Applying OCaml closures from C</h3>
 <p>C functions can apply OCaml function values (closures) to OCaml values.
 The following functions are provided to perform the applications:
 </p><ul class="itemize"><li class="li-itemize">
 <span class="c004">caml_callback(</span><span class="c010">f, a</span><span class="c004">)</span> applies the functional value <span class="c010">f</span> to
-the value <span class="c010">a</span> and returns the value returned by ‍<span class="c010">f</span>.
+the value <span class="c010">a</span> and returns the value returned by&nbsp;<span class="c010">f</span>.
 </li><li class="li-itemize"><span class="c004">caml_callback2(</span><span class="c010">f, a, b</span><span class="c004">)</span> applies the functional value <span class="c010">f</span>
 (which is assumed to be a curried OCaml function with two arguments) to
 <span class="c010">a</span> and <span class="c010">b</span>.
@@ -1205,7 +1205,7 @@ can crash since <span class="c010">v</span> does not contain a valid value.</p><
       CAMLreturn (res);
     }
 </pre>
-<h3 class="subsection" id="ss:c-closures"><a class="section-anchor" href="#ss:c-closures" aria-hidden="true">﻿</a>18.7.2 Obtaining or registering OCaml closures for use in C functions</h3>
+<h3 class="subsection" id="ss:c-closures"><a class="section-anchor" href="#ss:c-closures" aria-hidden="true">﻿</a><span class="number">7.2</span>Obtaining or registering OCaml closures for use in C functions</h3>
 <p>There are two ways to obtain OCaml function values (closures) to
 be passed to the <span class="c004">callback</span> functions described above. One way is to
 pass the OCaml function as an argument to a primitive function. For
@@ -1256,7 +1256,7 @@ calls <span class="c004">caml_named_value</span> only once:
         caml_callback(*closure_f, Val_int(arg));
     }
 </pre>
-<h3 class="subsection" id="ss:c-register-exn"><a class="section-anchor" href="#ss:c-register-exn" aria-hidden="true">﻿</a>18.7.3 Registering OCaml exceptions for use in C functions</h3>
+<h3 class="subsection" id="ss:c-register-exn"><a class="section-anchor" href="#ss:c-register-exn" aria-hidden="true">﻿</a><span class="number">7.3</span>Registering OCaml exceptions for use in C functions</h3>
 <p>The registration mechanism described above can also be used to
 communicate exception identifiers from OCaml to C. The OCaml code
 registers the exception by evaluating
@@ -1268,7 +1268,7 @@ exception to register. For example:
 </pre><p>The C code can then recover the exception identifier using
 <span class="c004">caml_named_value</span> and pass it as first argument to the functions
 <span class="c004">raise_constant</span>, <span class="c004">raise_with_arg</span>, and <span class="c004">raise_with_string</span> (described
-in section ‍<a href="#ss%3Ac-exceptions">18.4.5</a>) to actually raise the exception. For
+in section&nbsp;<a href="#ss%3Ac-exceptions">18.4.5</a>) to actually raise the exception. For
 example, here is a C function that raises the <span class="c004">Error</span> exception with
 the given argument:
 </p><pre>    void raise_error(char * msg)
@@ -1276,7 +1276,7 @@ the given argument:
         caml_raise_with_string(*caml_named_value("test exception"), msg);
     }
 </pre>
-<h3 class="subsection" id="ss:main-c"><a class="section-anchor" href="#ss:main-c" aria-hidden="true">﻿</a>18.7.4 Main program in C</h3>
+<h3 class="subsection" id="ss:main-c"><a class="section-anchor" href="#ss:main-c" aria-hidden="true">﻿</a><span class="number">7.4</span>Main program in C</h3>
 <p>In normal operation, a mixed OCaml/C program starts by executing the
 OCaml initialization code, which then may proceed to call C
 functions. We say that the main program is the OCaml code. In some
@@ -1300,16 +1300,16 @@ executes the initialization code of the OCaml program. Typically, this
 initialization code registers callback functions using <span class="c004">Callback.register</span>.
 Once the OCaml initialization code is complete, control returns to the
 C code that called <span class="c004">caml_main</span>.</li><li class="li-itemize">The C code can then invoke OCaml functions using the callback
-mechanism (see section ‍<a href="#ss%3Ac-callbacks">18.7.1</a>).
+mechanism (see section&nbsp;<a href="#ss%3Ac-callbacks">18.7.1</a>).
 </li></ul>
-<h3 class="subsection" id="ss:c-embedded-code"><a class="section-anchor" href="#ss:c-embedded-code" aria-hidden="true">﻿</a>18.7.5 Embedding the OCaml code in the C code</h3>
+<h3 class="subsection" id="ss:c-embedded-code"><a class="section-anchor" href="#ss:c-embedded-code" aria-hidden="true">﻿</a><span class="number">7.5</span>Embedding the OCaml code in the C code</h3>
 <p>The bytecode compiler in custom runtime mode (<span class="c004">ocamlc -custom</span>)
 normally appends the bytecode to the executable file containing the
 custom runtime. This has two consequences. First, the final linking
 step must be performed by <span class="c004">ocamlc</span>. Second, the OCaml runtime library
 must be able to find the name of the executable file from the
 command-line arguments. When using <span class="c004">caml_main(argv)</span> as in
-section ‍<a href="#ss%3Amain-c">18.7.4</a>, this means that <span class="c004">argv[0]</span> or <span class="c004">argv[1]</span> must
+section&nbsp;<a href="#ss%3Amain-c">18.7.4</a>, this means that <span class="c004">argv[0]</span> or <span class="c004">argv[1]</span> must
 contain the executable file name.</p><p>An alternative is to embed the bytecode in the C code. The
 <span class="c004">-output-obj</span> option to <span class="c004">ocamlc</span> is provided for this purpose. It
 causes the <span class="c004">ocamlc</span> compiler to output a C object file (<span class="c004">.o</span> file,
@@ -1388,7 +1388,7 @@ gracefully, which equals the following:
 </p><ul class="itemize"><li class="li-itemize">
 Running the functions that were registered with <span class="c004">Stdlib.at_exit</span>.
 </li><li class="li-itemize">Triggering finalization of allocated custom blocks (see
-section ‍<a href="#s%3Ac-custom">18.9</a>). For example, <span class="c004">Stdlib.in_channel</span> and
+section&nbsp;<a href="#s%3Ac-custom">18.9</a>). For example, <span class="c004">Stdlib.in_channel</span> and
 <span class="c004">Stdlib.out_channel</span> are represented by custom blocks that enclose file
 descriptors, which are to be released.
 </li><li class="li-itemize">Unloading the dependent shared libraries that were loaded by the runtime,
@@ -1407,9 +1407,9 @@ to <span class="c004">caml_shutdown</span> (in a nested fashion). The runtime wi
 there are no outstanding calls to <span class="c004">caml_startup</span>.</p><p>Once a runtime is unloaded, it cannot be started up again without reloading the
 shared library and reinitializing its static data. Therefore, at the moment, the
 facility is only useful for building reloadable shared libraries.</p>
-<h2 class="section" id="s:c-advexample"><a class="section-anchor" href="#s:c-advexample" aria-hidden="true">﻿</a>18.8 Advanced example with callbacks</h2>
+<h2 class="section" id="s:c-advexample"><a class="section-anchor" href="#s:c-advexample" aria-hidden="true">﻿</a><span class="number">8</span>Advanced example with callbacks</h2>
 <p>This section illustrates the callback facilities described in
-section ‍<a href="#s%3Ac-callback">18.7</a>. We are going to package some OCaml functions
+section&nbsp;<a href="#s%3Ac-callback">18.7</a>. We are going to package some OCaml functions
 in such a way that they can be linked with C code and called from C
 just like any C functions. The OCaml functions are defined in the
 following <span class="c004">mod.ml</span> OCaml source:</p><pre>(* File mod.ml -- some "useful" OCaml functions *)
@@ -1480,12 +1480,12 @@ To build the whole program, just invoke the C compiler as follows:
 </p><pre>        cc -o prog -I `ocamlc -where` main.c mod.a -lcurses
 </pre><p>(On some machines, you may need to put <span class="c004">-ltermcap</span> or
 <span class="c004">-lcurses -ltermcap</span> instead of <span class="c004">-lcurses</span>.)</p>
-<h2 class="section" id="s:c-custom"><a class="section-anchor" href="#s:c-custom" aria-hidden="true">﻿</a>18.9 Advanced topic: custom blocks</h2>
+<h2 class="section" id="s:c-custom"><a class="section-anchor" href="#s:c-custom" aria-hidden="true">﻿</a><span class="number">9</span>Advanced topic: custom blocks</h2>
 <p>Blocks with tag <span class="c004">Custom_tag</span> contain both arbitrary user data and a
 pointer to a C struct, with type <span class="c004">struct custom_operations</span>, that
 associates user-provided finalization, comparison, hashing,
 serialization and deserialization functions to this block.</p>
-<h3 class="subsection" id="ss:c-custom-ops"><a class="section-anchor" href="#ss:c-custom-ops" aria-hidden="true">﻿</a>18.9.1 The <span class="c004">struct custom_operations</span></h3>
+<h3 class="subsection" id="ss:c-custom-ops"><a class="section-anchor" href="#ss:c-custom-ops" aria-hidden="true">﻿</a><span class="number">9.1</span>The <span class="c004">struct custom_operations</span></h3>
 <p>The <span class="c004">struct custom_operations</span> is defined in <span class="c004">&lt;caml/custom.h&gt;</span> and
 contains the following fields:
 </p><ul class="itemize"><li class="li-itemize">
@@ -1568,7 +1568,7 @@ garbage collection. Within these functions, do not call any of the
 OCaml allocation functions, and do not perform a callback into OCaml
 code. Do not use <span class="c004">CAMLparam</span> to register the parameters to these
 functions, and do not use <span class="c004">CAMLreturn</span> to return the result.</p>
-<h3 class="subsection" id="ss:c-custom-alloc"><a class="section-anchor" href="#ss:c-custom-alloc" aria-hidden="true">﻿</a>18.9.2 Allocating custom blocks</h3>
+<h3 class="subsection" id="ss:c-custom-alloc"><a class="section-anchor" href="#ss:c-custom-alloc" aria-hidden="true">﻿</a><span class="number">9.2</span>Allocating custom blocks</h3>
 <p>Custom blocks must be allocated via <span class="c004">caml_alloc_custom</span> or
 <span class="c004">caml_alloc_custom_mem</span>:
 </p><div class="center">
@@ -1619,7 +1619,7 @@ memory that are held by your custom block. This function works like
 control of the user (via the <span class="c004">custom_major_ratio</span>,
 <span class="c004">custom_minor_ratio</span>, and <span class="c004">custom_minor_max_size</span> parameters) and
 proportional to the heap sizes.</p>
-<h3 class="subsection" id="ss:c-custom-access"><a class="section-anchor" href="#ss:c-custom-access" aria-hidden="true">﻿</a>18.9.3 Accessing custom blocks</h3>
+<h3 class="subsection" id="ss:c-custom-access"><a class="section-anchor" href="#ss:c-custom-access" aria-hidden="true">﻿</a><span class="number">9.3</span>Accessing custom blocks</h3>
 <p>The data part of a custom block <span class="c010">v</span> can be
 accessed via the pointer <span class="c004">Data_custom_val(</span><span class="c010">v</span><span class="c004">)</span>. This pointer
 has type <span class="c004">void *</span> and should be cast to the actual type of the data
@@ -1629,7 +1629,7 @@ heap. In other terms, never store an OCaml <span class="c004">value</span> in a 
 and do not use <span class="c004">Field</span>, <span class="c004">Store_field</span> nor <span class="c004">caml_modify</span> to access the data
 part of a custom block. Conversely, any C data structure (not
 containing heap pointers) can be stored in a custom block.</p>
-<h3 class="subsection" id="ss:c-custom-serialization"><a class="section-anchor" href="#ss:c-custom-serialization" aria-hidden="true">﻿</a>18.9.4 Writing custom serialization and deserialization functions</h3>
+<h3 class="subsection" id="ss:c-custom-serialization"><a class="section-anchor" href="#ss:c-custom-serialization" aria-hidden="true">﻿</a><span class="number">9.4</span>Writing custom serialization and deserialization functions</h3>
 <p>The following functions, defined in <span class="c004">&lt;caml/intext.h&gt;</span>, are provided to
 write and read back the contents of custom blocks in a portable way.
 Those functions handle endianness conversions when e.g. data is
@@ -1674,7 +1674,7 @@ reading the identifier off the input stream, allocating a custom block
 of the size specified in the input stream, searching the registered
 <span class="c004">struct custom_operation</span> blocks for one with the same identifier, and
 calling its <span class="c004">deserialize</span> function to fill the data part of the custom block.</p>
-<h3 class="subsection" id="ss:c-custom-idents"><a class="section-anchor" href="#ss:c-custom-idents" aria-hidden="true">﻿</a>18.9.5 Choosing identifiers</h3>
+<h3 class="subsection" id="ss:c-custom-idents"><a class="section-anchor" href="#ss:c-custom-idents" aria-hidden="true">﻿</a><span class="number">9.5</span>Choosing identifiers</h3>
 <p>Identifiers in <span class="c004">struct custom_operations</span> must be chosen carefully,
 since they must identify uniquely the data structure for serialization
 and deserialization operations. In particular, consider including a
@@ -1687,7 +1687,7 @@ data. We recommend to use a URL
 or a Java-style package name
 (<span class="c004">com.mydomain.mymachine.mylibrary.version-number</span>)
 as identifiers, to minimize the risk of identifier collision.</p>
-<h3 class="subsection" id="ss:c-finalized"><a class="section-anchor" href="#ss:c-finalized" aria-hidden="true">﻿</a>18.9.6 Finalized blocks</h3>
+<h3 class="subsection" id="ss:c-finalized"><a class="section-anchor" href="#ss:c-finalized" aria-hidden="true">﻿</a><span class="number">9.6</span>Finalized blocks</h3>
 <p>Custom blocks generalize the finalized blocks that were present in
 OCaml prior to version 3.00. For backward compatibility, the
 format of custom blocks is compatible with that of finalized blocks,
@@ -1699,14 +1699,14 @@ word is reserved for storing the custom operations; the other
 <span class="c010">n</span> words are available for your data. The two parameters
 <span class="c010">used</span> and <span class="c010">max</span> are used to control the speed of garbage
 collection, as described for <span class="c004">caml_alloc_custom</span>.</p>
-<h2 class="section" id="s:C-Bigarrays"><a class="section-anchor" href="#s:C-Bigarrays" aria-hidden="true">﻿</a>18.10 Advanced topic: Bigarrays and the OCaml-C interface</h2>
+<h2 class="section" id="s:C-Bigarrays"><a class="section-anchor" href="#s:C-Bigarrays" aria-hidden="true">﻿</a><span class="number">10</span>Advanced topic: Bigarrays and the OCaml-C interface</h2>
 <p>This section explains how C stub code that interfaces C or Fortran
 code with OCaml code can use Bigarrays.</p>
-<h3 class="subsection" id="ss:C-Bigarrays-include"><a class="section-anchor" href="#ss:C-Bigarrays-include" aria-hidden="true">﻿</a>18.10.1 Include file</h3>
+<h3 class="subsection" id="ss:C-Bigarrays-include"><a class="section-anchor" href="#ss:C-Bigarrays-include" aria-hidden="true">﻿</a><span class="number">10.1</span>Include file</h3>
 <p>The include file <span class="c004">&lt;caml/bigarray.h&gt;</span> must be included in the C stub
 file. It declares the functions, constants and macros discussed
 below.</p>
-<h3 class="subsection" id="ss:C-Bigarrays-access"><a class="section-anchor" href="#ss:C-Bigarrays-access" aria-hidden="true">﻿</a>18.10.2 Accessing an OCaml bigarray from C or Fortran</h3>
+<h3 class="subsection" id="ss:C-Bigarrays-access"><a class="section-anchor" href="#ss:C-Bigarrays-access" aria-hidden="true">﻿</a><span class="number">10.2</span>Accessing an OCaml bigarray from C or Fortran</h3>
 <p>If <span class="c010">v</span> is a OCaml <span class="c004">value</span> representing a Bigarray, the expression
 <span class="c004">Caml_ba_data_val(</span><span class="c010">v</span><span class="c004">)</span> returns a pointer to the data part of the array.
 This pointer is of type <span class="c004">void *</span> and can be cast to the appropriate C
@@ -1756,7 +1756,7 @@ to a C function and a Fortran function.
       return Val_unit;
     }
 </pre>
-<h3 class="subsection" id="ss:C-Bigarrays-wrap"><a class="section-anchor" href="#ss:C-Bigarrays-wrap" aria-hidden="true">﻿</a>18.10.3 Wrapping a C or Fortran array as an OCaml Bigarray</h3>
+<h3 class="subsection" id="ss:C-Bigarrays-wrap"><a class="section-anchor" href="#ss:C-Bigarrays-wrap" aria-hidden="true">﻿</a><span class="number">10.3</span>Wrapping a C or Fortran array as an OCaml Bigarray</h3>
 <p>A pointer <span class="c010">p</span> to an already-allocated C or Fortran array can be
 wrapped and returned to OCaml as a Bigarray using the <span class="c004">caml_ba_alloc</span>
 or <span class="c004">caml_ba_alloc_dims</span> functions.
@@ -1791,11 +1791,11 @@ Fortran arrays can be made available to OCaml.
                                 2, my_fortran_array_, 300L, 400L);
     }
 </pre>
-<h2 class="section" id="s:C-cheaper-call"><a class="section-anchor" href="#s:C-cheaper-call" aria-hidden="true">﻿</a>18.11 Advanced topic: cheaper C call</h2>
+<h2 class="section" id="s:C-cheaper-call"><a class="section-anchor" href="#s:C-cheaper-call" aria-hidden="true">﻿</a><span class="number">11</span>Advanced topic: cheaper C call</h2>
 <p>This section describe how to make calling C functions cheaper.</p><p><span class="c014">Note:</span> this only applies to the native compiler. So whenever you
 use any of these methods, you have to provide an alternative byte-code
 stub that ignores all the special annotations.</p>
-<h3 class="subsection" id="ss:c-unboxed"><a class="section-anchor" href="#ss:c-unboxed" aria-hidden="true">﻿</a>18.11.1 Passing unboxed values</h3>
+<h3 class="subsection" id="ss:c-unboxed"><a class="section-anchor" href="#ss:c-unboxed" aria-hidden="true">﻿</a><span class="number">11.1</span>Passing unboxed values</h3>
 <p>We said earlier that all OCaml objects are represented by the C type
 <span class="c004">value</span>, and one has to use macros such as <span class="c004">Int_val</span> to decode data from
 the <span class="c004">value</span> type. It is however possible to tell the OCaml native-code
@@ -1850,21 +1850,21 @@ OCaml and C. This is done by annotating the arguments and/or result
 with <span class="c004">[@untagged]</span>:</p><pre>external f : string -&gt; (int [@untagged]) = "f_byte" "f"
 </pre><p>
 The corresponding C type must be <span class="c004">intnat</span>.</p><p><span class="c014">Note:</span> do not use the C <span class="c004">int</span> type in correspondence with <span class="c004">(int [@untagged])</span>. This is because they often differ in size.</p>
-<h3 class="subsection" id="ss:c-direct-call"><a class="section-anchor" href="#ss:c-direct-call" aria-hidden="true">﻿</a>18.11.2 Direct C call</h3>
+<h3 class="subsection" id="ss:c-direct-call"><a class="section-anchor" href="#ss:c-direct-call" aria-hidden="true">﻿</a><span class="number">11.2</span>Direct C call</h3>
 <p>In order to be able to run the garbage collector in the middle of
 a C function, the OCaml native-code compiler generates some bookkeeping
 code around C calls. Technically it wraps every C call with the C function
 <span class="c004">caml_c_call</span> which is part of the OCaml runtime.</p><p>For small functions that are called repeatedly, this indirection can have
 a big impact on performances. However this is not needed if we know that
 the C function doesn’t allocate, doesn’t raise exceptions, and doesn’t release
-the master lock (see section ‍<a href="#ss%3Aparallel-execution-long-running-c-code">18.12.2</a>). 
+the master lock (see section&nbsp;<a href="#ss%3Aparallel-execution-long-running-c-code">18.12.2</a>). 
 We can instruct the OCaml native-code compiler of this fact by annotating the
 external declaration with the attribute <span class="c004">[@@noalloc]</span>:</p><pre>external bar : int -&gt; int -&gt; int = "foo" [@@noalloc]
 </pre><p>
 In this case calling <span class="c004">bar</span> from OCaml is as cheap as calling any other
 OCaml function, except for the fact that the OCaml compiler can’t
 inline C functions...</p>
-<h3 class="subsection" id="ss:c-direct-call-example"><a class="section-anchor" href="#ss:c-direct-call-example" aria-hidden="true">﻿</a>18.11.3 Example: calling C library functions without indirection</h3>
+<h3 class="subsection" id="ss:c-direct-call-example"><a class="section-anchor" href="#ss:c-direct-call-example" aria-hidden="true">﻿</a><span class="number">11.3</span>Example: calling C library functions without indirection</h3>
 <p>Using these attributes, it is possible to call C library functions
 with no indirection. For instance many math functions are defined this
 way in the OCaml standard library:</p><pre>external sqrt : float -&gt; float = "caml_sqrt_float" "sqrt"
@@ -1877,11 +1877,11 @@ external exp : float -&gt; float = "caml_exp_float" "exp" [@@unboxed] [@@noalloc
 external log : float -&gt; float = "caml_log_float" "log" [@@unboxed] [@@noalloc]
 (** Natural logarithm. *)
 </pre>
-<h2 class="section" id="s:C-multithreading"><a class="section-anchor" href="#s:C-multithreading" aria-hidden="true">﻿</a>18.12 Advanced topic: multithreading</h2>
+<h2 class="section" id="s:C-multithreading"><a class="section-anchor" href="#s:C-multithreading" aria-hidden="true">﻿</a><span class="number">12</span>Advanced topic: multithreading</h2>
 <p>Using multiple threads (shared-memory concurrency) in a mixed OCaml/C
 application requires special precautions, which are described in this
 section.</p>
-<h3 class="subsection" id="ss:c-thread-register"><a class="section-anchor" href="#ss:c-thread-register" aria-hidden="true">﻿</a>18.12.1 Registering threads created from C</h3>
+<h3 class="subsection" id="ss:c-thread-register"><a class="section-anchor" href="#ss:c-thread-register" aria-hidden="true">﻿</a><span class="number">12.1</span>Registering threads created from C</h3>
 <p>Callbacks from C to OCaml are possible only if the calling thread is
 known to the OCaml run-time system. Threads created from OCaml (through
 the <span class="c004">Thread.create</span> function of the system threads library) are
@@ -1898,7 +1898,7 @@ terminates, to unregister it from the OCaml run-time system.
 Returns 1 on success, 0 on error. If the calling thread was not
 previously registered, does nothing and returns 0.
 </li></ul>
-<h3 class="subsection" id="ss:parallel-execution-long-running-c-code"><a class="section-anchor" href="#ss:parallel-execution-long-running-c-code" aria-hidden="true">﻿</a>18.12.2 Parallel execution of long-running C code</h3>
+<h3 class="subsection" id="ss:parallel-execution-long-running-c-code"><a class="section-anchor" href="#ss:parallel-execution-long-running-c-code" aria-hidden="true">﻿</a><span class="number">12.2</span>Parallel execution of long-running C code</h3>
 <p>The OCaml run-time system is not reentrant: at any time, at most one
 thread can be executing OCaml code or C code that uses the OCaml
 run-time system. Technically, this is enforced by a “master lock”
@@ -1920,7 +1920,7 @@ The calling thread re-acquires the master lock and other OCaml
 resources. It may block until no other thread uses the OCaml run-time
 system.
 </li></ul><p>These functions poll for pending signals by calling asynchronous
-callbacks (section ‍<a href="#ss%3Ac-process-pending-actions">18.5.3</a>) before releasing and
+callbacks (section&nbsp;<a href="#ss%3Ac-process-pending-actions">18.5.3</a>) before releasing and
 after acquiring the lock. They can therefore execute arbitrary OCaml
 code including raising an asynchronous exception.</p><p>After <span class="c004">caml_release_runtime_system()</span> was called and until
 <span class="c004">caml_acquire_runtime_system()</span> is called, the C code must not access
@@ -1984,7 +1984,7 @@ names, declared in <span class="c004">&lt;caml/signals.h&gt;</span>:
 </li></ul><p>
 Intuition: a “blocking section” is a piece of C code that does not
 use the OCaml run-time system, typically a blocking input/output operation.</p>
-<h2 class="section" id="s:interfacing-windows-unicode-apis"><a class="section-anchor" href="#s:interfacing-windows-unicode-apis" aria-hidden="true">﻿</a>18.13 Advanced topic: interfacing with Windows Unicode APIs</h2>
+<h2 class="section" id="s:interfacing-windows-unicode-apis"><a class="section-anchor" href="#s:interfacing-windows-unicode-apis" aria-hidden="true">﻿</a><span class="number">13</span>Advanced topic: interfacing with Windows Unicode APIs</h2>
 <p>This section contains some general guidelines for writing C stubs that use
 Windows Unicode APIs.</p><p><span class="c014">Note:</span> This is an experimental feature of OCaml: the set of APIs below, as
 well as their exact semantics are not final and subject to change in future
@@ -2068,7 +2068,7 @@ CAMLprim value stub_getenv(value var_name)
   CAMLreturn(var_value);
 }
 </pre>
-<h2 class="section" id="s:ocamlmklib"><a class="section-anchor" href="#s:ocamlmklib" aria-hidden="true">﻿</a>18.14 Building mixed C/OCaml libraries: <span class="c004">ocamlmklib</span></h2>
+<h2 class="section" id="s:ocamlmklib"><a class="section-anchor" href="#s:ocamlmklib" aria-hidden="true">﻿</a><span class="number">14</span>Building mixed C/OCaml libraries: <span class="c004">ocamlmklib</span></h2>
 <p>The <span class="c004">ocamlmklib</span> command facilitates the construction of libraries
 containing both OCaml code and C code, and usable both in static
 linking and dynamic linking modes. This command is available under
@@ -2162,7 +2162,7 @@ support libraries (<span class="c004">-lz</span>) and the corresponding options
 (<span class="c004">-L/usr/local/zlib</span>) must be given on all three invocations of <span class="c004">ocamlmklib</span>,
 because they are needed at different times depending on whether shared
 libraries are supported.</p>
-<h2 class="section" id="s:c-internal-guidelines"><a class="section-anchor" href="#s:c-internal-guidelines" aria-hidden="true">﻿</a>18.15 Cautionary words: the internal runtime API</h2>
+<h2 class="section" id="s:c-internal-guidelines"><a class="section-anchor" href="#s:c-internal-guidelines" aria-hidden="true">﻿</a><span class="number">15</span>Cautionary words: the internal runtime API</h2>
 <p>Not all header available in the <span class="c004">caml/</span> directory were described in previous
 sections. All those unmentioned headers are part of the internal runtime API,
 for which there is <em>no</em> stability guarantee. If you really need access
@@ -2174,7 +2174,7 @@ of OCaml.
 <p> Programmers which come to rely on the internal API
 for a use-case which they find realistic and useful are encouraged to open
 a request for improvement on the bug tracker.</p>
-<h3 class="subsection" id="ss:c-internals"><a class="section-anchor" href="#ss:c-internals" aria-hidden="true">﻿</a>18.15.1 Internal variables and CAML_INTERNALS</h3>
+<h3 class="subsection" id="ss:c-internals"><a class="section-anchor" href="#ss:c-internals" aria-hidden="true">﻿</a><span class="number">15.1</span>Internal variables and CAML_INTERNALS</h3>
 <p>
 Since OCaml 4.04, it is possible to get access to every part of the internal
 runtime API by defining the <span class="c004">CAML_INTERNALS</span> macro before loading caml header files.
@@ -2188,7 +2188,7 @@ at some point in time.</p><p>For instance, rather than redefining <span class="c
 </pre><p>which breaks in OCaml ≥ 4.10, you should include the <span class="c004">minor_gc</span> header:
 </p><pre>#include &lt;caml/minor_gc.h&gt;
 </pre>
-<h3 class="subsection" id="ss:c-internal-macros"><a class="section-anchor" href="#ss:c-internal-macros" aria-hidden="true">﻿</a>18.15.2 OCaml version macros</h3>
+<h3 class="subsection" id="ss:c-internal-macros"><a class="section-anchor" href="#ss:c-internal-macros" aria-hidden="true">﻿</a><span class="number">15.2</span>OCaml version macros</h3>
 <p>
 Finally, if including the right headers is not enough, or if you need to support
 version older than OCaml 4.04, the header file <span class="c004">caml/version.h</span> should help
@@ -2206,7 +2206,7 @@ you could write
 #endif
 </pre>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="profil.html">« Chapter ‍17 Profiling (ocamlprof)</a><a class="next" href="flambda.html">Chapter ‍19 Optimisation with Flambda »</a></div>
+<div class="bottom-navigation"><a class="previous" href="profil.html">« Profiling (ocamlprof)</a><a class="next" href="flambda.html">Optimisation with Flambda »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/lablexamples.html
+++ b/site/releases/4.12/htmlman/lablexamples.html
@@ -5,25 +5,25 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍4 Labels and variants</title>
+<title>OCaml - Labels and variants</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍I An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">Chapter ‍1 The core language</a></li><li><a href="moduleexamples.html">Chapter ‍2 The module system</a></li><li><a href="objectexamples.html">Chapter ‍3 Objects in OCaml</a></li><li class="active"><a href="lablexamples.html">Chapter ‍4 Labels and variants</a></li><li><a href="polymorphism.html">Chapter ‍5 Polymorphism and its limitations</a></li><li><a href="advexamples.html">Chapter ‍6 Advanced examples with classes and modules</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li class="active"><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a></li><li><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec44">Chapter ‍4 Labels and variants</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍4 Labels and variants</a></li>
-<li><a href="lablexamples.html#s%3Alabels">4.1 Labels</a>
-</li><li><a href="lablexamples.html#s%3Apolymorphic-variants">4.2 Polymorphic variants</a>
+<h1 class="chapter" id="sec44"><span class="number">Chapter 4</span>Labels and variants</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Labels and variants</a></li>
+<li><a href="lablexamples.html#s%3Alabels"><span class="number">1</span>Labels</a>
+</li><li><a href="lablexamples.html#s%3Apolymorphic-variants"><span class="number">2</span>Polymorphic variants</a>
 </li></ul></nav></header>
 <p> <a id="c:labl-examples"></a>
 </p><p>
-<span class="c010">(Chapter written by Jacques Garrigue)</span></p><p><br>
+</p><p><br>
 <br>
 </p><p>This chapter gives an overview of the new features in
 OCaml 3: labels, and polymorphic variants.</p>
-<h2 class="section" id="s:labels"><a class="section-anchor" href="#s:labels" aria-hidden="true"></a>4.1 Labels</h2>
+<h2 class="section" id="s:labels"><a class="section-anchor" href="#s:labels" aria-hidden="true"></a><span class="number">1</span>Labels</h2>
 <p>If you have a look at modules ending in <span class="c004">Labels</span> in the standard
 library, you will see that function types have annotations you did not
 have in the functions you defined yourself.</p><div class="caml-example toplevel">
@@ -270,7 +270,7 @@ pattern, but you must prefix it with the label.
 <div class="pre caml-output ok">- : int = 3</div></div>
 
 </div>
-<h3 class="subsection" id="ss:optional-arguments"><a class="section-anchor" href="#ss:optional-arguments" aria-hidden="true">﻿</a>4.1.1 Optional arguments</h3>
+<h3 class="subsection" id="ss:optional-arguments"><a class="section-anchor" href="#ss:optional-arguments" aria-hidden="true">﻿</a><span class="number">1.1</span>Optional arguments</h3>
 <p>An interesting feature of labeled arguments is that they can be made
 optional. For optional parameters, the question mark <span class="c004">?</span> replaces the
 tilde <span class="c004">~</span> of non-optional ones, and the label is also prefixed by <span class="c004">?</span>
@@ -426,7 +426,7 @@ argument in an option type.</p><div class="caml-example toplevel">
 <div class="pre caml-output ok">- : ?y:int -&gt; unit -&gt; int * int * int = &lt;<span class="ocamlkeyword">fun</span>&gt;</div></div>
 
 </div>
-<h3 class="subsection" id="ss:label-inference"><a class="section-anchor" href="#ss:label-inference" aria-hidden="true">﻿</a>4.1.2 Labels and type inference</h3>
+<h3 class="subsection" id="ss:label-inference"><a class="section-anchor" href="#ss:label-inference" aria-hidden="true">﻿</a><span class="number">1.2</span>Labels and type inference</h3>
 <p>While they provide an increased comfort for writing function
 applications, labels and optional arguments have the pitfall that they
 cannot be inferred as completely as the rest of the language.</p><p>You can see it in the following two examples.
@@ -551,7 +551,7 @@ parameters.</p><div class="caml-example toplevel">
 including side-effects. That is, if the application of optional
 parameters shall produce side-effects, these are delayed until the
 received function is really applied to an argument.</p>
-<h3 class="subsection" id="ss:label-suggestions"><a class="section-anchor" href="#ss:label-suggestions" aria-hidden="true">﻿</a>4.1.3 Suggestions for labeling</h3>
+<h3 class="subsection" id="ss:label-suggestions"><a class="section-anchor" href="#ss:label-suggestions" aria-hidden="true">﻿</a><span class="number">1.3</span>Suggestions for labeling</h3>
 <p>Like for names, choosing labels for functions is not an easy task. A
 good labeling is a labeling which</p><ul class="itemize"><li class="li-itemize">
 makes programs more readable,
@@ -603,8 +603,8 @@ make the program harder to maintain.</p><p>In the ideal, the right function name
 enough to understand the function’s meaning. Since one can get this
 information with OCamlBrowser or the <span class="c004">ocaml</span> toplevel, the documentation
 is only used when a more detailed specification is needed.</p>
-<h2 class="section" id="s:polymorphic-variants"><a class="section-anchor" href="#s:polymorphic-variants" aria-hidden="true">﻿</a>4.2 Polymorphic variants</h2>
-<p>Variants as presented in section ‍<a href="coreexamples.html#s%3Atut-recvariants">1.4</a> are a
+<h2 class="section" id="s:polymorphic-variants"><a class="section-anchor" href="#s:polymorphic-variants" aria-hidden="true">﻿</a><span class="number">2</span>Polymorphic variants</h2>
+<p>Variants as presented in section&nbsp;<a href="coreexamples.html#s%3Atut-recvariants">1.4</a> are a
 powerful tool to build data structures and algorithms. However they
 sometimes lack flexibility when used in modular programming. This is
 due to the fact that every constructor is assigned to a unique type
@@ -906,7 +906,7 @@ or combined with with aliases.
 <div class="pre caml-output ok"><span class="ocamlkeyword">val</span> g : [&lt; `Tag1 <span class="ocamlkeyword">of</span> int | `Tag2 <span class="ocamlkeyword">of</span> bool | `Tag3 ] -&gt; string = &lt;<span class="ocamlkeyword">fun</span>&gt;</div></div>
 
 </div>
-<h3 class="subsection" id="ss:polyvariant-weaknesses"><a class="section-anchor" href="#ss:polyvariant-weaknesses" aria-hidden="true">﻿</a>4.2.1 Weaknesses of polymorphic variants</h3>
+<h3 class="subsection" id="ss:polyvariant-weaknesses"><a class="section-anchor" href="#ss:polyvariant-weaknesses" aria-hidden="true">﻿</a><span class="number">2.1</span>Weaknesses of polymorphic variants</h3>
 <p>After seeing the power of polymorphic variants, one may wonder why
 they were added to core language variants, rather than replacing them.</p><p>The answer is twofold. One first aspect is that while being pretty
 efficient, the lack of static type information allows for less
@@ -983,10 +983,10 @@ of Objective Caml 3.00 through 3.02, with some additional flexibility
 on total applications. The so-called classic mode (<span class="c004">-nolabels</span>
 options) is now deprecated for normal use.</div></dd></dl>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="objectexamples.html">« Chapter ‍3 Objects in OCaml</a><a class="next" href="polymorphism.html">Chapter ‍5 Polymorphism and its limitations »</a></div>
+<div class="bottom-navigation"><a class="previous" href="objectexamples.html">« Objects in OCaml</a><a class="next" href="polymorphism.html">Polymorphism and its limitations »</a></div>
 
 
 
 
-<div class="copyright">Copyright © 2021 Institut National de
+<span class="authors c010">(Chapter written by Jacques Garrigue)</span><div class="copyright">Copyright © 2021 Institut National de
 Recherche en Informatique et en Automatique</div></div></body></html>

--- a/site/releases/4.12/htmlman/language.html
+++ b/site/releases/4.12/htmlman/language.html
@@ -5,14 +5,14 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1>
 <p> <a id="c:refman"></a>
 </p><h3 class="subsection" id="ss:foreword"><a class="section-anchor" href="#ss:foreword" aria-hidden="true"></a>Foreword</h3>
 <p>This document is intended as a reference manual for the OCaml
@@ -31,36 +31,36 @@ Square brackets […] denote optional components. Curly brackets
 {…} denotes zero, one or several repetitions of the enclosed
 components. Curly brackets with a trailing plus sign {…}<sup>+</sup>
 denote one or several repetitions of the enclosed components.
-Parentheses (…) denote grouping.</p><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html">7.1 Lexical conventions</a>
-</li><li><a href="values.html">7.2 Values</a>
-</li><li><a href="names.html">7.3 Names</a>
-</li><li><a href="types.html">7.4 Type expressions</a>
-</li><li><a href="const.html">7.5 Constants</a>
-</li><li><a href="patterns.html">7.6 Patterns</a>
-</li><li><a href="expr.html">7.7 Expressions</a>
-</li><li><a href="typedecl.html">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html">7.9 Classes</a>
-</li><li><a href="modtypes.html">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html">7.12 Compilation units</a>
+Parentheses (…) denote grouping.</p><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html"><span class="number">2</span>Values</a>
+</li><li><a href="names.html"><span class="number">3</span>Names</a>
+</li><li><a href="types.html"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><ul class="ul-content">
-<li><a href="lex.html">7.1 Lexical conventions</a>
-</li><li><a href="values.html">7.2 Values</a>
-</li><li><a href="names.html">7.3 Names</a>
-</li><li><a href="types.html">7.4 Type expressions</a>
-</li><li><a href="const.html">7.5 Constants</a>
-</li><li><a href="patterns.html">7.6 Patterns</a>
-</li><li><a href="expr.html">7.7 Expressions</a>
-</li><li><a href="typedecl.html">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html">7.9 Classes</a>
-</li><li><a href="modtypes.html">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html">7.12 Compilation units</a>
+<li><a href="lex.html"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html"><span class="number">2</span>Values</a>
+</li><li><a href="names.html"><span class="number">3</span>Names</a>
+</li><li><a href="types.html"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html"><span class="number">12</span>Compilation units</a>
 </li></ul>
 
 <hr>
-<div class="bottom-navigation"><a class="previous" href="advexamples.html">« Chapter ‍6 Advanced examples with classes and modules</a><a class="next" href="extn.html">Chapter ‍8 Language extensions »</a></div>
+<div class="bottom-navigation"><a class="previous" href="advexamples.html">« Advanced examples with classes and modules</a><a class="next" href="extn.html">Language extensions »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/letrecvalues.html
+++ b/site/releases/4.12/htmlman/letrecvalues.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
-<h2 class="section" id="s:letrecvalues"><a class="section-anchor" href="#s:letrecvalues" aria-hidden="true"></a>8.1 Recursive definitions of values</h2>
-<p>(Introduced in Objective Caml 1.00)</p><p>As mentioned in section ‍<a href="expr.html#sss%3Aexpr-localdef">7.7.2</a>, the <span class="c003"><span class="c004">let</span> <span class="c004">rec</span></span> binding
+<h2 class="section" id="s:letrecvalues"><a class="section-anchor" href="#s:letrecvalues" aria-hidden="true"></a><span class="number">1</span>Recursive definitions of values</h2>
+<p>(Introduced in Objective Caml 1.00)</p><p>As mentioned in section&nbsp;<a href="expr.html#sss%3Aexpr-localdef">7.7.2</a>, the <span class="c003"><span class="c004">let</span> <span class="c004">rec</span></span> binding
 construct, in addition to the definition of recursive functions,
 also supports a certain class of recursive definitions of
 non-functional values, such as
@@ -99,7 +99,7 @@ linked to <span class="c011">name</span> or to one of the <span class="c011">xna
 is immediately linked to <span class="c011">name</span>.
 </li></ul>
 
-<div class="bottom-navigation"><a class="previous up" href="extn.html">Chapter ‍8 Language extensions</a><a class="next" href="manual024.html">8.2 Recursive modules »</a></div>
+<div class="bottom-navigation"><a class="previous up" href="extn.html">Language extensions</a><a class="next" href="manual024.html">Recursive modules »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/lex.html
+++ b/site/releases/4.12/htmlman/lex.html
@@ -5,31 +5,31 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
-<h2 class="section" id="s:lexical-conventions"><a class="section-anchor" href="#s:lexical-conventions" aria-hidden="true"></a>7.1 Lexical conventions</h2>
+<h2 class="section" id="s:lexical-conventions"><a class="section-anchor" href="#s:lexical-conventions" aria-hidden="true"></a><span class="number">1</span>Lexical conventions</h2>
 <h4 class="subsubsection" id="sss:lex:blanks"><a class="section-anchor" href="#sss:lex:blanks" aria-hidden="true">﻿</a>Blanks</h4>
 <p>The following characters are considered as blanks: space,
 horizontal tabulation, carriage return, line feed and form feed. Blanks are
@@ -212,7 +212,7 @@ escape sequence.</p><p>A Unicode character escape sequence is substituted by the
 encoding of the specified Unicode scalar value. The Unicode scalar
 value, an integer in the ranges 0x0000...0xD7FF or 0xE000...0x10FFFF,
 is defined using 1 to 6 hexadecimal digits; leading zeros are allowed.</p><p>To allow splitting long string literals across lines, the sequence
-<span class="c004">\</span><span class="c010">newline</span> ‍<span class="c010">spaces-or-tabs</span> (a backslash at the end of a line
+<span class="c004">\</span><span class="c010">newline</span>&nbsp;<span class="c010">spaces-or-tabs</span> (a backslash at the end of a line
 followed by any number of spaces and horizontal tabulations at the
 beginning of the next line) is ignored inside string literals.</p><p>Quoted string literals provide an alternative lexical syntax for
 string literals. They are useful to represent strings of arbitrary content
@@ -323,7 +323,7 @@ character string (the source file name).
 Line number directives are treated as blanks during lexical
 analysis.</p>
 
-<div class="bottom-navigation"><a class="previous up" href="language.html">Chapter ‍7 The OCaml language</a><a class="next" href="values.html">7.2 Values »</a></div>
+<div class="bottom-navigation"><a class="previous up" href="language.html">The OCaml language</a><a class="next" href="values.html">Values »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/lexyacc.html
+++ b/site/releases/4.12/htmlman/lexyacc.html
@@ -5,22 +5,22 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</title>
+<title>OCaml - Lexer and parser generators (ocamllex, ocamlyacc)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li class="active"><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li class="active"><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec320">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li>
-<li><a href="lexyacc.html#s%3Aocamllex-overview">13.1 Overview of <span class="c004">ocamllex</span></a>
-</li><li><a href="lexyacc.html#s%3Aocamllex-syntax">13.2 Syntax of lexer definitions</a>
-</li><li><a href="lexyacc.html#s%3Aocamlyacc-overview">13.3 Overview of <span class="c004">ocamlyacc</span></a>
-</li><li><a href="lexyacc.html#s%3Aocamlyacc-syntax">13.4 Syntax of grammar definitions</a>
-</li><li><a href="lexyacc.html#s%3Aocamlyacc-options">13.5 Options</a>
-</li><li><a href="lexyacc.html#s%3Alexyacc-example">13.6 A complete example</a>
-</li><li><a href="lexyacc.html#s%3Alexyacc-common-errors">13.7 Common errors</a>
+<h1 class="chapter" id="sec320"><span class="number">Chapter 13</span>Lexer and parser generators (ocamllex, ocamlyacc)</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Lexer and parser generators (ocamllex, ocamlyacc)</a></li>
+<li><a href="lexyacc.html#s%3Aocamllex-overview"><span class="number">1</span>Overview of <span class="c004">ocamllex</span></a>
+</li><li><a href="lexyacc.html#s%3Aocamllex-syntax"><span class="number">2</span>Syntax of lexer definitions</a>
+</li><li><a href="lexyacc.html#s%3Aocamlyacc-overview"><span class="number">3</span>Overview of <span class="c004">ocamlyacc</span></a>
+</li><li><a href="lexyacc.html#s%3Aocamlyacc-syntax"><span class="number">4</span>Syntax of grammar definitions</a>
+</li><li><a href="lexyacc.html#s%3Aocamlyacc-options"><span class="number">5</span>Options</a>
+</li><li><a href="lexyacc.html#s%3Alexyacc-example"><span class="number">6</span>A complete example</a>
+</li><li><a href="lexyacc.html#s%3Alexyacc-common-errors"><span class="number">7</span>Common errors</a>
 </li></ul></nav></header>
 <p>
 <a id="c:ocamlyacc"></a>
@@ -37,7 +37,7 @@ unfamiliar with <span class="c004">lex</span> and <span class="c004">yacc</span>
 principles, techniques, and tools” by Aho, Sethi and Ullman
 (Addison-Wesley, 1986), or “Lex &amp; Yacc”, by Levine, Mason and
 Brown (O’Reilly, 1992).</p>
-<h2 class="section" id="s:ocamllex-overview"><a class="section-anchor" href="#s:ocamllex-overview" aria-hidden="true"></a>13.1 Overview of <span class="c004">ocamllex</span></h2>
+<h2 class="section" id="s:ocamllex-overview"><a class="section-anchor" href="#s:ocamllex-overview" aria-hidden="true"></a><span class="number">1</span>Overview of <span class="c004">ocamllex</span></h2>
 <p>The <span class="c004">ocamllex</span> command produces a lexical analyzer from a set of regular
 expressions with attached semantic actions, in the style of
 <span class="c004">lex</span>. Assuming the input file is <span class="c010">lexer</span><span class="c004">.mll</span>, executing
@@ -52,11 +52,11 @@ library module <span class="c004">Lexing</span>. The functions <span class="c004
 <span class="c004">Lexing.from_string</span> and <span class="c004">Lexing.from_function</span> create
 lexer buffers that read from an input channel, a character string, or
 any reading function, respectively. (See the description of module
-<span class="c004">Lexing</span> in chapter ‍<a href="stdlib.html#c%3Astdlib">23</a>.)</p><p>When used in conjunction with a parser generated by <span class="c004">ocamlyacc</span>, the
+<span class="c004">Lexing</span> in chapter&nbsp;<a href="stdlib.html#c%3Astdlib">23</a>.)</p><p>When used in conjunction with a parser generated by <span class="c004">ocamlyacc</span>, the
 semantic actions compute a value belonging to the type <span class="c004">token</span> defined
 by the generated parsing module. (See the description of <span class="c004">ocamlyacc</span>
 below.)</p>
-<h3 class="subsection" id="ss:ocamllex-options"><a class="section-anchor" href="#ss:ocamllex-options" aria-hidden="true">﻿</a>13.1.1 Options</h3>
+<h3 class="subsection" id="ss:ocamllex-options"><a class="section-anchor" href="#ss:ocamllex-options" aria-hidden="true">﻿</a><span class="number">1.1</span>Options</h3>
 <p>
 The following command-line options are recognized by <span class="c004">ocamllex</span>.</p><dl class="description"><dt class="dt-description"><span class="c007">-ml</span></dt><dd class="dd-description">
 Output code that does not use OCaml’s built-in automata
@@ -71,7 +71,7 @@ Print version string and exit.</dd><dt class="dt-description"><span class="c007"
 Print short version number and exit.</dd><dt class="dt-description"><span class="c014"><span class="c004">-help</span> or <span class="c004">--help</span></span></dt><dd class="dd-description">
 Display a short usage summary and exit.
 </dd></dl>
-<h2 class="section" id="s:ocamllex-syntax"><a class="section-anchor" href="#s:ocamllex-syntax" aria-hidden="true">﻿</a>13.2 Syntax of lexer definitions</h2>
+<h2 class="section" id="s:ocamllex-syntax"><a class="section-anchor" href="#s:ocamllex-syntax" aria-hidden="true">﻿</a><span class="number">2</span>Syntax of lexer definitions</h2>
 <p>The format of lexer definitions is as follows:
 </p><pre>{ <span class="c010">header</span> }
 let <span class="c010">ident</span> = <span class="c010">regexp</span> …
@@ -88,8 +88,8 @@ and …
 Comments are delimited by <span class="c004">(*</span> and <span class="c004">*)</span>, as in OCaml.
 The <span class="c004">parse</span> keyword, can be replaced by the <span class="c004">shortest</span> keyword, with
 the semantic consequences explained below.</p><p>Refill handlers are a recent (optional) feature introduced in 4.02,
-documented below in subsection ‍<a href="#ss%3Arefill-handlers">13.2.7</a>.</p>
-<h3 class="subsection" id="ss:ocamllex-header-trailer"><a class="section-anchor" href="#ss:ocamllex-header-trailer" aria-hidden="true">﻿</a>13.2.1 Header and trailer</h3>
+documented below in subsection&nbsp;<a href="#ss%3Arefill-handlers">13.2.7</a>.</p>
+<h3 class="subsection" id="ss:ocamllex-header-trailer"><a class="section-anchor" href="#ss:ocamllex-header-trailer" aria-hidden="true">﻿</a><span class="number">2.1</span>Header and trailer</h3>
 <p>
 The <span class="c010">header</span> and <span class="c010">trailer</span> sections are arbitrary OCaml
 text enclosed in curly braces. Either or both can be omitted. If
@@ -98,13 +98,13 @@ output file and the trailer text at the end. Typically, the
 header section contains the <span class="c004">open</span> directives required
 by the actions, and possibly some auxiliary functions used in the
 actions.</p>
-<h3 class="subsection" id="ss:ocamllex-named-regexp"><a class="section-anchor" href="#ss:ocamllex-named-regexp" aria-hidden="true">﻿</a>13.2.2 Naming regular expressions</h3>
+<h3 class="subsection" id="ss:ocamllex-named-regexp"><a class="section-anchor" href="#ss:ocamllex-named-regexp" aria-hidden="true">﻿</a><span class="number">2.2</span>Naming regular expressions</h3>
 <p>Between the header and the entry points, one can give names to
 frequently-occurring regular expressions. This is written
 <span class="c005">let</span> <a class="syntax" href="lex.html#ident"><span class="c011">ident</span></a> <span class="c005">=</span>  <a class="syntax" href="#regexp"><span class="c011">regexp</span></a>.
 In regular expressions that follow this declaration, the identifier
 <span class="c010">ident</span> can be used as shorthand for <span class="c010">regexp</span>.</p>
-<h3 class="subsection" id="ss:ocamllex-entry-points"><a class="section-anchor" href="#ss:ocamllex-entry-points" aria-hidden="true">﻿</a>13.2.3 Entry points</h3>
+<h3 class="subsection" id="ss:ocamllex-entry-points"><a class="section-anchor" href="#ss:ocamllex-entry-points" aria-hidden="true">﻿</a><span class="number">2.3</span>Entry points</h3>
 <p>The names of the entry points must be valid identifiers for OCaml
 values (starting with a lowercase letter).
 Similarly, the arguments <span class="c006">arg</span><sub>1</sub><span class="c004">…
@@ -124,7 +124,7 @@ the shortest prefix of the input is selected. In case of tie, the
 regular expression that occurs earlier in the rule is still selected.
 This feature is not intended for use in ordinary lexical analyzers, it
 may facilitate the use of <span class="c004">ocamllex</span> as a simple text processing tool.</p>
-<h3 class="subsection" id="ss:ocamllex-regexp"><a class="section-anchor" href="#ss:ocamllex-regexp" aria-hidden="true">﻿</a>13.2.4 Regular expressions</h3>
+<h3 class="subsection" id="ss:ocamllex-regexp"><a class="section-anchor" href="#ss:ocamllex-regexp" aria-hidden="true">﻿</a><span class="number">2.4</span>Regular expressions</h3>
 <p>The regular expressions are in the style of <span class="c004">lex</span>, with a more
 OCaml-like syntax.
 </p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -170,7 +170,7 @@ Bind the substring matched by <a class="syntax" href="#regexp"><span class="c011
 </dd></dl><p>Concerning the precedences of operators, <span class="c004">#</span> has the highest precedence,
 followed by <span class="c004">*</span>, <span class="c004">+</span> and <span class="c004">?</span>,
 then concatenation, then <span class="c004">|</span> (alternation), then <span class="c004">as</span>.</p>
-<h3 class="subsection" id="ss:ocamllex-actions"><a class="section-anchor" href="#ss:ocamllex-actions" aria-hidden="true">﻿</a>13.2.5 Actions</h3>
+<h3 class="subsection" id="ss:ocamllex-actions"><a class="section-anchor" href="#ss:ocamllex-actions" aria-hidden="true">﻿</a><span class="number">2.5</span>Actions</h3>
 <p>The actions are arbitrary OCaml expressions. They are evaluated in
 a context where the identifiers defined by using the <span class="c004">as</span> construct
 are bound to subparts of the matched string.
@@ -193,7 +193,7 @@ offset 0.</dd><dt class="dt-description"><span class="c014"><span class="c010">e
 lexer definition.) Recursively call the lexer on the given entry point.
 Notice that <span class="c004">lexbuf</span> is the last argument.
 Useful for lexing nested comments, for example.</dd></dl>
-<h3 class="subsection" id="ss:ocamllex-variables"><a class="section-anchor" href="#ss:ocamllex-variables" aria-hidden="true">﻿</a>13.2.6 Variables in regular expressions</h3>
+<h3 class="subsection" id="ss:ocamllex-variables"><a class="section-anchor" href="#ss:ocamllex-variables" aria-hidden="true">﻿</a><span class="number">2.6</span>Variables in regular expressions</h3>
 <p>
 The <span class="c004">as</span> construct is similar to “<em>groups</em>” as provided by
 numerous regular expression packages.
@@ -231,7 +231,7 @@ The automata produced <span class="c004">ocamllex</span> on such ambiguous regul
 expressions will select one of the possible resulting sets of
 bindings.
 The selected set of bindings is purposely left unspecified.</p>
-<h3 class="subsection" id="ss:refill-handlers"><a class="section-anchor" href="#ss:refill-handlers" aria-hidden="true">﻿</a>13.2.7 Refill handlers</h3>
+<h3 class="subsection" id="ss:refill-handlers"><a class="section-anchor" href="#ss:refill-handlers" aria-hidden="true">﻿</a><span class="number">2.7</span>Refill handlers</h3>
 <p>By default, when ocamllex reaches the end of its lexing buffer, it
 will silently call the <span class="c004">refill_buff</span> function of <span class="c004">lexbuf</span> structure
 and continue lexing. It is sometimes useful to be able to take control
@@ -285,10 +285,10 @@ rule token = parse
 end
 }
 </pre>
-<h3 class="subsection" id="ss:ocamllex-reserved-ident"><a class="section-anchor" href="#ss:ocamllex-reserved-ident" aria-hidden="true">﻿</a>13.2.8 Reserved identifiers</h3>
+<h3 class="subsection" id="ss:ocamllex-reserved-ident"><a class="section-anchor" href="#ss:ocamllex-reserved-ident" aria-hidden="true">﻿</a><span class="number">2.8</span>Reserved identifiers</h3>
 <p>All identifiers starting with <span class="c004">__ocaml_lex</span> are reserved for use by
 <span class="c004">ocamllex</span>; do not use any such identifier in your programs.</p>
-<h2 class="section" id="s:ocamlyacc-overview"><a class="section-anchor" href="#s:ocamlyacc-overview" aria-hidden="true">﻿</a>13.3 Overview of <span class="c004">ocamlyacc</span></h2>
+<h2 class="section" id="s:ocamlyacc-overview"><a class="section-anchor" href="#s:ocamlyacc-overview" aria-hidden="true">﻿</a><span class="number">3</span>Overview of <span class="c004">ocamlyacc</span></h2>
 <p>The <span class="c004">ocamlyacc</span> command produces a parser from a context-free grammar
 specification with attached semantic actions, in the style of <span class="c004">yacc</span>.
 Assuming the input file is <span class="c010">grammar</span><span class="c004">.mly</span>, executing
@@ -305,7 +305,7 @@ functions are usually generated from a lexer specification by the
 implemented in the standard library module <span class="c004">Lexing</span>. Tokens are values from
 the concrete type <span class="c004">token</span>, defined in the interface file
 <span class="c010">grammar</span><span class="c004">.mli</span> produced by <span class="c004">ocamlyacc</span>.</p>
-<h2 class="section" id="s:ocamlyacc-syntax"><a class="section-anchor" href="#s:ocamlyacc-syntax" aria-hidden="true">﻿</a>13.4 Syntax of grammar definitions</h2>
+<h2 class="section" id="s:ocamlyacc-syntax"><a class="section-anchor" href="#s:ocamlyacc-syntax" aria-hidden="true">﻿</a><span class="number">4</span>Syntax of grammar definitions</h2>
 <p>Grammar definitions have the following format:
 </p><pre>%{
   <span class="c010">header</span>
@@ -318,13 +318,13 @@ the concrete type <span class="c004">token</span>, defined in the interface file
 </pre><p>Comments are enclosed between <code class="verb">/*</code> and <code class="verb">*/</code> (as in C) in the
 “declarations” and “rules” sections, and between <code class="verb">(*</code> and
 <code class="verb">*)</code> (as in OCaml) in the “header” and “trailer” sections.</p>
-<h3 class="subsection" id="ss:ocamlyacc-header-trailer"><a class="section-anchor" href="#ss:ocamlyacc-header-trailer" aria-hidden="true">﻿</a>13.4.1 Header and trailer</h3>
+<h3 class="subsection" id="ss:ocamlyacc-header-trailer"><a class="section-anchor" href="#ss:ocamlyacc-header-trailer" aria-hidden="true">﻿</a><span class="number">4.1</span>Header and trailer</h3>
 <p>The header and the trailer sections are OCaml code that is copied
 as is into file <span class="c010">grammar</span><span class="c004">.ml</span>. Both sections are optional. The header
 goes at the beginning of the output file; it usually contains
 <span class="c004">open</span> directives and auxiliary functions required by the semantic
 actions of the rules. The trailer goes at the end of the output file.</p>
-<h3 class="subsection" id="ss:ocamlyacc-declarations"><a class="section-anchor" href="#ss:ocamlyacc-declarations" aria-hidden="true">﻿</a>13.4.2 Declarations</h3>
+<h3 class="subsection" id="ss:ocamlyacc-declarations"><a class="section-anchor" href="#ss:ocamlyacc-declarations" aria-hidden="true">﻿</a><span class="number">4.2</span>Declarations</h3>
 <p>Declarations are given one per line. They all start with a <code class="verb">%</code> sign.</p><dl class="description"><dt class="dt-description"><span class="c005">%token</span> <a class="syntax" href="names.html#constr"><span class="c011">constr</span></a> …  <a class="syntax" href="names.html#constr"><span class="c011">constr</span></a></dt><dd class="dd-description">
 Declare the given symbols <a class="syntax" href="names.html#constr"><span class="c011">constr</span></a> …  <a class="syntax" href="names.html#constr"><span class="c011">constr</span></a>
 as tokens (terminal symbols). These symbols
@@ -387,7 +387,7 @@ error.
 method, then <span class="c004">ocamlyacc</span> will output a warning and the parser will
 always shift.
 </li></ul></dd></dl>
-<h3 class="subsection" id="ss:ocamlyacc-rules"><a class="section-anchor" href="#ss:ocamlyacc-rules" aria-hidden="true">﻿</a>13.4.3 Rules</h3>
+<h3 class="subsection" id="ss:ocamlyacc-rules"><a class="section-anchor" href="#ss:ocamlyacc-rules" aria-hidden="true">﻿</a><span class="number">4.3</span>Rules</h3>
 <p>The syntax for rules is as usual:
 </p><pre><span class="c010">nonterminal</span> :
     <span class="c010">symbol</span> … <span class="c010">symbol</span> { <span class="c010">semantic-action</span> }
@@ -407,7 +407,7 @@ first (leftmost) symbol, <code class="verb">$2</code> is the attribute for the s
 symbol, etc.</p><p>The rules may contain the special symbol <span class="c004">error</span> to indicate
 resynchronization points, as in <span class="c004">yacc</span>.</p><p>Actions occurring in the middle of rules are not supported.</p><p>Nonterminal symbols are like regular OCaml symbols, except that they
 cannot end with <span class="c004">'</span> (single quote).</p>
-<h3 class="subsection" id="ss:ocamlyacc-error-handling"><a class="section-anchor" href="#ss:ocamlyacc-error-handling" aria-hidden="true">﻿</a>13.4.4 Error handling</h3>
+<h3 class="subsection" id="ss:ocamlyacc-error-handling"><a class="section-anchor" href="#ss:ocamlyacc-error-handling" aria-hidden="true">﻿</a><span class="number">4.4</span>Error handling</h3>
 <p>Error recovery is supported as follows: when the parser reaches an
 error state (no grammar rules can apply), it calls a function named
 <span class="c004">parse_error</span> with the string <span class="c004">"syntax error"</span> as argument. The default
@@ -422,7 +422,7 @@ these. If no state can be uncovered where the error token can be
 shifted, then the parser aborts by raising the <span class="c004">Parsing.Parse_error</span>
 exception.</p><p>Refer to documentation on <span class="c004">yacc</span> for more details and guidance in how
 to use error recovery.</p>
-<h2 class="section" id="s:ocamlyacc-options"><a class="section-anchor" href="#s:ocamlyacc-options" aria-hidden="true">﻿</a>13.5 Options</h2>
+<h2 class="section" id="s:ocamlyacc-options"><a class="section-anchor" href="#s:ocamlyacc-options" aria-hidden="true">﻿</a><span class="number">5</span>Options</h2>
 <p>The <span class="c004">ocamlyacc</span> command recognizes the following options:</p><dl class="description"><dt class="dt-description"><span class="c014"><span class="c004">-b</span><span class="c010">prefix</span></span></dt><dd class="dd-description">
 Name the output files <span class="c010">prefix</span><span class="c004">.ml</span>, <span class="c010">prefix</span><span class="c004">.mli</span>,
 <span class="c010">prefix</span><span class="c004">.output</span>, instead of the default naming convention.</dd><dt class="dt-description"><span class="c007">-q</span></dt><dd class="dd-description">
@@ -438,12 +438,12 @@ Process <span class="c010">file</span> as the grammar specification, even if its
 starts with a dash (-) character. This option must be the last on the
 command line.</dd></dl><p>At run-time, the <span class="c004">ocamlyacc</span>-generated parser can be debugged by
 setting the <span class="c004">p</span> option in the <span class="c004">OCAMLRUNPARAM</span> environment variable
-(see section ‍<a href="runtime.html#s%3Aocamlrun-options">11.2</a>). This causes the pushdown
+(see section&nbsp;<a href="runtime.html#s%3Aocamlrun-options">11.2</a>). This causes the pushdown
 automaton executing the parser to print a trace of its action (tokens
 shifted, rules reduced, etc). The trace mentions rule numbers and
 state numbers that can be interpreted by looking at the file
 <span class="c010">grammar</span><span class="c004">.output</span> generated by <span class="c004">ocamlyacc -v</span>.</p>
-<h2 class="section" id="s:lexyacc-example"><a class="section-anchor" href="#s:lexyacc-example" aria-hidden="true">﻿</a>13.6 A complete example</h2>
+<h2 class="section" id="s:lexyacc-example"><a class="section-anchor" href="#s:lexyacc-example" aria-hidden="true">﻿</a><span class="number">6</span>A complete example</h2>
 <p>The all-time favorite: a desk calculator. This program reads
 arithmetic expressions on standard input, one per line, and prints
 their values. Here is the grammar definition:
@@ -507,7 +507,7 @@ their values. Here is the grammar definition:
         ocamlc -c calc.ml
         ocamlc -o calc lexer.cmo parser.cmo calc.cmo
 </pre>
-<h2 class="section" id="s:lexyacc-common-errors"><a class="section-anchor" href="#s:lexyacc-common-errors" aria-hidden="true">﻿</a>13.7 Common errors</h2>
+<h2 class="section" id="s:lexyacc-common-errors"><a class="section-anchor" href="#s:lexyacc-common-errors" aria-hidden="true">﻿</a><span class="number">7</span>Common errors</h2>
 <dl class="description"><dt class="dt-description"><span class="c014">ocamllex: transition table overflow, automaton is too big</span></dt><dd class="dd-description"><p>The deterministic automata generated by <span class="c004">ocamllex</span> are limited to at
 most 32767 transitions. The message above indicates that your lexer
 definition is too complex and overflows this limit. This is commonly
@@ -542,7 +542,7 @@ positions inside the scanned lexer buffer. The size of this table is
 limited to at most 255 cells. This error should not show up in normal
 situations.</dd></dl>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="native.html">« Chapter ‍12 Native-code compilation (ocamlopt)</a><a class="next" href="depend.html">Chapter ‍14 Dependency generator (ocamldep) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="native.html">« Native-code compilation (ocamlopt)</a><a class="next" href="depend.html">Dependency generator (ocamldep) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/libdynlink.html
+++ b/site/releases/4.12/htmlman/libdynlink.html
@@ -5,14 +5,14 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍28 The dynlink library: dynamic loading and linking of object files</title>
+<title>OCaml - The dynlink library: dynamic loading and linking of object files</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍IV The OCaml library</nav><ul id="part-menu"><li><a href="core.html">Chapter ‍22 The core library</a></li><li><a href="stdlib.html">Chapter ‍23 The standard library</a></li><li><a href="parsing.html">Chapter ‍24 The compiler front-end</a></li><li><a href="libunix.html">Chapter ‍25 The unix library: Unix system calls</a></li><li><a href="libstr.html">Chapter ‍26 The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">Chapter ‍27 The threads library</a></li><li class="active"><a href="libdynlink.html">Chapter ‍28 The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li class="active"><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
 
 
 
 
-<h1 class="chapter" id="sec573">Chapter ‍28 The dynlink library: dynamic loading and linking of object files</h1>
+<h1 class="chapter" id="sec573"><span class="number">Chapter 28</span>The dynlink library: dynamic loading and linking of object files</h1>
 <p>The <span class="c004">dynlink</span> library supports type-safe dynamic loading and linking
 of bytecode object files (<span class="c004">.cmo</span> and <span class="c004">.cma</span> files) in a running
 bytecode program, or of native plugins (usually <span class="c004">.cmxs</span> files) in a
@@ -32,7 +32,7 @@ programs using the <span class="c004">dynlink</span> library should be linked wi
 <a href="../api/Dynlink.html">Module <span class="c004">Dynlink</span>: dynamic loading of bytecode object files</a>
 </li></ul>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="libthreads.html">« Chapter ‍27 The threads library</a><a class="next" href="old.html">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="libthreads.html">« The threads library</a><a class="next" href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/libstr.html
+++ b/site/releases/4.12/htmlman/libstr.html
@@ -5,14 +5,14 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍26 The str library: regular expressions and string processing</title>
+<title>OCaml - The str library: regular expressions and string processing</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍IV The OCaml library</nav><ul id="part-menu"><li><a href="core.html">Chapter ‍22 The core library</a></li><li><a href="stdlib.html">Chapter ‍23 The standard library</a></li><li><a href="parsing.html">Chapter ‍24 The compiler front-end</a></li><li><a href="libunix.html">Chapter ‍25 The unix library: Unix system calls</a></li><li class="active"><a href="libstr.html">Chapter ‍26 The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">Chapter ‍27 The threads library</a></li><li><a href="libdynlink.html">Chapter ‍28 The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li class="active"><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
 
 
 
 
-<h1 class="chapter" id="sec571">Chapter ‍26 The str library: regular expressions and string processing</h1>
+<h1 class="chapter" id="sec571"><span class="number">Chapter 26</span>The str library: regular expressions and string processing</h1>
 <p>The <span class="c004">str</span> library provides high-level string processing functions,
 some based on regular expressions. It is intended to support the kind
 of file processing that is usually performed with scripting languages
@@ -29,7 +29,7 @@ start <span class="c004">ocaml</span> and type <span class="c004">#load "str.cma
 <a href="../api/Str.html">Module <span class="c004">Str</span>: regular expressions and string processing</a>
 </li></ul>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="libunix.html">« Chapter ‍25 The unix library: Unix system calls</a><a class="next" href="libthreads.html">Chapter ‍27 The threads library »</a></div>
+<div class="bottom-navigation"><a class="previous" href="libunix.html">« The unix library: Unix system calls</a><a class="next" href="libthreads.html">The threads library »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/libthreads.html
+++ b/site/releases/4.12/htmlman/libthreads.html
@@ -5,14 +5,14 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍27 The threads library</title>
+<title>OCaml - The threads library</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍IV The OCaml library</nav><ul id="part-menu"><li><a href="core.html">Chapter ‍22 The core library</a></li><li><a href="stdlib.html">Chapter ‍23 The standard library</a></li><li><a href="parsing.html">Chapter ‍24 The compiler front-end</a></li><li><a href="libunix.html">Chapter ‍25 The unix library: Unix system calls</a></li><li><a href="libstr.html">Chapter ‍26 The str library: regular expressions and string processing</a></li><li class="active"><a href="libthreads.html">Chapter ‍27 The threads library</a></li><li><a href="libdynlink.html">Chapter ‍28 The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li class="active"><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
 
 
 
 
-<h1 class="chapter" id="sec572">Chapter ‍27 The threads library</h1>
+<h1 class="chapter" id="sec572"><span class="number">Chapter 27</span>The threads library</h1>
 <p>
 <a id="c:threads"></a></p><p>The <span class="c004">threads</span> library allows concurrent programming in OCaml.
 It provides multiple threads of control (also called lightweight
@@ -31,7 +31,7 @@ overlapping I/O operations.</p><p>Programs that use threads must be linked as fo
         ocamlopt -I +threads <span class="c010">other options</span> unix.cmxa threads.cmxa <span class="c010">other files</span>
 </pre><p>
 Compilation units that use the <span class="c004">threads</span> library must also be compiled with
-the <span class="c004">-I +threads</span> option (see chapter ‍<a href="comp.html#c%3Acamlc">9</a>).</p><ul class="ftoc2"><li class="li-links">
+the <span class="c004">-I +threads</span> option (see chapter&nbsp;<a href="comp.html#c%3Acamlc">9</a>).</p><ul class="ftoc2"><li class="li-links">
 <a href="../api/Thread.html">Module <span class="c004">Thread</span>: lightweight threads</a>
 </li><li class="li-links"><a href="../api/Mutex.html">Module <span class="c004">Mutex</span>: locks for mutual exclusion</a>
 </li><li class="li-links"><a href="../api/Condition.html">Module <span class="c004">Condition</span>: condition variables to synchronize between threads</a>
@@ -39,7 +39,7 @@ the <span class="c004">-I +threads</span> option (see chapter ‍<a href="comp
 </li><li class="li-links"><a href="../api/Event.html">Module <span class="c004">Event</span>: first-class synchronous communication</a>
 </li></ul>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="libstr.html">« Chapter ‍26 The str library: regular expressions and string processing</a><a class="next" href="libdynlink.html">Chapter ‍28 The dynlink library: dynamic loading and linking of object files »</a></div>
+<div class="bottom-navigation"><a class="previous" href="libstr.html">« The str library: regular expressions and string processing</a><a class="next" href="libdynlink.html">The dynlink library: dynamic loading and linking of object files »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/libunix.html
+++ b/site/releases/4.12/htmlman/libunix.html
@@ -5,19 +5,19 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍25 The unix library: Unix system calls</title>
+<title>OCaml - The unix library: Unix system calls</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍IV The OCaml library</nav><ul id="part-menu"><li><a href="core.html">Chapter ‍22 The core library</a></li><li><a href="stdlib.html">Chapter ‍23 The standard library</a></li><li><a href="parsing.html">Chapter ‍24 The compiler front-end</a></li><li class="active"><a href="libunix.html">Chapter ‍25 The unix library: Unix system calls</a></li><li><a href="libstr.html">Chapter ‍26 The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">Chapter ‍27 The threads library</a></li><li><a href="libdynlink.html">Chapter ‍28 The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li class="active"><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
 
 
 
 
-<h1 class="chapter" id="sec570">Chapter ‍25 The unix library: Unix system calls</h1>
+<h1 class="chapter" id="sec570"><span class="number">Chapter 25</span>The unix library: Unix system calls</h1>
 <p>
 <a id="c:unix"></a></p><p>The <span class="c004">unix</span> library makes many Unix
 system calls and system-related library functions available to
 OCaml programs. This chapter describes briefly the functions
-provided. Refer to sections 2 ‍and ‍3 of the Unix manual for more
+provided. Refer to sections 2&nbsp;and&nbsp;3 of the Unix manual for more
 details on the behavior of these functions.</p><ul class="ftoc2"><li class="li-links">
 <a href="../api/Unix.html">Module <span class="c004">Unix</span>: Unix system calls</a>
 </li><li class="li-links"><a href="../api/UnixLabels.html">Module <span class="c004">UnixLabels</span>: Labeled
@@ -77,7 +77,7 @@ processes </td></tr>
 <tr><td class="c023"><span class="c004">setsid</span></td><td class="c022">not implemented </td></tr>
 </tbody></table></div></div>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="parsing.html">« Chapter ‍24 The compiler front-end</a><a class="next" href="libstr.html">Chapter ‍26 The str library: regular expressions and string processing »</a></div>
+<div class="bottom-navigation"><a class="previous" href="parsing.html">« The compiler front-end</a><a class="next" href="libstr.html">The str library: regular expressions and string processing »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/locallyabstract.html
+++ b/site/releases/4.12/htmlman/locallyabstract.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:locally-abstract"><a class="section-anchor" href="#s:locally-abstract" aria-hidden="true"></a>8.4 Locally abstract types</h2>
+<h2 class="section" id="s:locally-abstract"><a class="section-anchor" href="#s:locally-abstract" aria-hidden="true"></a><span class="number">4</span>Locally abstract types</h2>
 <p>
 <a id="hevea_manual.kwd210"></a>
 <a id="hevea_manual.kwd211"></a>
@@ -128,8 +128,8 @@ within a polymorphic function.
     S.elements (List.fold_right S.add l S.empty)</div></div>
 
 </div><p>It is also extremely useful for first-class modules (see
-section ‍<a href="firstclassmodules.html#s%3Afirst-class-modules">8.5</a>) and generalized algebraic datatypes
-(GADTs: see section ‍<a href="gadts.html#s%3Agadts">8.10</a>).</p>
+section&nbsp;<a href="firstclassmodules.html#s%3Afirst-class-modules">8.5</a>) and generalized algebraic datatypes
+(GADTs: see section&nbsp;<a href="gadts.html#s%3Agadts">8.10</a>).</p>
 <h5 class="paragraph" id="p:polymorpic-locally-abstract"><a class="section-anchor" href="#p:polymorpic-locally-abstract" aria-hidden="true">﻿</a>Polymorphic syntax</h5>
 <p> (Introduced in OCaml 4.00)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="expr.html#let-binding"><span class="c011">let-binding</span></a></td><td class="c016">::=</td><td class="c018">
@@ -178,9 +178,9 @@ is automatically expanded into
 </div><p>
 
 This syntax can be very useful when defining recursive functions involving
-GADTs, see the section ‍<a href="gadts.html#s%3Agadts">8.10</a> for a more detailed explanation.</p><p>The same feature is provided for method definitions.</p>
+GADTs, see the section&nbsp;<a href="gadts.html#s%3Agadts">8.10</a> for a more detailed explanation.</p><p>The same feature is provided for method definitions.</p>
 
-<div class="bottom-navigation"><a class="previous" href="privatetypes.html">« 8.3 Private types</a><a class="next" href="firstclassmodules.html">8.5 First-class modules »</a></div>
+<div class="bottom-navigation"><a class="previous" href="privatetypes.html">« Private types</a><a class="next" href="firstclassmodules.html">First-class modules »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/manual.css
+++ b/site/releases/4.12/htmlman/manual.css
@@ -99,11 +99,13 @@ html {
   .content ul {
     list-style: none; }
   .content ul.itemize li::before {
-    content: "▶";
+    content: "●";
     color: #ec6a0d;
-    font-size: smaller;
     margin-right: 4px;
-    margin-left: -1em; }
+    margin-left: -1em;
+    font-family: "Fira Sans",Helvetica,Arial,sans-serif;
+    font-size: 13px;
+    vertical-align: 1px; }
   .content .bottom-navigation {
     margin-bottom: 1em; }
     .content .bottom-navigation a.next {
@@ -125,11 +127,14 @@ html {
       .index ul li span.c003 {
         color: #564233; }
   .index ul.ul-content li::before {
-    content: "▶";
+    content: "●";
     color: #ec6a0d;
-    font-size: smaller;
     margin-right: 4px;
-    margin-left: -1em; }
+    margin-left: -1em;
+    font-family: "Fira Sans",Helvetica,Arial,sans-serif;
+    font-size: 13px;
+    vertical-align: 1px;
+    margin-left: 0; }
   .index ul.toc ul.toc ul.toc {
     font-size: smaller; }
   .index section > ul > li > a {
@@ -396,11 +401,13 @@ blockquote.quote {
 #part-menu li.active a {
   color: #000; }
   #part-menu li.active a::before {
-    content: "▶";
+    content: "◆";
     color: #ec6a0d;
-    font-size: smaller;
     margin-right: 4px;
-    margin-left: -1em; }
+    margin-left: -1em;
+    font-family: "Fira Sans",Helvetica,Arial,sans-serif;
+    font-size: 14px;
+    vertical-align: 1px; }
 
 span.c003 {
   color: #564233;
@@ -410,10 +417,14 @@ span.c003 {
 
 div.caml-example.toplevel code.caml-input::before,
 div.caml-example.toplevel div.caml-input::before {
-  content: "#";
+  /* content:"#"; */
+  /* pre-4.11 */
   color: #888; }
 
-span.c004 {
+span.number {
+  padding-right: 1ex; }
+
+span.c004, span.c002 {
   color: #888; }
 
 span.c006 {
@@ -426,7 +437,8 @@ span.c009 {
   background-color: #f3ece6;
   border-radius: 6px; }
 
-span.authors.c009 {
+span.authors {
+  font-style: italic;
   background-color: inherit; }
 
 span.c013 {

--- a/site/releases/4.12/htmlman/manual001.html
+++ b/site/releases/4.12/htmlman/manual001.html
@@ -11,7 +11,7 @@
 <body><div class="index content manual"><div id="sidebar-button"><span>☰</span></div><ul id="part-menu"></ul>
 
 
-<div class="maintitle"><h1><span>The OCaml system</span> &nbsp;release 4.12 </h1><h3>February ‍24, 2021</h3></div><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Select another version</a></div><ul><li class="top"><a href="#">The OCaml Manual</a></li>
+<div class="maintitle"><h1><span>The OCaml system</span> &nbsp;release 4.12 </h1><h3>April&nbsp;7, 2021</h3></div><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Select another version</a></div><ul><li class="top"><a href="#">The OCaml Manual</a></li>
 <li><a href="manual001.html#start-section">Contents</a>
 </li><li><a href="foreword.html#start-section">Foreword</a>
 </li><li><a href="manual067.html#start-section">Index of keywords</a></li><li><a href="../api/index.html">OCaml API</a></li><li><a href="../api/compilerlibref/index.html">OCaml Compiler API</a></li></ul></nav></header><a id="start-section"></a><section id="section">
@@ -20,552 +20,552 @@
 
 <h1 class="chapter" id="sec1">Contents</h1>
 <ul class="toc"><li class="li-toc">
-<a href="index.html#sec6">Part ‍I An introduction to OCaml</a>
+<a href="index.html#sec6">Part&nbsp;I An introduction to OCaml</a>
 <ul class="toc"><li class="li-toc">
-<a href="coreexamples.html#sec7">Chapter ‍1 The core language</a>
+<a href="coreexamples.html#sec7"><span class="number">Chapter 1</span>The core language</a>
 <ul class="toc"><li class="li-toc">
-<a href="coreexamples.html#s%3Abasics">1.1 Basics</a>
-</li><li class="li-toc"><a href="coreexamples.html#s%3Adatatypes">1.2 Data types</a>
-</li><li class="li-toc"><a href="coreexamples.html#s%3Afunctions-as-values">1.3 Functions as values</a>
-</li><li class="li-toc"><a href="coreexamples.html#s%3Atut-recvariants">1.4 Records and variants</a>
+<a href="coreexamples.html#s%3Abasics"><span class="number">1</span>Basics</a>
+</li><li class="li-toc"><a href="coreexamples.html#s%3Adatatypes"><span class="number">2</span>Data types</a>
+</li><li class="li-toc"><a href="coreexamples.html#s%3Afunctions-as-values"><span class="number">3</span>Functions as values</a>
+</li><li class="li-toc"><a href="coreexamples.html#s%3Atut-recvariants"><span class="number">4</span>Records and variants</a>
 <ul class="toc"><li class="li-toc">
-<a href="coreexamples.html#ss%3Arecord-and-variant-disambiguation">1.4.1 Record and variant disambiguation</a>
+<a href="coreexamples.html#ss%3Arecord-and-variant-disambiguation"><span class="number">4.1</span>Record and variant disambiguation</a>
 </li></ul>
-</li><li class="li-toc"><a href="coreexamples.html#s%3Aimperative-features">1.5 Imperative features</a>
-</li><li class="li-toc"><a href="coreexamples.html#s%3Aexceptions">1.6 Exceptions</a>
-</li><li class="li-toc"><a href="coreexamples.html#s%3Alazy-expr">1.7 Lazy expressions</a>
-</li><li class="li-toc"><a href="coreexamples.html#s%3Asymb-expr">1.8 Symbolic processing of expressions</a>
-</li><li class="li-toc"><a href="coreexamples.html#s%3Apretty-printing">1.9 Pretty-printing</a>
-</li><li class="li-toc"><a href="coreexamples.html#s%3Aprintf">1.10 Printf formats</a>
-</li><li class="li-toc"><a href="coreexamples.html#s%3Astandalone-programs">1.11 Standalone OCaml programs</a>
+</li><li class="li-toc"><a href="coreexamples.html#s%3Aimperative-features"><span class="number">5</span>Imperative features</a>
+</li><li class="li-toc"><a href="coreexamples.html#s%3Aexceptions"><span class="number">6</span>Exceptions</a>
+</li><li class="li-toc"><a href="coreexamples.html#s%3Alazy-expr"><span class="number">7</span>Lazy expressions</a>
+</li><li class="li-toc"><a href="coreexamples.html#s%3Asymb-expr"><span class="number">8</span>Symbolic processing of expressions</a>
+</li><li class="li-toc"><a href="coreexamples.html#s%3Apretty-printing"><span class="number">9</span>Pretty-printing</a>
+</li><li class="li-toc"><a href="coreexamples.html#s%3Aprintf"><span class="number">10</span>Printf formats</a>
+</li><li class="li-toc"><a href="coreexamples.html#s%3Astandalone-programs"><span class="number">11</span>Standalone OCaml programs</a>
 </li></ul>
-</li><li class="li-toc"><a href="moduleexamples.html#sec20">Chapter ‍2 The module system</a>
+</li><li class="li-toc"><a href="moduleexamples.html#sec20"><span class="number">Chapter 2</span>The module system</a>
 <ul class="toc"><li class="li-toc">
-<a href="moduleexamples.html#s%3Amodule%3Astructures">2.1 Structures</a>
-</li><li class="li-toc"><a href="moduleexamples.html#s%3Asignature">2.2 Signatures</a>
-</li><li class="li-toc"><a href="moduleexamples.html#s%3Afunctors">2.3 Functors</a>
-</li><li class="li-toc"><a href="moduleexamples.html#s%3Afunctors-and-abstraction">2.4 Functors and type abstraction</a>
-</li><li class="li-toc"><a href="moduleexamples.html#s%3Aseparate-compilation">2.5 Modules and separate compilation</a>
+<a href="moduleexamples.html#s%3Amodule%3Astructures"><span class="number">1</span>Structures</a>
+</li><li class="li-toc"><a href="moduleexamples.html#s%3Asignature"><span class="number">2</span>Signatures</a>
+</li><li class="li-toc"><a href="moduleexamples.html#s%3Afunctors"><span class="number">3</span>Functors</a>
+</li><li class="li-toc"><a href="moduleexamples.html#s%3Afunctors-and-abstraction"><span class="number">4</span>Functors and type abstraction</a>
+</li><li class="li-toc"><a href="moduleexamples.html#s%3Aseparate-compilation"><span class="number">5</span>Modules and separate compilation</a>
 </li></ul>
-</li><li class="li-toc"><a href="objectexamples.html#sec26">Chapter ‍3 Objects in OCaml</a>
+</li><li class="li-toc"><a href="objectexamples.html#sec26"><span class="number">Chapter 3</span>Objects in OCaml</a>
 <ul class="toc"><li class="li-toc">
-<a href="objectexamples.html#s%3Aclasses-and-objects">3.1 Classes and objects</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Aimmediate-objects">3.2 Immediate objects</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Areference-to-self">3.3 Reference to self</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Ainitializers">3.4 Initializers</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Avirtual-methods">3.5 Virtual methods</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Aprivate-methods">3.6 Private methods</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Aclass-interfaces">3.7 Class interfaces</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Ainheritance">3.8 Inheritance</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Amultiple-inheritance">3.9 Multiple inheritance</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Aparameterized-classes">3.10 Parameterized classes</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Apolymorphic-methods">3.11 Polymorphic methods</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Ausing-coercions">3.12 Using coercions</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Afunctional-objects">3.13 Functional objects</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Acloning-objects">3.14 Cloning objects</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Arecursive-classes">3.15 Recursive classes</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Abinary-methods">3.16 Binary methods</a>
-</li><li class="li-toc"><a href="objectexamples.html#s%3Afriends">3.17 Friends</a>
+<a href="objectexamples.html#s%3Aclasses-and-objects"><span class="number">1</span>Classes and objects</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Aimmediate-objects"><span class="number">2</span>Immediate objects</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Areference-to-self"><span class="number">3</span>Reference to self</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Ainitializers"><span class="number">4</span>Initializers</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Avirtual-methods"><span class="number">5</span>Virtual methods</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Aprivate-methods"><span class="number">6</span>Private methods</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Aclass-interfaces"><span class="number">7</span>Class interfaces</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Ainheritance"><span class="number">8</span>Inheritance</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Amultiple-inheritance"><span class="number">9</span>Multiple inheritance</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Aparameterized-classes"><span class="number">10</span>Parameterized classes</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Apolymorphic-methods"><span class="number">11</span>Polymorphic methods</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Ausing-coercions"><span class="number">12</span>Using coercions</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Afunctional-objects"><span class="number">13</span>Functional objects</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Acloning-objects"><span class="number">14</span>Cloning objects</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Arecursive-classes"><span class="number">15</span>Recursive classes</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Abinary-methods"><span class="number">16</span>Binary methods</a>
+</li><li class="li-toc"><a href="objectexamples.html#s%3Afriends"><span class="number">17</span>Friends</a>
 </li></ul>
-</li><li class="li-toc"><a href="lablexamples.html#sec44">Chapter ‍4 Labels and variants</a>
+</li><li class="li-toc"><a href="lablexamples.html#sec44"><span class="number">Chapter 4</span>Labels and variants</a>
 <ul class="toc"><li class="li-toc">
-<a href="lablexamples.html#s%3Alabels">4.1 Labels</a>
+<a href="lablexamples.html#s%3Alabels"><span class="number">1</span>Labels</a>
 <ul class="toc"><li class="li-toc">
-<a href="lablexamples.html#ss%3Aoptional-arguments">4.1.1 Optional arguments</a>
-</li><li class="li-toc"><a href="lablexamples.html#ss%3Alabel-inference">4.1.2 Labels and type inference</a>
-</li><li class="li-toc"><a href="lablexamples.html#ss%3Alabel-suggestions">4.1.3 Suggestions for labeling</a>
+<a href="lablexamples.html#ss%3Aoptional-arguments"><span class="number">1.1</span>Optional arguments</a>
+</li><li class="li-toc"><a href="lablexamples.html#ss%3Alabel-inference"><span class="number">1.2</span>Labels and type inference</a>
+</li><li class="li-toc"><a href="lablexamples.html#ss%3Alabel-suggestions"><span class="number">1.3</span>Suggestions for labeling</a>
 </li></ul>
-</li><li class="li-toc"><a href="lablexamples.html#s%3Apolymorphic-variants">4.2 Polymorphic variants</a>
+</li><li class="li-toc"><a href="lablexamples.html#s%3Apolymorphic-variants"><span class="number">2</span>Polymorphic variants</a>
 <ul class="toc"><li class="li-toc">
-<a href="lablexamples.html#ss%3Apolyvariant-weaknesses">4.2.1 Weaknesses of polymorphic variants</a>
+<a href="lablexamples.html#ss%3Apolyvariant-weaknesses"><span class="number">2.1</span>Weaknesses of polymorphic variants</a>
 </li></ul>
 </li></ul>
-</li><li class="li-toc"><a href="polymorphism.html#sec53">Chapter ‍5 Polymorphism and its limitations</a>
+</li><li class="li-toc"><a href="polymorphism.html#sec53"><span class="number">Chapter 5</span>Polymorphism and its limitations</a>
 <ul class="toc"><li class="li-toc">
-<a href="polymorphism.html#s%3Aweak-polymorphism">5.1 Weak polymorphism and mutation</a>
+<a href="polymorphism.html#s%3Aweak-polymorphism"><span class="number">1</span>Weak polymorphism and mutation</a>
 <ul class="toc"><li class="li-toc">
-<a href="polymorphism.html#ss%3Aweak-types">5.1.1 Weakly polymorphic types</a>
-</li><li class="li-toc"><a href="polymorphism.html#ss%3Avaluerestriction">5.1.2 The value restriction</a>
-</li><li class="li-toc"><a href="polymorphism.html#ss%3Arelaxed-value-restriction">5.1.3 The relaxed value restriction</a>
-</li><li class="li-toc"><a href="polymorphism.html#ss%3Avariance-and-value-restriction">5.1.4 Variance and value restriction</a>
-</li><li class="li-toc"><a href="polymorphism.html#ss%3Avariance%3Aabstract-data-types">5.1.5 Abstract data types</a>
+<a href="polymorphism.html#ss%3Aweak-types"><span class="number">1.1</span>Weakly polymorphic types</a>
+</li><li class="li-toc"><a href="polymorphism.html#ss%3Avaluerestriction"><span class="number">1.2</span>The value restriction</a>
+</li><li class="li-toc"><a href="polymorphism.html#ss%3Arelaxed-value-restriction"><span class="number">1.3</span>The relaxed value restriction</a>
+</li><li class="li-toc"><a href="polymorphism.html#ss%3Avariance-and-value-restriction"><span class="number">1.4</span>Variance and value restriction</a>
+</li><li class="li-toc"><a href="polymorphism.html#ss%3Avariance%3Aabstract-data-types"><span class="number">1.5</span>Abstract data types</a>
 </li></ul>
-</li><li class="li-toc"><a href="polymorphism.html#s%3Apolymorphic-recursion">5.2 Polymorphic recursion</a>
+</li><li class="li-toc"><a href="polymorphism.html#s%3Apolymorphic-recursion"><span class="number">2</span>Polymorphic recursion</a>
 <ul class="toc"><li class="li-toc">
-<a href="polymorphism.html#ss%3Aexplicit-polymorphism">5.2.1 Explicitly polymorphic annotations</a>
-</li><li class="li-toc"><a href="polymorphism.html#ss%3Arecursive-poly-examples">5.2.2 More examples</a>
+<a href="polymorphism.html#ss%3Aexplicit-polymorphism"><span class="number">2.1</span>Explicitly polymorphic annotations</a>
+</li><li class="li-toc"><a href="polymorphism.html#ss%3Arecursive-poly-examples"><span class="number">2.2</span>More examples</a>
 </li></ul>
-</li><li class="li-toc"><a href="polymorphism.html#s%3Ahigher-rank-poly">5.3 Higher-rank polymorphic functions</a>
+</li><li class="li-toc"><a href="polymorphism.html#s%3Ahigher-rank-poly"><span class="number">3</span>Higher-rank polymorphic functions</a>
 </li></ul>
-</li><li class="li-toc"><a href="advexamples.html#sec64">Chapter ‍6 Advanced examples with classes and modules</a>
+</li><li class="li-toc"><a href="advexamples.html#sec64"><span class="number">Chapter 6</span>Advanced examples with classes and modules</a>
 <ul class="toc"><li class="li-toc">
-<a href="advexamples.html#s%3Aextended-bank-accounts">6.1 Extended example: bank accounts</a>
-</li><li class="li-toc"><a href="advexamples.html#s%3Amodules-as-classes">6.2 Simple modules as classes</a>
+<a href="advexamples.html#s%3Aextended-bank-accounts"><span class="number">1</span>Extended example: bank accounts</a>
+</li><li class="li-toc"><a href="advexamples.html#s%3Amodules-as-classes"><span class="number">2</span>Simple modules as classes</a>
 <ul class="toc"><li class="li-toc">
-<a href="advexamples.html#ss%3Astring-as-class">6.2.1 Strings</a>
-</li><li class="li-toc"><a href="advexamples.html#ss%3Ahashtbl-as-class">6.2.2 Hashtbl</a>
-</li><li class="li-toc"><a href="advexamples.html#ss%3Aset-as-class">6.2.3 Sets</a>
+<a href="advexamples.html#ss%3Astring-as-class"><span class="number">2.1</span>Strings</a>
+</li><li class="li-toc"><a href="advexamples.html#ss%3Ahashtbl-as-class"><span class="number">2.2</span>Hashtbl</a>
+</li><li class="li-toc"><a href="advexamples.html#ss%3Aset-as-class"><span class="number">2.3</span>Sets</a>
 </li></ul>
-</li><li class="li-toc"><a href="advexamples.html#s%3Asubject-observer">6.3 The subject/observer pattern</a>
+</li><li class="li-toc"><a href="advexamples.html#s%3Asubject-observer"><span class="number">3</span>The subject/observer pattern</a>
 </li></ul>
 </li></ul>
-</li><li class="li-toc"><a href="index.html#sec72">Part ‍II The OCaml language</a>
+</li><li class="li-toc"><a href="index.html#sec72">Part&nbsp;II The OCaml language</a>
 <ul class="toc"><li class="li-toc">
-<a href="language.html#sec73">Chapter ‍7 The OCaml language</a>
+<a href="language.html#sec73"><span class="number">Chapter 7</span>The OCaml language</a>
 <ul class="toc"><li class="li-toc">
-<a href="lex.html#s%3Alexical-conventions">7.1 Lexical conventions</a>
-</li><li class="li-toc"><a href="values.html#s%3Avalues">7.2 Values</a>
+<a href="lex.html#s%3Alexical-conventions"><span class="number">1</span>Lexical conventions</a>
+</li><li class="li-toc"><a href="values.html#s%3Avalues"><span class="number">2</span>Values</a>
 <ul class="toc"><li class="li-toc">
-<a href="values.html#ss%3Avalues%3Abase">7.2.1 Base values</a>
-</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Atuple">7.2.2 Tuples</a>
-</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Arecords">7.2.3 Records</a>
-</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Aarray">7.2.4 Arrays</a>
-</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Avariant">7.2.5 Variant values</a>
-</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Apolyvars">7.2.6 Polymorphic variants</a>
-</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Afun">7.2.7 Functions</a>
-</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Aobj">7.2.8 Objects</a>
+<a href="values.html#ss%3Avalues%3Abase"><span class="number">2.1</span>Base values</a>
+</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Atuple"><span class="number">2.2</span>Tuples</a>
+</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Arecords"><span class="number">2.3</span>Records</a>
+</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Aarray"><span class="number">2.4</span>Arrays</a>
+</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Avariant"><span class="number">2.5</span>Variant values</a>
+</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Apolyvars"><span class="number">2.6</span>Polymorphic variants</a>
+</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Afun"><span class="number">2.7</span>Functions</a>
+</li><li class="li-toc"><a href="values.html#ss%3Avalues%3Aobj"><span class="number">2.8</span>Objects</a>
 </li></ul>
-</li><li class="li-toc"><a href="names.html#s%3Anames">7.3 Names</a>
-</li><li class="li-toc"><a href="types.html#s%3Atypexpr">7.4 Type expressions</a>
-</li><li class="li-toc"><a href="const.html#s%3Aconst">7.5 Constants</a>
-</li><li class="li-toc"><a href="patterns.html#s%3Apatterns">7.6 Patterns</a>
-</li><li class="li-toc"><a href="expr.html#s%3Avalue-expr">7.7 Expressions</a>
+</li><li class="li-toc"><a href="names.html#s%3Anames"><span class="number">3</span>Names</a>
+</li><li class="li-toc"><a href="types.html#s%3Atypexpr"><span class="number">4</span>Type expressions</a>
+</li><li class="li-toc"><a href="const.html#s%3Aconst"><span class="number">5</span>Constants</a>
+</li><li class="li-toc"><a href="patterns.html#s%3Apatterns"><span class="number">6</span>Patterns</a>
+</li><li class="li-toc"><a href="expr.html#s%3Avalue-expr"><span class="number">7</span>Expressions</a>
 <ul class="toc"><li class="li-toc">
-<a href="expr.html#ss%3Aprecedence-and-associativity">7.7.1 Precedence and associativity</a>
-</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-basic">7.7.2 Basic expressions</a>
-</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-control">7.7.3 Control structures</a>
-</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-ops-on-data">7.7.4 Operations on data structures</a>
-</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-operators">7.7.5 Operators</a>
-</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-obj">7.7.6 Objects</a>
-</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-coercions">7.7.7 Coercions</a>
-</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-other">7.7.8 Other</a>
+<a href="expr.html#ss%3Aprecedence-and-associativity"><span class="number">7.1</span>Precedence and associativity</a>
+</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-basic"><span class="number">7.2</span>Basic expressions</a>
+</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-control"><span class="number">7.3</span>Control structures</a>
+</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-ops-on-data"><span class="number">7.4</span>Operations on data structures</a>
+</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-operators"><span class="number">7.5</span>Operators</a>
+</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-obj"><span class="number">7.6</span>Objects</a>
+</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-coercions"><span class="number">7.7</span>Coercions</a>
+</li><li class="li-toc"><a href="expr.html#ss%3Aexpr-other"><span class="number">7.8</span>Other</a>
 </li></ul>
-</li><li class="li-toc"><a href="typedecl.html#s%3Atydef">7.8 Type and exception definitions</a>
+</li><li class="li-toc"><a href="typedecl.html#s%3Atydef"><span class="number">8</span>Type and exception definitions</a>
 <ul class="toc"><li class="li-toc">
-<a href="typedecl.html#ss%3Atypedefs">7.8.1 Type definitions</a>
-</li><li class="li-toc"><a href="typedecl.html#ss%3Aexndef">7.8.2 Exception definitions</a>
+<a href="typedecl.html#ss%3Atypedefs"><span class="number">8.1</span>Type definitions</a>
+</li><li class="li-toc"><a href="typedecl.html#ss%3Aexndef"><span class="number">8.2</span>Exception definitions</a>
 </li></ul>
-</li><li class="li-toc"><a href="classes.html#s%3Aclasses">7.9 Classes</a>
+</li><li class="li-toc"><a href="classes.html#s%3Aclasses"><span class="number">9</span>Classes</a>
 <ul class="toc"><li class="li-toc">
-<a href="classes.html#ss%3Aclasses%3Aclass-types">7.9.1 Class types</a>
-</li><li class="li-toc"><a href="classes.html#ss%3Aclass-expr">7.9.2 Class expressions</a>
-</li><li class="li-toc"><a href="classes.html#ss%3Aclass-def">7.9.3 Class definitions</a>
-</li><li class="li-toc"><a href="classes.html#ss%3Aclass-spec">7.9.4 Class specifications</a>
-</li><li class="li-toc"><a href="classes.html#ss%3Aclasstype">7.9.5 Class type definitions</a>
+<a href="classes.html#ss%3Aclasses%3Aclass-types"><span class="number">9.1</span>Class types</a>
+</li><li class="li-toc"><a href="classes.html#ss%3Aclass-expr"><span class="number">9.2</span>Class expressions</a>
+</li><li class="li-toc"><a href="classes.html#ss%3Aclass-def"><span class="number">9.3</span>Class definitions</a>
+</li><li class="li-toc"><a href="classes.html#ss%3Aclass-spec"><span class="number">9.4</span>Class specifications</a>
+</li><li class="li-toc"><a href="classes.html#ss%3Aclasstype"><span class="number">9.5</span>Class type definitions</a>
 </li></ul>
-</li><li class="li-toc"><a href="modtypes.html#s%3Amodtypes">7.10 Module types (module specifications)</a>
+</li><li class="li-toc"><a href="modtypes.html#s%3Amodtypes"><span class="number">10</span>Module types (module specifications)</a>
 <ul class="toc"><li class="li-toc">
-<a href="modtypes.html#ss%3Amty-simple">7.10.1 Simple module types</a>
-</li><li class="li-toc"><a href="modtypes.html#ss%3Amty-signatures">7.10.2 Signatures</a>
-</li><li class="li-toc"><a href="modtypes.html#ss%3Amty-functors">7.10.3 Functor types</a>
-</li><li class="li-toc"><a href="modtypes.html#ss%3Amty-with">7.10.4 The <span class="c004">with</span> operator</a>
+<a href="modtypes.html#ss%3Amty-simple"><span class="number">10.1</span>Simple module types</a>
+</li><li class="li-toc"><a href="modtypes.html#ss%3Amty-signatures"><span class="number">10.2</span>Signatures</a>
+</li><li class="li-toc"><a href="modtypes.html#ss%3Amty-functors"><span class="number">10.3</span>Functor types</a>
+</li><li class="li-toc"><a href="modtypes.html#ss%3Amty-with"><span class="number">10.4</span>The <span class="c004">with</span> operator</a>
 </li></ul>
-</li><li class="li-toc"><a href="modules.html#s%3Amodule-expr">7.11 Module expressions (module implementations)</a>
+</li><li class="li-toc"><a href="modules.html#s%3Amodule-expr"><span class="number">11</span>Module expressions (module implementations)</a>
 <ul class="toc"><li class="li-toc">
-<a href="modules.html#ss%3Amexpr-simple">7.11.1 Simple module expressions</a>
-</li><li class="li-toc"><a href="modules.html#ss%3Amexpr-structures">7.11.2 Structures</a>
-</li><li class="li-toc"><a href="modules.html#ss%3Amexpr-functors">7.11.3 Functors</a>
+<a href="modules.html#ss%3Amexpr-simple"><span class="number">11.1</span>Simple module expressions</a>
+</li><li class="li-toc"><a href="modules.html#ss%3Amexpr-structures"><span class="number">11.2</span>Structures</a>
+</li><li class="li-toc"><a href="modules.html#ss%3Amexpr-functors"><span class="number">11.3</span>Functors</a>
 </li></ul>
-</li><li class="li-toc"><a href="compunit.html#s%3Acompilation-units">7.12 Compilation units</a>
+</li><li class="li-toc"><a href="compunit.html#s%3Acompilation-units"><span class="number">12</span>Compilation units</a>
 </li></ul>
-</li><li class="li-toc"><a href="extn.html#sec238">Chapter ‍8 Language extensions</a>
+</li><li class="li-toc"><a href="extn.html#sec238"><span class="number">Chapter 8</span>Language extensions</a>
 <ul class="toc"><li class="li-toc">
-<a href="letrecvalues.html#s%3Aletrecvalues">8.1 Recursive definitions of values</a>
-</li><li class="li-toc"><a href="manual024.html#s%3Arecursive-modules">8.2 Recursive modules</a>
-</li><li class="li-toc"><a href="privatetypes.html#s%3Aprivate-types">8.3 Private types</a>
+<a href="letrecvalues.html#s%3Aletrecvalues"><span class="number">1</span>Recursive definitions of values</a>
+</li><li class="li-toc"><a href="manual024.html#s%3Arecursive-modules"><span class="number">2</span>Recursive modules</a>
+</li><li class="li-toc"><a href="privatetypes.html#s%3Aprivate-types"><span class="number">3</span>Private types</a>
 <ul class="toc"><li class="li-toc">
-<a href="privatetypes.html#ss%3Aprivate-types-variant">8.3.1 Private variant and record types</a>
-</li><li class="li-toc"><a href="privatetypes.html#ss%3Aprivate-types-abbrev">8.3.2 Private type abbreviations</a>
-</li><li class="li-toc"><a href="privatetypes.html#ss%3Aprivate-rows">8.3.3 Private row types</a>
+<a href="privatetypes.html#ss%3Aprivate-types-variant"><span class="number">3.1</span>Private variant and record types</a>
+</li><li class="li-toc"><a href="privatetypes.html#ss%3Aprivate-types-abbrev"><span class="number">3.2</span>Private type abbreviations</a>
+</li><li class="li-toc"><a href="privatetypes.html#ss%3Aprivate-rows"><span class="number">3.3</span>Private row types</a>
 </li></ul>
-</li><li class="li-toc"><a href="locallyabstract.html#s%3Alocally-abstract">8.4 Locally abstract types</a>
-</li><li class="li-toc"><a href="firstclassmodules.html#s%3Afirst-class-modules">8.5 First-class modules</a>
-</li><li class="li-toc"><a href="moduletypeof.html#s%3Amodule-type-of">8.6 Recovering the type of a module</a>
-</li><li class="li-toc"><a href="signaturesubstitution.html#s%3Asignature-substitution">8.7 Substituting inside a signature</a>
+</li><li class="li-toc"><a href="locallyabstract.html#s%3Alocally-abstract"><span class="number">4</span>Locally abstract types</a>
+</li><li class="li-toc"><a href="firstclassmodules.html#s%3Afirst-class-modules"><span class="number">5</span>First-class modules</a>
+</li><li class="li-toc"><a href="moduletypeof.html#s%3Amodule-type-of"><span class="number">6</span>Recovering the type of a module</a>
+</li><li class="li-toc"><a href="signaturesubstitution.html#s%3Asignature-substitution"><span class="number">7</span>Substituting inside a signature</a>
 <ul class="toc"><li class="li-toc">
-<a href="signaturesubstitution.html#ss%3Adestructive-substitution">8.7.1 Destructive substitutions</a>
-</li><li class="li-toc"><a href="signaturesubstitution.html#ss%3Alocal-substitution">8.7.2 Local substitution declarations</a>
+<a href="signaturesubstitution.html#ss%3Adestructive-substitution"><span class="number">7.1</span>Destructive substitutions</a>
+</li><li class="li-toc"><a href="signaturesubstitution.html#ss%3Alocal-substitution"><span class="number">7.2</span>Local substitution declarations</a>
 </li></ul>
-</li><li class="li-toc"><a href="modulealias.html#s%3Amodule-alias">8.8 Type-level module aliases</a>
-</li><li class="li-toc"><a href="overridingopen.html#s%3Aexplicit-overriding-open">8.9 Overriding in open statements</a>
-</li><li class="li-toc"><a href="gadts.html#s%3Agadts">8.10 Generalized algebraic datatypes</a>
-</li><li class="li-toc"><a href="bigarray.html#s%3Abigarray-access">8.11 Syntax for Bigarray access</a>
-</li><li class="li-toc"><a href="attributes.html#s%3Aattributes">8.12 Attributes</a>
+</li><li class="li-toc"><a href="modulealias.html#s%3Amodule-alias"><span class="number">8</span>Type-level module aliases</a>
+</li><li class="li-toc"><a href="overridingopen.html#s%3Aexplicit-overriding-open"><span class="number">9</span>Overriding in open statements</a>
+</li><li class="li-toc"><a href="gadts.html#s%3Agadts"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li class="li-toc"><a href="bigarray.html#s%3Abigarray-access"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li class="li-toc"><a href="attributes.html#s%3Aattributes"><span class="number">12</span>Attributes</a>
 <ul class="toc"><li class="li-toc">
-<a href="attributes.html#ss%3Abuiltin-attributes">8.12.1 Built-in attributes</a>
+<a href="attributes.html#ss%3Abuiltin-attributes"><span class="number">12.1</span>Built-in attributes</a>
 </li></ul>
-</li><li class="li-toc"><a href="extensionnodes.html#s%3Aextension-nodes">8.13 Extension nodes</a>
+</li><li class="li-toc"><a href="extensionnodes.html#s%3Aextension-nodes"><span class="number">13</span>Extension nodes</a>
 <ul class="toc"><li class="li-toc">
-<a href="extensionnodes.html#ss%3Abuiltin-extension-nodes">8.13.1 Built-in extension nodes</a>
+<a href="extensionnodes.html#ss%3Abuiltin-extension-nodes"><span class="number">13.1</span>Built-in extension nodes</a>
 </li></ul>
-</li><li class="li-toc"><a href="extensiblevariants.html#s%3Aextensible-variants">8.14 Extensible variant types</a>
+</li><li class="li-toc"><a href="extensiblevariants.html#s%3Aextensible-variants"><span class="number">14</span>Extensible variant types</a>
 <ul class="toc"><li class="li-toc">
-<a href="extensiblevariants.html#ss%3Aprivate-extensible">8.14.1 Private extensible variant types</a>
+<a href="extensiblevariants.html#ss%3Aprivate-extensible"><span class="number">14.1</span>Private extensible variant types</a>
 </li></ul>
-</li><li class="li-toc"><a href="generativefunctors.html#s%3Agenerative-functors">8.15 Generative functors</a>
-</li><li class="li-toc"><a href="extensionsyntax.html#s%3Aextension-syntax">8.16 Extension-only syntax</a>
+</li><li class="li-toc"><a href="generativefunctors.html#s%3Agenerative-functors"><span class="number">15</span>Generative functors</a>
+</li><li class="li-toc"><a href="extensionsyntax.html#s%3Aextension-syntax"><span class="number">16</span>Extension-only syntax</a>
 <ul class="toc"><li class="li-toc">
-<a href="extensionsyntax.html#ss%3Aextension-operators">8.16.1 Extension operators</a>
-</li><li class="li-toc"><a href="extensionsyntax.html#ss%3Aextension-literals">8.16.2 Extension literals</a>
+<a href="extensionsyntax.html#ss%3Aextension-operators"><span class="number">16.1</span>Extension operators</a>
+</li><li class="li-toc"><a href="extensionsyntax.html#ss%3Aextension-literals"><span class="number">16.2</span>Extension literals</a>
 </li></ul>
-</li><li class="li-toc"><a href="inlinerecords.html#s%3Ainline-records">8.17 Inline records</a>
-</li><li class="li-toc"><a href="doccomments.html#s%3Adoc-comments">8.18 Documentation comments</a>
+</li><li class="li-toc"><a href="inlinerecords.html#s%3Ainline-records"><span class="number">17</span>Inline records</a>
+</li><li class="li-toc"><a href="doccomments.html#s%3Adoc-comments"><span class="number">18</span>Documentation comments</a>
 <ul class="toc"><li class="li-toc">
-<a href="doccomments.html#ss%3Afloating-comments">8.18.1 Floating comments</a>
-</li><li class="li-toc"><a href="doccomments.html#ss%3Aitem-comments">8.18.2 Item comments</a>
-</li><li class="li-toc"><a href="doccomments.html#ss%3Alabel-comments">8.18.3 Label comments</a>
+<a href="doccomments.html#ss%3Afloating-comments"><span class="number">18.1</span>Floating comments</a>
+</li><li class="li-toc"><a href="doccomments.html#ss%3Aitem-comments"><span class="number">18.2</span>Item comments</a>
+</li><li class="li-toc"><a href="doccomments.html#ss%3Alabel-comments"><span class="number">18.3</span>Label comments</a>
 </li></ul>
-</li><li class="li-toc"><a href="indexops.html#s%3Aindex-operators">8.19 Extended indexing operators </a>
+</li><li class="li-toc"><a href="indexops.html#s%3Aindex-operators"><span class="number">19</span>Extended indexing operators </a>
 <ul class="toc"><li class="li-toc">
-<a href="indexops.html#ss%3Amultiindexing">8.19.1 Multi-index notation</a>
+<a href="indexops.html#ss%3Amultiindexing"><span class="number">19.1</span>Multi-index notation</a>
 </li></ul>
-</li><li class="li-toc"><a href="emptyvariants.html#s%3Aempty-variants">8.20 Empty variant types</a>
-</li><li class="li-toc"><a href="alerts.html#s%3Aalerts">8.21 Alerts</a>
-</li><li class="li-toc"><a href="generalizedopens.html#s%3Ageneralized-open">8.22 Generalized open statements</a>
-</li><li class="li-toc"><a href="bindingops.html#s%3Abinding-operators">8.23 Binding operators</a>
+</li><li class="li-toc"><a href="emptyvariants.html#s%3Aempty-variants"><span class="number">20</span>Empty variant types</a>
+</li><li class="li-toc"><a href="alerts.html#s%3Aalerts"><span class="number">21</span>Alerts</a>
+</li><li class="li-toc"><a href="generalizedopens.html#s%3Ageneralized-open"><span class="number">22</span>Generalized open statements</a>
+</li><li class="li-toc"><a href="bindingops.html#s%3Abinding-operators"><span class="number">23</span>Binding operators</a>
 <ul class="toc"><li class="li-toc">
-<a href="bindingops.html#ss%3Aletops-rationale">8.23.1 Rationale</a>
+<a href="bindingops.html#ss%3Aletops-rationale"><span class="number">23.1</span>Rationale</a>
 </li></ul>
 </li></ul>
 </li></ul>
-</li><li class="li-toc"><a href="index.html#sec286">Part ‍III The OCaml tools</a>
+</li><li class="li-toc"><a href="index.html#sec286">Part&nbsp;III The OCaml tools</a>
 <ul class="toc"><li class="li-toc">
-<a href="comp.html#sec287">Chapter ‍9 Batch compilation (ocamlc)</a>
+<a href="comp.html#sec287"><span class="number">Chapter 9</span>Batch compilation (ocamlc)</a>
 <ul class="toc"><li class="li-toc">
-<a href="comp.html#s%3Acomp-overview">9.1 Overview of the compiler</a>
-</li><li class="li-toc"><a href="comp.html#s%3Acomp-options">9.2 Options</a>
-</li><li class="li-toc"><a href="comp.html#s%3Amodules-file-system">9.3 Modules and the file system</a>
-</li><li class="li-toc"><a href="comp.html#s%3Acomp-errors">9.4 Common errors</a>
-</li><li class="li-toc"><a href="comp.html#s%3Acomp-warnings">9.5 Warning reference</a>
+<a href="comp.html#s%3Acomp-overview"><span class="number">1</span>Overview of the compiler</a>
+</li><li class="li-toc"><a href="comp.html#s%3Acomp-options"><span class="number">2</span>Options</a>
+</li><li class="li-toc"><a href="comp.html#s%3Amodules-file-system"><span class="number">3</span>Modules and the file system</a>
+</li><li class="li-toc"><a href="comp.html#s%3Acomp-errors"><span class="number">4</span>Common errors</a>
+</li><li class="li-toc"><a href="comp.html#s%3Acomp-warnings"><span class="number">5</span>Warning reference</a>
 <ul class="toc"><li class="li-toc">
-<a href="comp.html#ss%3Awarn9">9.5.1 Warning 9: missing fields in a record pattern</a>
-</li><li class="li-toc"><a href="comp.html#ss%3Awarn52">9.5.2 Warning 52: fragile constant pattern</a>
-</li><li class="li-toc"><a href="comp.html#ss%3Awarn57">9.5.3 Warning 57: Ambiguous or-pattern variables under guard</a>
+<a href="comp.html#ss%3Awarn9"><span class="number">5.1</span>Warning 9: missing fields in a record pattern</a>
+</li><li class="li-toc"><a href="comp.html#ss%3Awarn52"><span class="number">5.2</span>Warning 52: fragile constant pattern</a>
+</li><li class="li-toc"><a href="comp.html#ss%3Awarn57"><span class="number">5.3</span>Warning 57: Ambiguous or-pattern variables under guard</a>
 </li></ul>
 </li></ul>
-</li><li class="li-toc"><a href="toplevel.html#sec297">Chapter ‍10 The toplevel system or REPL (ocaml)</a>
+</li><li class="li-toc"><a href="toplevel.html#sec297"><span class="number">Chapter 10</span>The toplevel system or REPL (ocaml)</a>
 <ul class="toc"><li class="li-toc">
-<a href="toplevel.html#s%3Atoplevel-options">10.1 Options</a>
-</li><li class="li-toc"><a href="toplevel.html#s%3Atoplevel-directives">10.2 Toplevel directives</a>
-</li><li class="li-toc"><a href="toplevel.html#s%3Atoplevel-modules">10.3 The toplevel and the module system</a>
-</li><li class="li-toc"><a href="toplevel.html#s%3Atoplevel-common-errors">10.4 Common errors</a>
-</li><li class="li-toc"><a href="toplevel.html#s%3Acustom-toplevel">10.5 Building custom toplevel systems: <span class="c004">ocamlmktop</span></a>
+<a href="toplevel.html#s%3Atoplevel-options"><span class="number">1</span>Options</a>
+</li><li class="li-toc"><a href="toplevel.html#s%3Atoplevel-directives"><span class="number">2</span>Toplevel directives</a>
+</li><li class="li-toc"><a href="toplevel.html#s%3Atoplevel-modules"><span class="number">3</span>The toplevel and the module system</a>
+</li><li class="li-toc"><a href="toplevel.html#s%3Atoplevel-common-errors"><span class="number">4</span>Common errors</a>
+</li><li class="li-toc"><a href="toplevel.html#s%3Acustom-toplevel"><span class="number">5</span>Building custom toplevel systems: <span class="c004">ocamlmktop</span></a>
 <ul class="toc"><li class="li-toc">
-<a href="toplevel.html#ss%3Aocamlmktop-options">10.5.1 Options</a>
+<a href="toplevel.html#ss%3Aocamlmktop-options"><span class="number">5.1</span>Options</a>
 </li></ul>
-</li><li class="li-toc"><a href="toplevel.html#s%3Aocamlnat">10.6 The native toplevel: <span class="c004">ocamlnat</span> (experimental)</a>
+</li><li class="li-toc"><a href="toplevel.html#s%3Aocamlnat"><span class="number">6</span>The native toplevel: <span class="c004">ocamlnat</span> (experimental)</a>
 </li></ul>
-</li><li class="li-toc"><a href="runtime.html#sec305">Chapter ‍11 The runtime system (ocamlrun)</a>
+</li><li class="li-toc"><a href="runtime.html#sec305"><span class="number">Chapter 11</span>The runtime system (ocamlrun)</a>
 <ul class="toc"><li class="li-toc">
-<a href="runtime.html#s%3Aocamlrun-overview">11.1 Overview</a>
-</li><li class="li-toc"><a href="runtime.html#s%3Aocamlrun-options">11.2 Options</a>
-</li><li class="li-toc"><a href="runtime.html#s%3Aocamlrun-dllpath">11.3 Dynamic loading of shared libraries</a>
-</li><li class="li-toc"><a href="runtime.html#s%3Aocamlrun-common-errors">11.4 Common errors</a>
+<a href="runtime.html#s%3Aocamlrun-overview"><span class="number">1</span>Overview</a>
+</li><li class="li-toc"><a href="runtime.html#s%3Aocamlrun-options"><span class="number">2</span>Options</a>
+</li><li class="li-toc"><a href="runtime.html#s%3Aocamlrun-dllpath"><span class="number">3</span>Dynamic loading of shared libraries</a>
+</li><li class="li-toc"><a href="runtime.html#s%3Aocamlrun-common-errors"><span class="number">4</span>Common errors</a>
 </li></ul>
-</li><li class="li-toc"><a href="native.html#sec310">Chapter ‍12 Native-code compilation (ocamlopt)</a>
+</li><li class="li-toc"><a href="native.html#sec310"><span class="number">Chapter 12</span>Native-code compilation (ocamlopt)</a>
 <ul class="toc"><li class="li-toc">
-<a href="native.html#s%3Anative-overview">12.1 Overview of the compiler</a>
-</li><li class="li-toc"><a href="native.html#s%3Anative-options">12.2 Options</a>
-</li><li class="li-toc"><a href="native.html#s%3Anative-common-errors">12.3 Common errors</a>
-</li><li class="li-toc"><a href="native.html#s%3Anative%3Arunning-executable">12.4 Running executables produced by ocamlopt</a>
-</li><li class="li-toc"><a href="native.html#s%3Acompat-native-bytecode">12.5 Compatibility with the bytecode compiler</a>
+<a href="native.html#s%3Anative-overview"><span class="number">1</span>Overview of the compiler</a>
+</li><li class="li-toc"><a href="native.html#s%3Anative-options"><span class="number">2</span>Options</a>
+</li><li class="li-toc"><a href="native.html#s%3Anative-common-errors"><span class="number">3</span>Common errors</a>
+</li><li class="li-toc"><a href="native.html#s%3Anative%3Arunning-executable"><span class="number">4</span>Running executables produced by ocamlopt</a>
+</li><li class="li-toc"><a href="native.html#s%3Acompat-native-bytecode"><span class="number">5</span>Compatibility with the bytecode compiler</a>
 </li></ul>
-</li><li class="li-toc"><a href="lexyacc.html#sec320">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a>
+</li><li class="li-toc"><a href="lexyacc.html#sec320"><span class="number">Chapter 13</span>Lexer and parser generators (ocamllex, ocamlyacc)</a>
 <ul class="toc"><li class="li-toc">
-<a href="lexyacc.html#s%3Aocamllex-overview">13.1 Overview of <span class="c004">ocamllex</span></a>
+<a href="lexyacc.html#s%3Aocamllex-overview"><span class="number">1</span>Overview of <span class="c004">ocamllex</span></a>
 <ul class="toc"><li class="li-toc">
-<a href="lexyacc.html#ss%3Aocamllex-options">13.1.1 Options</a>
+<a href="lexyacc.html#ss%3Aocamllex-options"><span class="number">1.1</span>Options</a>
 </li></ul>
-</li><li class="li-toc"><a href="lexyacc.html#s%3Aocamllex-syntax">13.2 Syntax of lexer definitions</a>
+</li><li class="li-toc"><a href="lexyacc.html#s%3Aocamllex-syntax"><span class="number">2</span>Syntax of lexer definitions</a>
 <ul class="toc"><li class="li-toc">
-<a href="lexyacc.html#ss%3Aocamllex-header-trailer">13.2.1 Header and trailer</a>
-</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-named-regexp">13.2.2 Naming regular expressions</a>
-</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-entry-points">13.2.3 Entry points</a>
-</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-regexp">13.2.4 Regular expressions</a>
-</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-actions">13.2.5 Actions</a>
-</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-variables">13.2.6 Variables in regular expressions</a>
-</li><li class="li-toc"><a href="lexyacc.html#ss%3Arefill-handlers">13.2.7 Refill handlers</a>
-</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-reserved-ident">13.2.8 Reserved identifiers</a>
+<a href="lexyacc.html#ss%3Aocamllex-header-trailer"><span class="number">2.1</span>Header and trailer</a>
+</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-named-regexp"><span class="number">2.2</span>Naming regular expressions</a>
+</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-entry-points"><span class="number">2.3</span>Entry points</a>
+</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-regexp"><span class="number">2.4</span>Regular expressions</a>
+</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-actions"><span class="number">2.5</span>Actions</a>
+</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-variables"><span class="number">2.6</span>Variables in regular expressions</a>
+</li><li class="li-toc"><a href="lexyacc.html#ss%3Arefill-handlers"><span class="number">2.7</span>Refill handlers</a>
+</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamllex-reserved-ident"><span class="number">2.8</span>Reserved identifiers</a>
 </li></ul>
-</li><li class="li-toc"><a href="lexyacc.html#s%3Aocamlyacc-overview">13.3 Overview of <span class="c004">ocamlyacc</span></a>
-</li><li class="li-toc"><a href="lexyacc.html#s%3Aocamlyacc-syntax">13.4 Syntax of grammar definitions</a>
+</li><li class="li-toc"><a href="lexyacc.html#s%3Aocamlyacc-overview"><span class="number">3</span>Overview of <span class="c004">ocamlyacc</span></a>
+</li><li class="li-toc"><a href="lexyacc.html#s%3Aocamlyacc-syntax"><span class="number">4</span>Syntax of grammar definitions</a>
 <ul class="toc"><li class="li-toc">
-<a href="lexyacc.html#ss%3Aocamlyacc-header-trailer">13.4.1 Header and trailer</a>
-</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamlyacc-declarations">13.4.2 Declarations</a>
-</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamlyacc-rules">13.4.3 Rules</a>
-</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamlyacc-error-handling">13.4.4 Error handling</a>
+<a href="lexyacc.html#ss%3Aocamlyacc-header-trailer"><span class="number">4.1</span>Header and trailer</a>
+</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamlyacc-declarations"><span class="number">4.2</span>Declarations</a>
+</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamlyacc-rules"><span class="number">4.3</span>Rules</a>
+</li><li class="li-toc"><a href="lexyacc.html#ss%3Aocamlyacc-error-handling"><span class="number">4.4</span>Error handling</a>
 </li></ul>
-</li><li class="li-toc"><a href="lexyacc.html#s%3Aocamlyacc-options">13.5 Options</a>
-</li><li class="li-toc"><a href="lexyacc.html#s%3Alexyacc-example">13.6 A complete example</a>
-</li><li class="li-toc"><a href="lexyacc.html#s%3Alexyacc-common-errors">13.7 Common errors</a>
+</li><li class="li-toc"><a href="lexyacc.html#s%3Aocamlyacc-options"><span class="number">5</span>Options</a>
+</li><li class="li-toc"><a href="lexyacc.html#s%3Alexyacc-example"><span class="number">6</span>A complete example</a>
+</li><li class="li-toc"><a href="lexyacc.html#s%3Alexyacc-common-errors"><span class="number">7</span>Common errors</a>
 </li></ul>
-</li><li class="li-toc"><a href="depend.html#sec341">Chapter ‍14 Dependency generator (ocamldep)</a>
+</li><li class="li-toc"><a href="depend.html#sec341"><span class="number">Chapter 14</span>Dependency generator (ocamldep)</a>
 <ul class="toc"><li class="li-toc">
-<a href="depend.html#s%3Aocamldep-options">14.1 Options</a>
-</li><li class="li-toc"><a href="depend.html#s%3Aocamldep-makefile">14.2 A typical Makefile</a>
+<a href="depend.html#s%3Aocamldep-options"><span class="number">1</span>Options</a>
+</li><li class="li-toc"><a href="depend.html#s%3Aocamldep-makefile"><span class="number">2</span>A typical Makefile</a>
 </li></ul>
-</li><li class="li-toc"><a href="ocamldoc.html#sec344">Chapter ‍15 The documentation generator (ocamldoc)</a>
+</li><li class="li-toc"><a href="ocamldoc.html#sec344"><span class="number">Chapter 15</span>The documentation generator (ocamldoc)</a>
 <ul class="toc"><li class="li-toc">
-<a href="ocamldoc.html#s%3Aocamldoc-usage">15.1 Usage</a>
+<a href="ocamldoc.html#s%3Aocamldoc-usage"><span class="number">1</span>Usage</a>
 <ul class="toc"><li class="li-toc">
-<a href="ocamldoc.html#ss%3Aocamldoc-invocation">15.1.1 Invocation</a>
-</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-merge">15.1.2 Merging of module information</a>
-</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-rules">15.1.3 Coding rules</a>
+<a href="ocamldoc.html#ss%3Aocamldoc-invocation"><span class="number">1.1</span>Invocation</a>
+</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-merge"><span class="number">1.2</span>Merging of module information</a>
+</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-rules"><span class="number">1.3</span>Coding rules</a>
 </li></ul>
-</li><li class="li-toc"><a href="ocamldoc.html#s%3Aocamldoc-comments">15.2 Syntax of documentation comments</a>
+</li><li class="li-toc"><a href="ocamldoc.html#s%3Aocamldoc-comments"><span class="number">2</span>Syntax of documentation comments</a>
 <ul class="toc"><li class="li-toc">
-<a href="ocamldoc.html#ss%3Aocamldoc-placement">15.2.1 Placement of documentation comments</a>
-</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-stop">15.2.2 The Stop special comment</a>
-</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-syntax">15.2.3 Syntax of documentation comments</a>
-</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-formatting">15.2.4 Text formatting</a>
-</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-tags">15.2.5 Documentation tags (@-tags)</a>
+<a href="ocamldoc.html#ss%3Aocamldoc-placement"><span class="number">2.1</span>Placement of documentation comments</a>
+</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-stop"><span class="number">2.2</span>The Stop special comment</a>
+</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-syntax"><span class="number">2.3</span>Syntax of documentation comments</a>
+</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-formatting"><span class="number">2.4</span>Text formatting</a>
+</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-tags"><span class="number">2.5</span>Documentation tags (@-tags)</a>
 </li></ul>
-</li><li class="li-toc"><a href="ocamldoc.html#s%3Aocamldoc-custom-generators">15.3 Custom generators</a>
+</li><li class="li-toc"><a href="ocamldoc.html#s%3Aocamldoc-custom-generators"><span class="number">3</span>Custom generators</a>
 <ul class="toc"><li class="li-toc">
-<a href="ocamldoc.html#ss%3Aocamldoc-generators">15.3.1 The generator modules</a>
-</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-handling-custom-tags">15.3.2 Handling custom tags</a>
+<a href="ocamldoc.html#ss%3Aocamldoc-generators"><span class="number">3.1</span>The generator modules</a>
+</li><li class="li-toc"><a href="ocamldoc.html#ss%3Aocamldoc-handling-custom-tags"><span class="number">3.2</span>Handling custom tags</a>
 </li></ul>
-</li><li class="li-toc"><a href="ocamldoc.html#s%3Aocamldoc-adding-flags">15.4 Adding command line options</a>
+</li><li class="li-toc"><a href="ocamldoc.html#s%3Aocamldoc-adding-flags"><span class="number">4</span>Adding command line options</a>
 <ul class="toc"><li class="li-toc">
-<a href="ocamldoc.html#ss%3Aocamldoc-compilation-and-usage">15.4.1 Compilation and usage</a>
+<a href="ocamldoc.html#ss%3Aocamldoc-compilation-and-usage"><span class="number">4.1</span>Compilation and usage</a>
 </li></ul>
 </li></ul>
-</li><li class="li-toc"><a href="debugger.html#sec381">Chapter ‍16 The debugger (ocamldebug)</a>
+</li><li class="li-toc"><a href="debugger.html#sec381"><span class="number">Chapter 16</span>The debugger (ocamldebug)</a>
 <ul class="toc"><li class="li-toc">
-<a href="debugger.html#s%3Adebugger-compilation">16.1 Compiling for debugging</a>
-</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-invocation">16.2 Invocation</a>
+<a href="debugger.html#s%3Adebugger-compilation"><span class="number">1</span>Compiling for debugging</a>
+</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-invocation"><span class="number">2</span>Invocation</a>
 <ul class="toc"><li class="li-toc">
-<a href="debugger.html#ss%3Adebugger-start">16.2.1 Starting the debugger</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-init-file">16.2.2 Initialization file</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-exut">16.2.3 Exiting the debugger</a>
+<a href="debugger.html#ss%3Adebugger-start"><span class="number">2.1</span>Starting the debugger</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-init-file"><span class="number">2.2</span>Initialization file</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-exut"><span class="number">2.3</span>Exiting the debugger</a>
 </li></ul>
-</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-commands">16.3 Commands</a>
+</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-commands"><span class="number">3</span>Commands</a>
 <ul class="toc"><li class="li-toc">
-<a href="debugger.html#ss%3Adebugger-help">16.3.1 Getting help</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-state">16.3.2 Accessing the debugger state</a>
+<a href="debugger.html#ss%3Adebugger-help"><span class="number">3.1</span>Getting help</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-state"><span class="number">3.2</span>Accessing the debugger state</a>
 </li></ul>
-</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-execution">16.4 Executing a program</a>
+</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-execution"><span class="number">4</span>Executing a program</a>
 <ul class="toc"><li class="li-toc">
-<a href="debugger.html#ss%3Adebugger-events">16.4.1 Events</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-starting-program">16.4.2 Starting the debugged program</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-running">16.4.3 Running the program</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-time-travel">16.4.4 Time travel</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-kill">16.4.5 Killing the program</a>
+<a href="debugger.html#ss%3Adebugger-events"><span class="number">4.1</span>Events</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-starting-program"><span class="number">4.2</span>Starting the debugged program</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-running"><span class="number">4.3</span>Running the program</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-time-travel"><span class="number">4.4</span>Time travel</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-kill"><span class="number">4.5</span>Killing the program</a>
 </li></ul>
-</li><li class="li-toc"><a href="debugger.html#s%3Abreakpoints">16.5 Breakpoints</a>
-</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-callstack">16.6 The call stack</a>
-</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-examining-values">16.7 Examining variable values</a>
-</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-control">16.8 Controlling the debugger</a>
+</li><li class="li-toc"><a href="debugger.html#s%3Abreakpoints"><span class="number">5</span>Breakpoints</a>
+</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-callstack"><span class="number">6</span>The call stack</a>
+</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-examining-values"><span class="number">7</span>Examining variable values</a>
+</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-control"><span class="number">8</span>Controlling the debugger</a>
 <ul class="toc"><li class="li-toc">
-<a href="debugger.html#ss%3Adebugger-name-and-arguments">16.8.1 Setting the program name and arguments</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-loading">16.8.2 How programs are loaded</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-search-path">16.8.3 Search path for files</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-working-dir">16.8.4 Working directory</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-reverse-execution">16.8.5 Turning reverse execution on and off</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-fork">16.8.6 Behavior of the debugger with respect to <span class="c004">fork</span></a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-stop-at-new-load">16.8.7 Stopping execution when new code is loaded</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-communication">16.8.8 Communication between the debugger and the program</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-fine-tuning">16.8.9 Fine-tuning the debugger</a>
-</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-printers">16.8.10 User-defined printers</a>
+<a href="debugger.html#ss%3Adebugger-name-and-arguments"><span class="number">8.1</span>Setting the program name and arguments</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-loading"><span class="number">8.2</span>How programs are loaded</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-search-path"><span class="number">8.3</span>Search path for files</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-working-dir"><span class="number">8.4</span>Working directory</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-reverse-execution"><span class="number">8.5</span>Turning reverse execution on and off</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-fork"><span class="number">8.6</span>Behavior of the debugger with respect to <span class="c004">fork</span></a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-stop-at-new-load"><span class="number">8.7</span>Stopping execution when new code is loaded</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-communication"><span class="number">8.8</span>Communication between the debugger and the program</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-fine-tuning"><span class="number">8.9</span>Fine-tuning the debugger</a>
+</li><li class="li-toc"><a href="debugger.html#ss%3Adebugger-printers"><span class="number">8.10</span>User-defined printers</a>
 </li></ul>
-</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-misc-cmds">16.9 Miscellaneous commands</a>
-</li><li class="li-toc"><a href="debugger.html#s%3Ainf-debugger">16.10 Running the debugger under Emacs</a>
+</li><li class="li-toc"><a href="debugger.html#s%3Adebugger-misc-cmds"><span class="number">9</span>Miscellaneous commands</a>
+</li><li class="li-toc"><a href="debugger.html#s%3Ainf-debugger"><span class="number">10</span>Running the debugger under Emacs</a>
 </li></ul>
-</li><li class="li-toc"><a href="profil.html#sec412">Chapter ‍17 Profiling (ocamlprof)</a>
+</li><li class="li-toc"><a href="profil.html#sec412"><span class="number">Chapter 17</span>Profiling (ocamlprof)</a>
 <ul class="toc"><li class="li-toc">
-<a href="profil.html#s%3Aocamlprof-compiling">17.1 Compiling for profiling</a>
-</li><li class="li-toc"><a href="profil.html#s%3Aocamlprof-profiling">17.2 Profiling an execution</a>
-</li><li class="li-toc"><a href="profil.html#s%3Aocamlprof-printing">17.3 Printing profiling information</a>
-</li><li class="li-toc"><a href="profil.html#s%3Aocamlprof-time-profiling">17.4 Time profiling</a>
+<a href="profil.html#s%3Aocamlprof-compiling"><span class="number">1</span>Compiling for profiling</a>
+</li><li class="li-toc"><a href="profil.html#s%3Aocamlprof-profiling"><span class="number">2</span>Profiling an execution</a>
+</li><li class="li-toc"><a href="profil.html#s%3Aocamlprof-printing"><span class="number">3</span>Printing profiling information</a>
+</li><li class="li-toc"><a href="profil.html#s%3Aocamlprof-time-profiling"><span class="number">4</span>Time profiling</a>
 </li></ul>
-</li><li class="li-toc"><a href="intfc.html#c%3Aintf-c">Chapter ‍18 Interfacing C with OCaml</a>
+</li><li class="li-toc"><a href="intfc.html#c%3Aintf-c"><span class="number">Chapter 18</span>Interfacing C with OCaml</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#s%3Ac-overview">18.1 Overview and compilation information</a>
+<a href="intfc.html#s%3Ac-overview"><span class="number">1</span>Overview and compilation information</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#ss%3Ac-prim-decl">18.1.1 Declaring primitives</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-prim-impl">18.1.2 Implementing primitives</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Astaticlink-c-code">18.1.3 Statically linking C code with OCaml code</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Adynlink-c-code">18.1.4 Dynamically linking C code with OCaml code</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-static-vs-dynamic">18.1.5 Choosing between static linking and dynamic linking</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Acustom-runtime">18.1.6 Building standalone custom runtime systems</a>
+<a href="intfc.html#ss%3Ac-prim-decl"><span class="number">1.1</span>Declaring primitives</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-prim-impl"><span class="number">1.2</span>Implementing primitives</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Astaticlink-c-code"><span class="number">1.3</span>Statically linking C code with OCaml code</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Adynlink-c-code"><span class="number">1.4</span>Dynamically linking C code with OCaml code</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-static-vs-dynamic"><span class="number">1.5</span>Choosing between static linking and dynamic linking</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Acustom-runtime"><span class="number">1.6</span>Building standalone custom runtime systems</a>
 </li></ul>
-</li><li class="li-toc"><a href="intfc.html#s%3Ac-value">18.2 The <span class="c004">value</span> type</a>
+</li><li class="li-toc"><a href="intfc.html#s%3Ac-value"><span class="number">2</span>The <span class="c004">value</span> type</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#ss%3Ac-int">18.2.1 Integer values</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-blocks">18.2.2 Blocks</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-outside-head">18.2.3 Pointers outside the heap</a>
+<a href="intfc.html#ss%3Ac-int"><span class="number">2.1</span>Integer values</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-blocks"><span class="number">2.2</span>Blocks</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-outside-head"><span class="number">2.3</span>Pointers outside the heap</a>
 </li></ul>
-</li><li class="li-toc"><a href="intfc.html#s%3Ac-ocaml-datatype-repr">18.3 Representation of OCaml data types</a>
+</li><li class="li-toc"><a href="intfc.html#s%3Ac-ocaml-datatype-repr"><span class="number">3</span>Representation of OCaml data types</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#ss%3Ac-atomic">18.3.1 Atomic types</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-tuples-and-records">18.3.2 Tuples and records</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-arrays">18.3.3 Arrays</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-concrete-datatypes">18.3.4 Concrete data types</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-objects">18.3.5 Objects</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-polyvar">18.3.6 Polymorphic variants</a>
+<a href="intfc.html#ss%3Ac-atomic"><span class="number">3.1</span>Atomic types</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-tuples-and-records"><span class="number">3.2</span>Tuples and records</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-arrays"><span class="number">3.3</span>Arrays</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-concrete-datatypes"><span class="number">3.4</span>Concrete data types</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-objects"><span class="number">3.5</span>Objects</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-polyvar"><span class="number">3.6</span>Polymorphic variants</a>
 </li></ul>
-</li><li class="li-toc"><a href="intfc.html#s%3Ac-ops-on-values">18.4 Operations on values</a>
+</li><li class="li-toc"><a href="intfc.html#s%3Ac-ops-on-values"><span class="number">4</span>Operations on values</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#ss%3Ac-kind-tests">18.4.1 Kind tests</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-int-ops">18.4.2 Operations on integers</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-block-access">18.4.3 Accessing blocks</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-block-allocation">18.4.4 Allocating blocks</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-exceptions">18.4.5 Raising exceptions</a>
+<a href="intfc.html#ss%3Ac-kind-tests"><span class="number">4.1</span>Kind tests</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-int-ops"><span class="number">4.2</span>Operations on integers</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-block-access"><span class="number">4.3</span>Accessing blocks</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-block-allocation"><span class="number">4.4</span>Allocating blocks</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-exceptions"><span class="number">4.5</span>Raising exceptions</a>
 </li></ul>
-</li><li class="li-toc"><a href="intfc.html#s%3Ac-gc-harmony">18.5 Living in harmony with the garbage collector</a>
+</li><li class="li-toc"><a href="intfc.html#s%3Ac-gc-harmony"><span class="number">5</span>Living in harmony with the garbage collector</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#ss%3Ac-simple-gc-harmony">18.5.1 Simple interface</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-low-level-gc-harmony">18.5.2 Low-level interface</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-process-pending-actions">18.5.3 Pending actions and asynchronous exceptions</a>
+<a href="intfc.html#ss%3Ac-simple-gc-harmony"><span class="number">5.1</span>Simple interface</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-low-level-gc-harmony"><span class="number">5.2</span>Low-level interface</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-process-pending-actions"><span class="number">5.3</span>Pending actions and asynchronous exceptions</a>
 </li></ul>
-</li><li class="li-toc"><a href="intfc.html#s%3Ac-intf-example">18.6 A complete example</a>
-</li><li class="li-toc"><a href="intfc.html#s%3Ac-callback">18.7 Advanced topic: callbacks from C to OCaml</a>
+</li><li class="li-toc"><a href="intfc.html#s%3Ac-intf-example"><span class="number">6</span>A complete example</a>
+</li><li class="li-toc"><a href="intfc.html#s%3Ac-callback"><span class="number">7</span>Advanced topic: callbacks from C to OCaml</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#ss%3Ac-callbacks">18.7.1 Applying OCaml closures from C</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-closures">18.7.2 Obtaining or registering OCaml closures for use in C functions</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-register-exn">18.7.3 Registering OCaml exceptions for use in C functions</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Amain-c">18.7.4 Main program in C</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-embedded-code">18.7.5 Embedding the OCaml code in the C code</a>
+<a href="intfc.html#ss%3Ac-callbacks"><span class="number">7.1</span>Applying OCaml closures from C</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-closures"><span class="number">7.2</span>Obtaining or registering OCaml closures for use in C functions</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-register-exn"><span class="number">7.3</span>Registering OCaml exceptions for use in C functions</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Amain-c"><span class="number">7.4</span>Main program in C</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-embedded-code"><span class="number">7.5</span>Embedding the OCaml code in the C code</a>
 </li></ul>
-</li><li class="li-toc"><a href="intfc.html#s%3Ac-advexample">18.8 Advanced example with callbacks</a>
-</li><li class="li-toc"><a href="intfc.html#s%3Ac-custom">18.9 Advanced topic: custom blocks</a>
+</li><li class="li-toc"><a href="intfc.html#s%3Ac-advexample"><span class="number">8</span>Advanced example with callbacks</a>
+</li><li class="li-toc"><a href="intfc.html#s%3Ac-custom"><span class="number">9</span>Advanced topic: custom blocks</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#ss%3Ac-custom-ops">18.9.1 The <span class="c004">struct custom_operations</span></a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-custom-alloc">18.9.2 Allocating custom blocks</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-custom-access">18.9.3 Accessing custom blocks</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-custom-serialization">18.9.4 Writing custom serialization and deserialization functions</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-custom-idents">18.9.5 Choosing identifiers</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-finalized">18.9.6 Finalized blocks</a>
+<a href="intfc.html#ss%3Ac-custom-ops"><span class="number">9.1</span>The <span class="c004">struct custom_operations</span></a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-custom-alloc"><span class="number">9.2</span>Allocating custom blocks</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-custom-access"><span class="number">9.3</span>Accessing custom blocks</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-custom-serialization"><span class="number">9.4</span>Writing custom serialization and deserialization functions</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-custom-idents"><span class="number">9.5</span>Choosing identifiers</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-finalized"><span class="number">9.6</span>Finalized blocks</a>
 </li></ul>
-</li><li class="li-toc"><a href="intfc.html#s%3AC-Bigarrays">18.10 Advanced topic: Bigarrays and the OCaml-C interface</a>
+</li><li class="li-toc"><a href="intfc.html#s%3AC-Bigarrays"><span class="number">10</span>Advanced topic: Bigarrays and the OCaml-C interface</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#ss%3AC-Bigarrays-include">18.10.1 Include file</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3AC-Bigarrays-access">18.10.2 Accessing an OCaml bigarray from C or Fortran</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3AC-Bigarrays-wrap">18.10.3 Wrapping a C or Fortran array as an OCaml Bigarray</a>
+<a href="intfc.html#ss%3AC-Bigarrays-include"><span class="number">10.1</span>Include file</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3AC-Bigarrays-access"><span class="number">10.2</span>Accessing an OCaml bigarray from C or Fortran</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3AC-Bigarrays-wrap"><span class="number">10.3</span>Wrapping a C or Fortran array as an OCaml Bigarray</a>
 </li></ul>
-</li><li class="li-toc"><a href="intfc.html#s%3AC-cheaper-call">18.11 Advanced topic: cheaper C call</a>
+</li><li class="li-toc"><a href="intfc.html#s%3AC-cheaper-call"><span class="number">11</span>Advanced topic: cheaper C call</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#ss%3Ac-unboxed">18.11.1 Passing unboxed values</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-direct-call">18.11.2 Direct C call</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-direct-call-example">18.11.3 Example: calling C library functions without indirection</a>
+<a href="intfc.html#ss%3Ac-unboxed"><span class="number">11.1</span>Passing unboxed values</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-direct-call"><span class="number">11.2</span>Direct C call</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-direct-call-example"><span class="number">11.3</span>Example: calling C library functions without indirection</a>
 </li></ul>
-</li><li class="li-toc"><a href="intfc.html#s%3AC-multithreading">18.12 Advanced topic: multithreading</a>
+</li><li class="li-toc"><a href="intfc.html#s%3AC-multithreading"><span class="number">12</span>Advanced topic: multithreading</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#ss%3Ac-thread-register">18.12.1 Registering threads created from C</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Aparallel-execution-long-running-c-code">18.12.2 Parallel execution of long-running C code</a>
+<a href="intfc.html#ss%3Ac-thread-register"><span class="number">12.1</span>Registering threads created from C</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Aparallel-execution-long-running-c-code"><span class="number">12.2</span>Parallel execution of long-running C code</a>
 </li></ul>
-</li><li class="li-toc"><a href="intfc.html#s%3Ainterfacing-windows-unicode-apis">18.13 Advanced topic: interfacing with Windows Unicode APIs</a>
-</li><li class="li-toc"><a href="intfc.html#s%3Aocamlmklib">18.14 Building mixed C/OCaml libraries: <span class="c004">ocamlmklib</span></a>
-</li><li class="li-toc"><a href="intfc.html#s%3Ac-internal-guidelines">18.15 Cautionary words: the internal runtime API</a>
+</li><li class="li-toc"><a href="intfc.html#s%3Ainterfacing-windows-unicode-apis"><span class="number">13</span>Advanced topic: interfacing with Windows Unicode APIs</a>
+</li><li class="li-toc"><a href="intfc.html#s%3Aocamlmklib"><span class="number">14</span>Building mixed C/OCaml libraries: <span class="c004">ocamlmklib</span></a>
+</li><li class="li-toc"><a href="intfc.html#s%3Ac-internal-guidelines"><span class="number">15</span>Cautionary words: the internal runtime API</a>
 <ul class="toc"><li class="li-toc">
-<a href="intfc.html#ss%3Ac-internals">18.15.1 Internal variables and CAML_INTERNALS</a>
-</li><li class="li-toc"><a href="intfc.html#ss%3Ac-internal-macros">18.15.2 OCaml version macros</a>
+<a href="intfc.html#ss%3Ac-internals"><span class="number">15.1</span>Internal variables and CAML_INTERNALS</a>
+</li><li class="li-toc"><a href="intfc.html#ss%3Ac-internal-macros"><span class="number">15.2</span>OCaml version macros</a>
 </li></ul>
 </li></ul>
-</li><li class="li-toc"><a href="flambda.html#sec495">Chapter ‍19 Optimisation with Flambda</a>
+</li><li class="li-toc"><a href="flambda.html#sec495"><span class="number">Chapter 19</span>Optimisation with Flambda</a>
 <ul class="toc"><li class="li-toc">
-<a href="flambda.html#s%3Aflambda-overview">19.1 Overview</a>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-cli">19.2 Command-line flags</a>
+<a href="flambda.html#s%3Aflambda-overview"><span class="number">1</span>Overview</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-cli"><span class="number">2</span>Command-line flags</a>
 <ul class="toc"><li class="li-toc">
-<a href="flambda.html#ss%3Aflambda-rounds">19.2.1 Specification of optimisation parameters by round</a>
+<a href="flambda.html#ss%3Aflambda-rounds"><span class="number">2.1</span>Specification of optimisation parameters by round</a>
 </li></ul>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-inlining">19.3 Inlining</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-inlining"><span class="number">3</span>Inlining</a>
 <ul class="toc"><li class="li-toc">
-<a href="flambda.html#ss%3Aflambda-classic">19.3.1 Classic inlining heuristic</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-inlining-overview">19.3.2 Overview of “Flambda” inlining heuristics</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-by-constructs">19.3.3 Handling of specific language constructs</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-inlining-reports">19.3.4 Inlining reports</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-assessment-inlining">19.3.5 Assessment of inlining benefit</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-speculation">19.3.6 Control of speculation</a>
+<a href="flambda.html#ss%3Aflambda-classic"><span class="number">3.1</span>Classic inlining heuristic</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-inlining-overview"><span class="number">3.2</span>Overview of “Flambda” inlining heuristics</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-by-constructs"><span class="number">3.3</span>Handling of specific language constructs</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-inlining-reports"><span class="number">3.4</span>Inlining reports</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-assessment-inlining"><span class="number">3.5</span>Assessment of inlining benefit</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-speculation"><span class="number">3.6</span>Control of speculation</a>
 </li></ul>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-specialisation">19.4 Specialisation</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-specialisation"><span class="number">4</span>Specialisation</a>
 <ul class="toc"><li class="li-toc">
-<a href="flambda.html#ss%3Aflambda-assessment-specialisation">19.4.1 Assessment of specialisation benefit</a>
+<a href="flambda.html#ss%3Aflambda-assessment-specialisation"><span class="number">4.1</span>Assessment of specialisation benefit</a>
 </li></ul>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-defaults">19.5 Default settings of parameters</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-defaults"><span class="number">5</span>Default settings of parameters</a>
 <ul class="toc"><li class="li-toc">
-<a href="flambda.html#ss%3Aflambda-o2">19.5.1 Settings at -O2 optimisation level</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-o3">19.5.2 Settings at -O3 optimisation level</a>
+<a href="flambda.html#ss%3Aflambda-o2"><span class="number">5.1</span>Settings at -O2 optimisation level</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-o3"><span class="number">5.2</span>Settings at -O3 optimisation level</a>
 </li></ul>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-manual-control">19.6 Manual control of inlining and specialisation</a>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-simplification">19.7 Simplification</a>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-other-transfs">19.8 Other code motion transformations</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-manual-control"><span class="number">6</span>Manual control of inlining and specialisation</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-simplification"><span class="number">7</span>Simplification</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-other-transfs"><span class="number">8</span>Other code motion transformations</a>
 <ul class="toc"><li class="li-toc">
-<a href="flambda.html#ss%3Aflambda-lift-const">19.8.1 Lifting of constants</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-lift-toplevel-let">19.8.2 Lifting of toplevel let bindings</a>
+<a href="flambda.html#ss%3Aflambda-lift-const"><span class="number">8.1</span>Lifting of constants</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-lift-toplevel-let"><span class="number">8.2</span>Lifting of toplevel let bindings</a>
 </li></ul>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-unboxing">19.9 Unboxing transformations</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-unboxing"><span class="number">9</span>Unboxing transformations</a>
 <ul class="toc"><li class="li-toc">
-<a href="flambda.html#ss%3Aflambda-unbox-fvs">19.9.1 Unboxing of closure variables</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-unbox-spec-args">19.9.2 Unboxing of specialised arguments</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-unbox-closures">19.9.3 Unboxing of closures</a>
+<a href="flambda.html#ss%3Aflambda-unbox-fvs"><span class="number">9.1</span>Unboxing of closure variables</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-unbox-spec-args"><span class="number">9.2</span>Unboxing of specialised arguments</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-unbox-closures"><span class="number">9.3</span>Unboxing of closures</a>
 </li></ul>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-remove-unused">19.10 Removal of unused code and values</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-remove-unused"><span class="number">10</span>Removal of unused code and values</a>
 <ul class="toc"><li class="li-toc">
-<a href="flambda.html#ss%3Aflambda-redundant-let">19.10.1 Removal of redundant let expressions</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-redundant">19.10.2 Removal of redundant program constructs</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-remove-unused-args">19.10.3 Removal of unused arguments</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-removal-closure-vars">19.10.4 Removal of unused closure variables</a>
+<a href="flambda.html#ss%3Aflambda-redundant-let"><span class="number">10.1</span>Removal of redundant let expressions</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-redundant"><span class="number">10.2</span>Removal of redundant program constructs</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-remove-unused-args"><span class="number">10.3</span>Removal of unused arguments</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-removal-closure-vars"><span class="number">10.4</span>Removal of unused closure variables</a>
 </li></ul>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-other">19.11 Other code transformations</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-other"><span class="number">11</span>Other code transformations</a>
 <ul class="toc"><li class="li-toc">
-<a href="flambda.html#ss%3Aflambda-non-escaping-refs">19.11.1 Transformation of non-escaping references into mutable variables</a>
-</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-subst-closure-vars">19.11.2 Substitution of closure variables for specialised arguments</a>
+<a href="flambda.html#ss%3Aflambda-non-escaping-refs"><span class="number">11.1</span>Transformation of non-escaping references into mutable variables</a>
+</li><li class="li-toc"><a href="flambda.html#ss%3Aflambda-subst-closure-vars"><span class="number">11.2</span>Substitution of closure variables for specialised arguments</a>
 </li></ul>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-effects">19.12 Treatment of effects</a>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-static-modules">19.13 Compilation of statically-allocated modules</a>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-inhibition">19.14 Inhibition of optimisation</a>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-unsafe">19.15 Use of unsafe operations</a>
-</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-glossary">19.16 Glossary</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-effects"><span class="number">12</span>Treatment of effects</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-static-modules"><span class="number">13</span>Compilation of statically-allocated modules</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-inhibition"><span class="number">14</span>Inhibition of optimisation</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-unsafe"><span class="number">15</span>Use of unsafe operations</a>
+</li><li class="li-toc"><a href="flambda.html#s%3Aflambda-glossary"><span class="number">16</span>Glossary</a>
 </li></ul>
-</li><li class="li-toc"><a href="afl-fuzz.html#sec546">Chapter ‍20 Fuzzing with afl-fuzz</a>
+</li><li class="li-toc"><a href="afl-fuzz.html#sec546"><span class="number">Chapter 20</span>Fuzzing with afl-fuzz</a>
 <ul class="toc"><li class="li-toc">
-<a href="afl-fuzz.html#s%3Aafl-overview">20.1 Overview</a>
-</li><li class="li-toc"><a href="afl-fuzz.html#s%3Aafl-generate">20.2 Generating instrumentation</a>
+<a href="afl-fuzz.html#s%3Aafl-overview"><span class="number">1</span>Overview</a>
+</li><li class="li-toc"><a href="afl-fuzz.html#s%3Aafl-generate"><span class="number">2</span>Generating instrumentation</a>
 <ul class="toc"><li class="li-toc">
-<a href="afl-fuzz.html#ss%3Aafl-advanced">20.2.1 Advanced options</a>
+<a href="afl-fuzz.html#ss%3Aafl-advanced"><span class="number">2.1</span>Advanced options</a>
 </li></ul>
-</li><li class="li-toc"><a href="afl-fuzz.html#s%3Aafl-example">20.3 Example</a>
+</li><li class="li-toc"><a href="afl-fuzz.html#s%3Aafl-example"><span class="number">3</span>Example</a>
 </li></ul>
-</li><li class="li-toc"><a href="instrumented-runtime.html#sec551">Chapter ‍21 Runtime tracing with the instrumented runtime</a>
+</li><li class="li-toc"><a href="instrumented-runtime.html#sec551"><span class="number">Chapter 21</span>Runtime tracing with the instrumented runtime</a>
 <ul class="toc"><li class="li-toc">
-<a href="instrumented-runtime.html#s%3Ainstr-runtime-overview">21.1 Overview</a>
-</li><li class="li-toc"><a href="instrumented-runtime.html#s%3Ainstr-runtime-enabling">21.2 Enabling runtime instrumentation</a>
-</li><li class="li-toc"><a href="instrumented-runtime.html#s%3Ainstr-runtime-read">21.3 Reading traces</a>
+<a href="instrumented-runtime.html#s%3Ainstr-runtime-overview"><span class="number">1</span>Overview</a>
+</li><li class="li-toc"><a href="instrumented-runtime.html#s%3Ainstr-runtime-enabling"><span class="number">2</span>Enabling runtime instrumentation</a>
+</li><li class="li-toc"><a href="instrumented-runtime.html#s%3Ainstr-runtime-read"><span class="number">3</span>Reading traces</a>
 <ul class="toc"><li class="li-toc">
-<a href="instrumented-runtime.html#ss%3Ainstr-runtime-tools">21.3.1 eventlog-tools</a>
-</li><li class="li-toc"><a href="instrumented-runtime.html#ss%3Ainstr-runtime-babeltrace">21.3.2 babeltrace</a>
+<a href="instrumented-runtime.html#ss%3Ainstr-runtime-tools"><span class="number">3.1</span>eventlog-tools</a>
+</li><li class="li-toc"><a href="instrumented-runtime.html#ss%3Ainstr-runtime-babeltrace"><span class="number">3.2</span>babeltrace</a>
 </li></ul>
-</li><li class="li-toc"><a href="instrumented-runtime.html#s%3Ainstr-runtime-more">21.4 Controlling instrumentation and limitations</a>
+</li><li class="li-toc"><a href="instrumented-runtime.html#s%3Ainstr-runtime-more"><span class="number">4</span>Controlling instrumentation and limitations</a>
 <ul class="toc"><li class="li-toc">
-<a href="instrumented-runtime.html#ss%3Ainstr-runtime-prefix">21.4.1 Trace filename</a>
-</li><li class="li-toc"><a href="instrumented-runtime.html#ss%3Ainstr-runtime-pause">21.4.2 Pausing and resuming tracing</a>
-</li><li class="li-toc"><a href="instrumented-runtime.html#ss%3Ainstr-runtime-limitations">21.4.3 Limitations</a>
+<a href="instrumented-runtime.html#ss%3Ainstr-runtime-prefix"><span class="number">4.1</span>Trace filename</a>
+</li><li class="li-toc"><a href="instrumented-runtime.html#ss%3Ainstr-runtime-pause"><span class="number">4.2</span>Pausing and resuming tracing</a>
+</li><li class="li-toc"><a href="instrumented-runtime.html#ss%3Ainstr-runtime-limitations"><span class="number">4.3</span>Limitations</a>
 </li></ul>
 </li></ul>
 </li></ul>
-</li><li class="li-toc"><a href="index.html#sec562">Part ‍IV The OCaml library</a>
+</li><li class="li-toc"><a href="index.html#sec562">Part&nbsp;IV The OCaml library</a>
 <ul class="toc"><li class="li-toc">
-<a href="core.html#sec563">Chapter ‍22 The core library</a>
+<a href="core.html#sec563"><span class="number">Chapter 22</span>The core library</a>
 <ul class="toc"><li class="li-toc">
-<a href="core.html#s%3Acore-builtins">22.1 Built-in types and predefined exceptions</a>
-</li><li class="li-toc"><a href="core.html#s%3Astdlib-module">22.2 Module <span class="c004">Stdlib</span>: the initially opened module</a>
+<a href="core.html#s%3Acore-builtins"><span class="number">1</span>Built-in types and predefined exceptions</a>
+</li><li class="li-toc"><a href="core.html#s%3Astdlib-module"><span class="number">2</span>Module <span class="c004">Stdlib</span>: the initially opened module</a>
 </li></ul>
-</li><li class="li-toc"><a href="stdlib.html#sec568">Chapter ‍23 The standard library</a>
-</li><li class="li-toc"><a href="parsing.html#sec569">Chapter ‍24 The compiler front-end</a>
-</li><li class="li-toc"><a href="libunix.html#sec570">Chapter ‍25 The unix library: Unix system calls</a>
-</li><li class="li-toc"><a href="libstr.html#sec571">Chapter ‍26 The str library: regular expressions and string processing</a>
-</li><li class="li-toc"><a href="libthreads.html#sec572">Chapter ‍27 The threads library</a>
-</li><li class="li-toc"><a href="libdynlink.html#sec573">Chapter ‍28 The dynlink library: dynamic loading and linking of object files</a>
-</li><li class="li-toc"><a href="old.html#sec574">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a>
+</li><li class="li-toc"><a href="stdlib.html#sec568"><span class="number">Chapter 23</span>The standard library</a>
+</li><li class="li-toc"><a href="parsing.html#sec569"><span class="number">Chapter 24</span>The compiler front-end</a>
+</li><li class="li-toc"><a href="libunix.html#sec570"><span class="number">Chapter 25</span>The unix library: Unix system calls</a>
+</li><li class="li-toc"><a href="libstr.html#sec571"><span class="number">Chapter 26</span>The str library: regular expressions and string processing</a>
+</li><li class="li-toc"><a href="libthreads.html#sec572"><span class="number">Chapter 27</span>The threads library</a>
+</li><li class="li-toc"><a href="libdynlink.html#sec573"><span class="number">Chapter 28</span>The dynlink library: dynamic loading and linking of object files</a>
+</li><li class="li-toc"><a href="old.html#sec574"><span class="number">Chapter 29</span>Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a>
 <ul class="toc"><li class="li-toc">
-<a href="old.html#s%3Agraphics-removed">29.1 The Graphics Library</a>
-</li><li class="li-toc"><a href="old.html#s%3Abigarray-moved">29.2 The Bigarray Library</a>
-</li><li class="li-toc"><a href="old.html#sec577">29.3 The Num Library</a>
-</li><li class="li-toc"><a href="old.html#s%3Alabltk-removed">29.4 The Labltk Library and OCamlBrowser</a>
+<a href="old.html#s%3Agraphics-removed"><span class="number">1</span>The Graphics Library</a>
+</li><li class="li-toc"><a href="old.html#s%3Abigarray-moved"><span class="number">2</span>The Bigarray Library</a>
+</li><li class="li-toc"><a href="old.html#sec577"><span class="number">3</span>The Num Library</a>
+</li><li class="li-toc"><a href="old.html#s%3Alabltk-removed"><span class="number">4</span>The Labltk Library and OCamlBrowser</a>
 </li></ul>
 </li></ul>
-</li><li class="li-toc"><a href="index.html#sec579">Part ‍V Indexes</a>
+</li><li class="li-toc"><a href="index.html#sec579">Part&nbsp;V Indexes</a>
 </li></ul>
 <div class="bottom-navigation"><a class="previous up" href="index.html">Home</a><a class="next" href="foreword.html">Foreword »</a></div>
 

--- a/site/releases/4.12/htmlman/manual024.html
+++ b/site/releases/4.12/htmlman/manual024.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:recursive-modules"><a class="section-anchor" href="#s:recursive-modules" aria-hidden="true"></a>8.2 Recursive modules</h2>
+<h2 class="section" id="s:recursive-modules"><a class="section-anchor" href="#s:recursive-modules" aria-hidden="true"></a><span class="number">2</span>Recursive modules</h2>
 <p>
 <a id="hevea_manual.kwd206"></a>
 <a id="hevea_manual.kwd207"></a></p><p>(Introduced in Objective Caml 3.07)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -151,7 +151,7 @@ function component of a safe module is applied during this computation
 </div><p>Note that, in the <a class="syntax" href="modtypes.html#specification"><span class="c011">specification</span></a> case, the <a class="syntax" href="modtypes.html#module-type"><span class="c011">module-type</span></a>s must be
 parenthesized if they use the <span class="c005">with</span> <a class="syntax" href="modtypes.html#mod-constraint"><span class="c011">mod-constraint</span></a> construct.</p>
 
-<div class="bottom-navigation"><a class="previous" href="letrecvalues.html">« 8.1 Recursive definitions of values</a><a class="next" href="privatetypes.html">8.3 Private types »</a></div>
+<div class="bottom-navigation"><a class="previous" href="letrecvalues.html">« Recursive definitions of values</a><a class="next" href="privatetypes.html">Private types »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/manual067.html
+++ b/site/releases/4.12/htmlman/manual067.html
@@ -11,7 +11,7 @@
 <body><div class="index content manual"><div id="sidebar-button"><span>☰</span></div><ul id="part-menu"></ul>
 
 
-<div class="maintitle"><h1><span>The OCaml system</span> &nbsp;release 4.12 </h1><h3>February ‍24, 2021</h3></div><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Select another version</a></div><ul><li class="top"><a href="#">The OCaml Manual</a></li>
+<div class="maintitle"><h1><span>The OCaml system</span> &nbsp;release 4.12 </h1><h3>April&nbsp;7, 2021</h3></div><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Select another version</a></div><ul><li class="top"><a href="#">The OCaml Manual</a></li>
 <li><a href="manual001.html#start-section">Contents</a>
 </li><li><a href="foreword.html#start-section">Foreword</a>
 </li><li><a href="manual067.html#start-section">Index of keywords</a></li><li><a href="../api/index.html">OCaml API</a></li><li><a href="../api/compilerlibref/index.html">OCaml Compiler API</a></li></ul></nav></header><a id="start-section"></a><section id="section">
@@ -98,7 +98,7 @@
 </li></ul></td></tr>
 </tbody></table>
 </div>
-<div class="bottom-navigation"><a class="previous" href="old.html">« Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a><a class="next up" href="index.html">Home</a></div>
+<div class="bottom-navigation"><a class="previous" href="old.html">« Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a><a class="next up" href="index.html">Home</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/modtypes.html
+++ b/site/releases/4.12/htmlman/modtypes.html
@@ -5,37 +5,37 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:modtypes"><a class="section-anchor" href="#s:modtypes" aria-hidden="true"></a>7.10 Module types (module specifications)</h2>
+<h2 class="section" id="s:modtypes"><a class="section-anchor" href="#s:modtypes" aria-hidden="true"></a><span class="number">10</span>Module types (module specifications)</h2>
 <ul>
-<li><a href="modtypes.html#ss%3Amty-simple">7.10.1 Simple module types</a>
-</li><li><a href="modtypes.html#ss%3Amty-signatures">7.10.2 Signatures</a>
-</li><li><a href="modtypes.html#ss%3Amty-functors">7.10.3 Functor types</a>
-</li><li><a href="modtypes.html#ss%3Amty-with">7.10.4 The <span class="c004">with</span> operator</a>
+<li><a href="modtypes.html#ss%3Amty-simple"><span class="number">10.1</span>Simple module types</a>
+</li><li><a href="modtypes.html#ss%3Amty-signatures"><span class="number">10.2</span>Signatures</a>
+</li><li><a href="modtypes.html#ss%3Amty-functors"><span class="number">10.3</span>Functor types</a>
+</li><li><a href="modtypes.html#ss%3Amty-with"><span class="number">10.4</span>The <span class="c004">with</span> operator</a>
 </li></ul>
 <p>Module types are the module-level equivalent of type expressions: they
 specify the general shape and type properties of modules.</p><p><a id="hevea_manual.kwd150"></a>
@@ -109,12 +109,12 @@ See also the following language extensions:
 <a href="attributes.html#s%3Aattributes">attributes</a>,
 <a href="extensionnodes.html#s%3Aextension-nodes">extension nodes</a> and
 <a href="generativefunctors.html#s%3Agenerative-functors">generative functors</a>.</p>
-<h3 class="subsection" id="ss:mty-simple"><a class="section-anchor" href="#ss:mty-simple" aria-hidden="true">﻿</a>7.10.1 Simple module types</h3>
+<h3 class="subsection" id="ss:mty-simple"><a class="section-anchor" href="#ss:mty-simple" aria-hidden="true">﻿</a><span class="number">10.1</span>Simple module types</h3>
 <p>The expression <a class="syntax" href="names.html#modtype-path"><span class="c011">modtype-path</span></a> is equivalent to the module type bound
 to the name <a class="syntax" href="names.html#modtype-path"><span class="c011">modtype-path</span></a>.
 The expression <span class="c005">(</span> <a class="syntax" href="#module-type"><span class="c011">module-type</span></a> <span class="c005">)</span> denotes the same type as
 <a class="syntax" href="#module-type"><span class="c011">module-type</span></a>.</p>
-<h3 class="subsection" id="ss:mty-signatures"><a class="section-anchor" href="#ss:mty-signatures" aria-hidden="true">﻿</a>7.10.2 Signatures</h3>
+<h3 class="subsection" id="ss:mty-signatures"><a class="section-anchor" href="#ss:mty-signatures" aria-hidden="true">﻿</a><span class="number">10.2</span>Signatures</h3>
 <p><a id="hevea_manual.kwd163"></a>
 <a id="hevea_manual.kwd164"></a></p><p>Signatures are type specifications for structures. Signatures
 <span class="c005">sig</span> … <span class="c005">end</span> are collections of type specifications for value
@@ -130,7 +130,7 @@ meaning.</p><h4 class="subsubsection" id="sss:mty-values"><a class="section-anch
 value and <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a> its expected type.</p><p><a id="hevea_manual.kwd166"></a></p><p>The form <span class="c005">external</span> <a class="syntax" href="names.html#value-name"><span class="c011">value-name</span></a> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a> <span class="c005">=</span>  <a class="syntax" href="intfc.html#external-declaration"><span class="c011">external-declaration</span></a>
 is similar, except that it requires in addition the name to be
 implemented as the external function specified in <a class="syntax" href="intfc.html#external-declaration"><span class="c011">external-declaration</span></a>
-(see chapter ‍<a href="intfc.html#c%3Aintf-c">18</a>).</p><h4 class="subsubsection" id="sss:mty-type"><a class="section-anchor" href="#sss:mty-type" aria-hidden="true">﻿</a>Type specifications</h4>
+(see chapter&nbsp;<a href="intfc.html#c%3Aintf-c">18</a>).</p><h4 class="subsubsection" id="sss:mty-type"><a class="section-anchor" href="#sss:mty-type" aria-hidden="true">﻿</a>Type specifications</h4>
 <p><a id="hevea_manual.kwd167"></a></p><p>A specification of one or several type components in a signature is
 written <span class="c005">type</span> <a class="syntax" href="typedecl.html#typedef"><span class="c011">typedef</span></a>  { <span class="c005">and</span> <a class="syntax" href="typedecl.html#typedef"><span class="c011">typedef</span></a> } and consists of a sequence
 of mutually recursive definitions of type names.</p><p>Each type definition in the signature specifies an optional type
@@ -142,7 +142,7 @@ given), and have the specified representation (if given). Conversely,
 users of that signature will be able to rely on the type equation
 or type representation, if given. More precisely, we have the
 following four situations:</p><dl class="description"><dt class="dt-description">
-<span class="c014">Abstract type: no equation, no representation.</span></dt><dd class="dd-description">  ‍ <br>
+<span class="c014">Abstract type: no equation, no representation.</span></dt><dd class="dd-description"> &nbsp; <br>
 Names that are defined as abstract types in a signature can be
 implemented in a matching structure by any kind of type definition
 (provided it has the same number of type parameters). The exact
@@ -153,17 +153,17 @@ accessible to the users; if the type is implemented as an
 abbreviation, the type equality between the type name and the
 right-hand side of the abbreviation will be hidden from the users of the
 structure. Users of the structure consider that type as incompatible
-with any other type: a fresh type has been generated.</dd><dt class="dt-description"><span class="c014">Type abbreviation: an equation </span><span class="c005">=</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a><span class="c014">, no representation.</span></dt><dd class="dd-description">  ‍ <br>
+with any other type: a fresh type has been generated.</dd><dt class="dt-description"><span class="c014">Type abbreviation: an equation </span><span class="c005">=</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a><span class="c014">, no representation.</span></dt><dd class="dd-description"> &nbsp; <br>
 The type name must be implemented by a type compatible with <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a>.
 All users of the structure know that the type name is
-compatible with <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a>.</dd><dt class="dt-description"><span class="c014">New variant type or record type: no equation, a representation.</span></dt><dd class="dd-description">  ‍ <br>
+compatible with <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a>.</dd><dt class="dt-description"><span class="c014">New variant type or record type: no equation, a representation.</span></dt><dd class="dd-description"> &nbsp; <br>
 The type name must be implemented by a variant type or record type
 with exactly the constructors or fields specified. All users of the
 structure have access to the constructors or fields, and can use them
 to create or inspect values of that type. However, users of the
 structure consider that type as incompatible with any other type: a
 fresh type has been generated.</dd><dt class="dt-description"><span class="c014">Re-exported variant type or record type: an equation,
-a representation.</span></dt><dd class="dd-description">  ‍ <br>
+a representation.</span></dt><dd class="dd-description"> &nbsp; <br>
 This case combines the previous two: the representation of the type is
 made visible to all users, and no fresh type is generated.
 </dd></dl><h4 class="subsubsection" id="sss:mty-exn"><a class="section-anchor" href="#sss:mty-exn" aria-hidden="true">﻿</a>Exception specification</h4>
@@ -174,13 +174,13 @@ users of the structure.</p><h4 class="subsubsection" id="sss:mty-class"><a class
 <p><a id="hevea_manual.kwd169"></a></p><p>A specification of one or several classes in a signature is written
 <span class="c005">class</span> <a class="syntax" href="classes.html#class-spec"><span class="c011">class-spec</span></a>  { <span class="c005">and</span> <a class="syntax" href="classes.html#class-spec"><span class="c011">class-spec</span></a> } and consists of a sequence
 of mutually recursive definitions of class names.</p><p>Class specifications are described more precisely in
-section ‍<a href="classes.html#ss%3Aclass-spec">7.9.4</a>.</p><h4 class="subsubsection" id="sss:mty-classtype"><a class="section-anchor" href="#sss:mty-classtype" aria-hidden="true">﻿</a>Class type specifications</h4>
+section&nbsp;<a href="classes.html#ss%3Aclass-spec">7.9.4</a>.</p><h4 class="subsubsection" id="sss:mty-classtype"><a class="section-anchor" href="#sss:mty-classtype" aria-hidden="true">﻿</a>Class type specifications</h4>
 <p><a id="hevea_manual.kwd170"></a>
 <a id="hevea_manual.kwd171"></a></p><p>A specification of one or several classe types in a signature is
 written <span class="c003"><span class="c004">class</span> <span class="c004">type</span></span> <a class="syntax" href="classes.html#classtype-def"><span class="c011">classtype-def</span></a> { <span class="c005">and</span> <a class="syntax" href="classes.html#classtype-def"><span class="c011">classtype-def</span></a> } and
 consists of a sequence of mutually recursive definitions of class type
 names. Class type specifications are described more precisely in
-section ‍<a href="classes.html#ss%3Aclasstype">7.9.5</a>.</p><h4 class="subsubsection" id="sss:mty-module"><a class="section-anchor" href="#sss:mty-module" aria-hidden="true">﻿</a>Module specifications</h4>
+section&nbsp;<a href="classes.html#ss%3Aclasstype">7.9.5</a>.</p><h4 class="subsubsection" id="sss:mty-module"><a class="section-anchor" href="#sss:mty-module" aria-hidden="true">﻿</a>Module specifications</h4>
 <p><a id="hevea_manual.kwd172"></a></p><p>A specification of a module component in a signature is written
 <span class="c005">module</span> <a class="syntax" href="names.html#module-name"><span class="c011">module-name</span></a> <span class="c005">:</span>  <a class="syntax" href="#module-type"><span class="c011">module-type</span></a>, where <a class="syntax" href="names.html#module-name"><span class="c011">module-name</span></a> is the
 name of the module component and <a class="syntax" href="#module-type"><span class="c011">module-type</span></a> its expected type.
@@ -221,7 +221,7 @@ inclusion of the components of the signature denoted by <a class="syntax" href="
 It behaves as if the components of the included signature were copied
 at the location of the <span class="c005">include</span>. The <a class="syntax" href="#module-type"><span class="c011">module-type</span></a> argument must
 refer to a module type that is a signature, not a functor type.</p>
-<h3 class="subsection" id="ss:mty-functors"><a class="section-anchor" href="#ss:mty-functors" aria-hidden="true">﻿</a>7.10.3 Functor types</h3>
+<h3 class="subsection" id="ss:mty-functors"><a class="section-anchor" href="#ss:mty-functors" aria-hidden="true">﻿</a><span class="number">10.3</span>Functor types</h3>
 <p><a id="hevea_manual.kwd177"></a></p><p>The module type expression
 <span class="c003"><span class="c004">functor</span> <span class="c004">(</span></span> <a class="syntax" href="names.html#module-name"><span class="c011">module-name</span></a> <span class="c005">:</span>  <a class="syntax" href="#module-type"><span class="c011">module-type</span></a><sub>1</sub> <span class="c003"><span class="c004">)</span> <span class="c004">-&gt;</span></span>  <a class="syntax" href="#module-type"><span class="c011">module-type</span></a><sub>2</sub>
 is the type of functors (functions from modules to modules) that take
@@ -235,7 +235,7 @@ can be simplified with the alternative short syntax
 No restrictions are placed on the type of the functor argument; in
 particular, a functor may take another functor as argument
 (“higher-order” functor).</p>
-<h3 class="subsection" id="ss:mty-with"><a class="section-anchor" href="#ss:mty-with" aria-hidden="true">﻿</a>7.10.4 The <span class="c004">with</span> operator</h3>
+<h3 class="subsection" id="ss:mty-with"><a class="section-anchor" href="#ss:mty-with" aria-hidden="true">﻿</a><span class="number">10.4</span>The <span class="c004">with</span> operator</h3>
 <p><a id="hevea_manual.kwd178"></a></p><p>Assuming <a class="syntax" href="#module-type"><span class="c011">module-type</span></a> denotes a signature, the expression
 <a class="syntax" href="#module-type"><span class="c011">module-type</span></a> <span class="c005">with</span>  <a class="syntax" href="#mod-constraint"><span class="c011">mod-constraint</span></a> { <span class="c005">and</span> <a class="syntax" href="#mod-constraint"><span class="c011">mod-constraint</span></a> } denotes
 the same signature where type equations have been added to some of the
@@ -264,7 +264,7 @@ remove information.
 
 </p>
 
-<div class="bottom-navigation"><a class="previous" href="classes.html">« 7.9 Classes</a><a class="next" href="modules.html">7.11 Module expressions (module implementations) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="classes.html">« Classes</a><a class="next" href="modules.html">Module expressions (module implementations) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/modulealias.html
+++ b/site/releases/4.12/htmlman/modulealias.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:module-alias"><a class="section-anchor" href="#s:module-alias" aria-hidden="true"></a>8.8 Type-level module aliases</h2>
+<h2 class="section" id="s:module-alias"><a class="section-anchor" href="#s:module-alias" aria-hidden="true"></a><span class="number">8</span>Type-level module aliases</h2>
 <p>
 <a id="hevea_manual.kwd223"></a>
 </p><p>(Introduced in OCaml 4.02)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -144,7 +144,7 @@ compiler will always display <span class="c005">Lib.FooBar</span> instead of
 all the user sees is the nicer dot names. This is how the OCaml
 standard library is compiled.</p>
 
-<div class="bottom-navigation"><a class="previous" href="signaturesubstitution.html">« 8.7 Substituting inside a signature</a><a class="next" href="overridingopen.html">8.9 Overriding in open statements »</a></div>
+<div class="bottom-navigation"><a class="previous" href="signaturesubstitution.html">« Substituting inside a signature</a><a class="next" href="overridingopen.html">Overriding in open statements »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/moduleexamples.html
+++ b/site/releases/4.12/htmlman/moduleexamples.html
@@ -5,24 +5,24 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍2 The module system</title>
+<title>OCaml - The module system</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍I An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">Chapter ‍1 The core language</a></li><li class="active"><a href="moduleexamples.html">Chapter ‍2 The module system</a></li><li><a href="objectexamples.html">Chapter ‍3 Objects in OCaml</a></li><li><a href="lablexamples.html">Chapter ‍4 Labels and variants</a></li><li><a href="polymorphism.html">Chapter ‍5 Polymorphism and its limitations</a></li><li><a href="advexamples.html">Chapter ‍6 Advanced examples with classes and modules</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">The core language</a></li><li class="active"><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a></li><li><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec20">Chapter ‍2 The module system</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍2 The module system</a></li>
-<li><a href="moduleexamples.html#s%3Amodule%3Astructures">2.1 Structures</a>
-</li><li><a href="moduleexamples.html#s%3Asignature">2.2 Signatures</a>
-</li><li><a href="moduleexamples.html#s%3Afunctors">2.3 Functors</a>
-</li><li><a href="moduleexamples.html#s%3Afunctors-and-abstraction">2.4 Functors and type abstraction</a>
-</li><li><a href="moduleexamples.html#s%3Aseparate-compilation">2.5 Modules and separate compilation</a>
+<h1 class="chapter" id="sec20"><span class="number">Chapter 2</span>The module system</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The module system</a></li>
+<li><a href="moduleexamples.html#s%3Amodule%3Astructures"><span class="number">1</span>Structures</a>
+</li><li><a href="moduleexamples.html#s%3Asignature"><span class="number">2</span>Signatures</a>
+</li><li><a href="moduleexamples.html#s%3Afunctors"><span class="number">3</span>Functors</a>
+</li><li><a href="moduleexamples.html#s%3Afunctors-and-abstraction"><span class="number">4</span>Functors and type abstraction</a>
+</li><li><a href="moduleexamples.html#s%3Aseparate-compilation"><span class="number">5</span>Modules and separate compilation</a>
 </li></ul></nav></header>
 <p> <a id="c:moduleexamples"></a>
 </p><p>This chapter introduces the module system of OCaml.</p>
-<h2 class="section" id="s:module:structures"><a class="section-anchor" href="#s:module:structures" aria-hidden="true"></a>2.1 Structures</h2>
+<h2 class="section" id="s:module:structures"><a class="section-anchor" href="#s:module:structures" aria-hidden="true"></a><span class="number">1</span>Structures</h2>
 <p>A primary motivation for modules is to package together related
 definitions (such as the definitions of a data type and associated
 operations over that type) and enforce a consistent naming scheme for
@@ -294,7 +294,7 @@ an exception when the priority queue is empty.
   <span class="ocamlkeyword">end</span></div></div>
 
 </div>
-<h2 class="section" id="s:signature"><a class="section-anchor" href="#s:signature" aria-hidden="true">﻿</a>2.2 Signatures</h2>
+<h2 class="section" id="s:signature"><a class="section-anchor" href="#s:signature" aria-hidden="true">﻿</a><span class="number">2</span>Signatures</h2>
 <p>Signatures are interfaces for structures. A signature specifies
 which components of a structure are accessible from the outside, and
 with which type. It can be used to hide some components of a structure
@@ -406,7 +406,7 @@ function:</p><div class="caml-example toplevel">
   <span class="ocamlkeyword">end</span></div></div>
 
 </div>
-<h2 class="section" id="s:functors"><a class="section-anchor" href="#s:functors" aria-hidden="true">﻿</a>2.3 Functors</h2>
+<h2 class="section" id="s:functors"><a class="section-anchor" href="#s:functors" aria-hidden="true">﻿</a><span class="number">3</span>Functors</h2>
 <p>Functors are “functions” from modules to modules. Functors let you create
 parameterized modules and then provide other modules as parameter(s) to get
 a specific implementation. For instance, a <span class="c004">Set</span> module implementing sets
@@ -523,7 +523,7 @@ type, we obtain set operations for this type:
 <div class="pre caml-output ok">- : bool = <span class="ocamlkeyword">false</span></div></div>
 
 </div>
-<h2 class="section" id="s:functors-and-abstraction"><a class="section-anchor" href="#s:functors-and-abstraction" aria-hidden="true">﻿</a>2.4 Functors and type abstraction</h2>
+<h2 class="section" id="s:functors-and-abstraction"><a class="section-anchor" href="#s:functors-and-abstraction" aria-hidden="true">﻿</a><span class="number">4</span>Functors and type abstraction</h2>
 <p>As in the <span class="c004">PrioQueue</span> example, it would be good style to hide the
 actual implementation of the type <span class="c004">set</span>, so that users of the
 structure will not rely on sets being lists, and we can switch later
@@ -763,7 +763,7 @@ standard ordering and for the case-insensitive ordering). Applying
 operations from <span class="c004">AbstractStringSet</span> to values of type
 <span class="c004">NoCaseStringSet.set</span> could give incorrect results, or build
 lists that violate the invariants of <span class="c004">NoCaseStringSet</span>.</p>
-<h2 class="section" id="s:separate-compilation"><a class="section-anchor" href="#s:separate-compilation" aria-hidden="true">﻿</a>2.5 Modules and separate compilation</h2>
+<h2 class="section" id="s:separate-compilation"><a class="section-anchor" href="#s:separate-compilation" aria-hidden="true">﻿</a><span class="number">5</span>Modules and separate compilation</h2>
 <p>All examples of modules so far have been given in the context of the
 interactive system. However, modules are most useful for large,
 batch-compiled programs. For these programs, it is a practical
@@ -820,7 +820,7 @@ inside a structure, which can then be mapped to a file.
 
 </p>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="coreexamples.html">« Chapter ‍1 The core language</a><a class="next" href="objectexamples.html">Chapter ‍3 Objects in OCaml »</a></div>
+<div class="bottom-navigation"><a class="previous" href="coreexamples.html">« The core language</a><a class="next" href="objectexamples.html">Objects in OCaml »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/modules.html
+++ b/site/releases/4.12/htmlman/modules.html
@@ -5,36 +5,36 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:module-expr"><a class="section-anchor" href="#s:module-expr" aria-hidden="true"></a>7.11 Module expressions (module implementations)</h2>
+<h2 class="section" id="s:module-expr"><a class="section-anchor" href="#s:module-expr" aria-hidden="true"></a><span class="number">11</span>Module expressions (module implementations)</h2>
 <ul>
-<li><a href="modules.html#ss%3Amexpr-simple">7.11.1 Simple module expressions</a>
-</li><li><a href="modules.html#ss%3Amexpr-structures">7.11.2 Structures</a>
-</li><li><a href="modules.html#ss%3Amexpr-functors">7.11.3 Functors</a>
+<li><a href="modules.html#ss%3Amexpr-simple"><span class="number">11.1</span>Simple module expressions</a>
+</li><li><a href="modules.html#ss%3Amexpr-structures"><span class="number">11.2</span>Structures</a>
+</li><li><a href="modules.html#ss%3Amexpr-functors"><span class="number">11.3</span>Functors</a>
 </li></ul>
 <p>Module expressions are the module-level equivalent of value
 expressions: they evaluate to modules, thus providing implementations
@@ -101,7 +101,7 @@ See also the following language extensions:
 <a href="attributes.html#s%3Aattributes">attributes</a>,
 <a href="extensionnodes.html#s%3Aextension-nodes">extension nodes</a> and
 <a href="generativefunctors.html#s%3Agenerative-functors">generative functors</a>.</p>
-<h3 class="subsection" id="ss:mexpr-simple"><a class="section-anchor" href="#ss:mexpr-simple" aria-hidden="true">﻿</a>7.11.1 Simple module expressions</h3>
+<h3 class="subsection" id="ss:mexpr-simple"><a class="section-anchor" href="#ss:mexpr-simple" aria-hidden="true">﻿</a><span class="number">11.1</span>Simple module expressions</h3>
 <p>The expression <a class="syntax" href="names.html#module-path"><span class="c011">module-path</span></a> evaluates to the module bound to the name
 <a class="syntax" href="names.html#module-path"><span class="c011">module-path</span></a>.</p><p>The expression <span class="c005">(</span> <a class="syntax" href="#module-expr"><span class="c011">module-expr</span></a> <span class="c005">)</span> evaluates to the same module as
 <a class="syntax" href="#module-expr"><span class="c011">module-expr</span></a>.</p><p>The expression <span class="c005">(</span> <a class="syntax" href="#module-expr"><span class="c011">module-expr</span></a> <span class="c005">:</span>  <a class="syntax" href="modtypes.html#module-type"><span class="c011">module-type</span></a> <span class="c005">)</span> checks that the
@@ -113,7 +113,7 @@ in <a class="syntax" href="modtypes.html#module-type"><span class="c011">module-
 expression evaluates to the same module as <a class="syntax" href="#module-expr"><span class="c011">module-expr</span></a>, except that
 all components not specified in <a class="syntax" href="modtypes.html#module-type"><span class="c011">module-type</span></a> are hidden and can no
 longer be accessed.</p>
-<h3 class="subsection" id="ss:mexpr-structures"><a class="section-anchor" href="#ss:mexpr-structures" aria-hidden="true">﻿</a>7.11.2 Structures</h3>
+<h3 class="subsection" id="ss:mexpr-structures"><a class="section-anchor" href="#ss:mexpr-structures" aria-hidden="true">﻿</a><span class="number">11.2</span>Structures</h3>
 <p><a id="hevea_manual.kwd191"></a>
 <a id="hevea_manual.kwd192"></a></p><p>Structures <span class="c005">struct</span> … <span class="c005">end</span> are collections of definitions for
 value names, type names, exceptions, module names and module type
@@ -121,7 +121,7 @@ names. The definitions are evaluated in the order in which they appear
 in the structure. The scopes of the bindings performed by the
 definitions extend to the end of the structure. As a consequence, a
 definition may refer to names bound by earlier definitions in the same
-structure.</p><p>For compatibility with toplevel phrases (chapter ‍<a href="toplevel.html#c%3Acamllight">10</a>),
+structure.</p><p>For compatibility with toplevel phrases (chapter&nbsp;<a href="toplevel.html#c%3Acamllight">10</a>),
 optional <span class="c005">;;</span> are allowed after and before each definition in a structure. These
 <span class="c005">;;</span> have no semantic meanings. Similarly, an <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a> preceded by <span class="c004">;;</span> is allowed as
 a component of a structure. It is equivalent to <span class="c003"><span class="c004">let</span> <span class="c004">_</span> <span class="c004">=</span></span> <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a>, i.e. <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a> is
@@ -129,11 +129,11 @@ evaluated for its side-effects but is not bound to any identifier. If <a class="
 the first component of a structure, the preceding <span class="c004">;;</span> can be omitted.</p><h4 class="subsubsection" id="sss:mexpr-value-defs"><a class="section-anchor" href="#sss:mexpr-value-defs" aria-hidden="true">﻿</a>Value definitions</h4>
 <p><a id="hevea_manual.kwd193"></a></p><p>A value definition <span class="c005">let</span> [<span class="c005">rec</span>] <a class="syntax" href="expr.html#let-binding"><span class="c011">let-binding</span></a>  { <span class="c005">and</span> <a class="syntax" href="expr.html#let-binding"><span class="c011">let-binding</span></a> }
 bind value names in the same way as a <span class="c005">let</span> … <span class="c005">in</span> … expression
-(see section ‍<a href="expr.html#sss%3Aexpr-localdef">7.7.2</a>). The value names appearing in the
+(see section&nbsp;<a href="expr.html#sss%3Aexpr-localdef">7.7.2</a>). The value names appearing in the
 left-hand sides of the bindings are bound to the corresponding values
 in the right-hand sides.</p><p><a id="hevea_manual.kwd194"></a></p><p>A value definition <span class="c005">external</span> <a class="syntax" href="names.html#value-name"><span class="c011">value-name</span></a> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a> <span class="c005">=</span>  <a class="syntax" href="intfc.html#external-declaration"><span class="c011">external-declaration</span></a>
 implements <a class="syntax" href="names.html#value-name"><span class="c011">value-name</span></a> as the external function specified in
-<a class="syntax" href="intfc.html#external-declaration"><span class="c011">external-declaration</span></a> (see chapter ‍<a href="intfc.html#c%3Aintf-c">18</a>).</p><h4 class="subsubsection" id="sss:mexpr-type-defs"><a class="section-anchor" href="#sss:mexpr-type-defs" aria-hidden="true">﻿</a>Type definitions</h4>
+<a class="syntax" href="intfc.html#external-declaration"><span class="c011">external-declaration</span></a> (see chapter&nbsp;<a href="intfc.html#c%3Aintf-c">18</a>).</p><h4 class="subsubsection" id="sss:mexpr-type-defs"><a class="section-anchor" href="#sss:mexpr-type-defs" aria-hidden="true">﻿</a>Type definitions</h4>
 <p><a id="hevea_manual.kwd195"></a></p><p>A definition of one or several type components is written
 <span class="c005">type</span> <a class="syntax" href="typedecl.html#typedef"><span class="c011">typedef</span></a>  { <span class="c005">and</span> <a class="syntax" href="typedecl.html#typedef"><span class="c011">typedef</span></a> } and consists of a sequence
 of mutually recursive definitions of type names.</p><h4 class="subsubsection" id="sss:mexpr-exn-defs"><a class="section-anchor" href="#sss:mexpr-exn-defs" aria-hidden="true">﻿</a>Exception definitions</h4>
@@ -142,13 +142,13 @@ or <span class="c005">exception</span> <a class="syntax" href="names.html#constr
 <p><a id="hevea_manual.kwd197"></a></p><p>A definition of one or several classes is written <span class="c005">class</span>
 <a class="syntax" href="classes.html#class-binding"><span class="c011">class-binding</span></a>  { <span class="c005">and</span> <a class="syntax" href="classes.html#class-binding"><span class="c011">class-binding</span></a> } and consists of a sequence of
 mutually recursive definitions of class names. Class definitions are
-described more precisely in section ‍<a href="classes.html#ss%3Aclass-def">7.9.3</a>.</p><h4 class="subsubsection" id="sss:mexpr-classtype-defs"><a class="section-anchor" href="#sss:mexpr-classtype-defs" aria-hidden="true">﻿</a>Class type definitions</h4>
+described more precisely in section&nbsp;<a href="classes.html#ss%3Aclass-def">7.9.3</a>.</p><h4 class="subsubsection" id="sss:mexpr-classtype-defs"><a class="section-anchor" href="#sss:mexpr-classtype-defs" aria-hidden="true">﻿</a>Class type definitions</h4>
 <p><a id="hevea_manual.kwd198"></a>
 <a id="hevea_manual.kwd199"></a></p><p>A definition of one or several classes is written
 <span class="c003"><span class="c004">class</span> <span class="c004">type</span></span> <a class="syntax" href="classes.html#classtype-def"><span class="c011">classtype-def</span></a>  { <span class="c005">and</span> <a class="syntax" href="classes.html#classtype-def"><span class="c011">classtype-def</span></a> } and consists of
 a sequence of mutually recursive definitions of class type names.
 Class type definitions are described more precisely in
-section ‍<a href="classes.html#ss%3Aclasstype">7.9.5</a>.</p><h4 class="subsubsection" id="sss:mexpr-module-defs"><a class="section-anchor" href="#sss:mexpr-module-defs" aria-hidden="true">﻿</a>Module definitions</h4>
+section&nbsp;<a href="classes.html#ss%3Aclasstype">7.9.5</a>.</p><h4 class="subsubsection" id="sss:mexpr-module-defs"><a class="section-anchor" href="#sss:mexpr-module-defs" aria-hidden="true">﻿</a>Module definitions</h4>
 <p><a id="hevea_manual.kwd200"></a></p><p>The basic form for defining a module component is
 <span class="c005">module</span> <a class="syntax" href="names.html#module-name"><span class="c011">module-name</span></a> <span class="c005">=</span>  <a class="syntax" href="#module-expr"><span class="c011">module-expr</span></a>, which evaluates <a class="syntax" href="#module-expr"><span class="c011">module-expr</span></a> and binds
 the result to the name <a class="syntax" href="names.html#module-name"><span class="c011">module-name</span></a>.</p><p>One can write
@@ -224,7 +224,7 @@ simply provides short names for the components of the opened
 structure, without defining any components of the current structure,
 while <span class="c005">include</span> also adds definitions for the components of the
 included structure.</p>
-<h3 class="subsection" id="ss:mexpr-functors"><a class="section-anchor" href="#ss:mexpr-functors" aria-hidden="true">﻿</a>7.11.3 Functors</h3>
+<h3 class="subsection" id="ss:mexpr-functors"><a class="section-anchor" href="#ss:mexpr-functors" aria-hidden="true">﻿</a><span class="number">11.3</span>Functors</h3>
 <h4 class="subsubsection" id="sss:mexpr-functor-defs"><a class="section-anchor" href="#sss:mexpr-functor-defs" aria-hidden="true">﻿</a>Functor definition</h4>
 <p><a id="hevea_manual.kwd205"></a></p><p>The expression <span class="c003"><span class="c004">functor</span> <span class="c004">(</span></span> <a class="syntax" href="names.html#module-name"><span class="c011">module-name</span></a> <span class="c005">:</span>  <a class="syntax" href="modtypes.html#module-type"><span class="c011">module-type</span></a> <span class="c003"><span class="c004">)</span> <span class="c004">-&gt;</span></span>
  <a class="syntax" href="#module-expr"><span class="c011">module-expr</span></a> evaluates to a functor that takes as argument modules of
@@ -238,7 +238,7 @@ argument (“higher-order” functor).</p><h4 class="subsubsection" id="sss:mexp
 applies the former to the latter. The type of <a class="syntax" href="#module-expr"><span class="c011">module-expr</span></a><sub>2</sub> must
 match the type expected for the arguments of the functor <a class="syntax" href="#module-expr"><span class="c011">module-expr</span></a><sub>1</sub>.</p>
 
-<div class="bottom-navigation"><a class="previous" href="modtypes.html">« 7.10 Module types (module specifications)</a><a class="next" href="compunit.html">7.12 Compilation units »</a></div>
+<div class="bottom-navigation"><a class="previous" href="modtypes.html">« Module types (module specifications)</a><a class="next" href="compunit.html">Compilation units »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/moduletypeof.html
+++ b/site/releases/4.12/htmlman/moduletypeof.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:module-type-of"><a class="section-anchor" href="#s:module-type-of" aria-hidden="true"></a>8.6 Recovering the type of a module</h2>
+<h2 class="section" id="s:module-type-of"><a class="section-anchor" href="#s:module-type-of" aria-hidden="true"></a><span class="number">6</span>Recovering the type of a module</h2>
 <p><a id="hevea_manual.kwd216"></a>
 <a id="hevea_manual.kwd217"></a>
 <a id="hevea_manual.kwd218"></a>
@@ -110,7 +110,7 @@ to provide an alternative implementation for an existing module.
 This idiom guarantees that <span class="c004">Myset</span> is compatible with Set, but allows
 it to represent sets internally in a different way.</p>
 
-<div class="bottom-navigation"><a class="previous" href="firstclassmodules.html">« 8.5 First-class modules</a><a class="next" href="signaturesubstitution.html">8.7 Substituting inside a signature »</a></div>
+<div class="bottom-navigation"><a class="previous" href="firstclassmodules.html">« First-class modules</a><a class="next" href="signaturesubstitution.html">Substituting inside a signature »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/names.html
+++ b/site/releases/4.12/htmlman/names.html
@@ -5,38 +5,38 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:names"><a class="section-anchor" href="#s:names" aria-hidden="true"></a>7.3 Names</h2>
+<h2 class="section" id="s:names"><a class="section-anchor" href="#s:names" aria-hidden="true"></a><span class="number">3</span>Names</h2>
 <p>Identifiers are used to give names to several classes of language
 objects and refer to these objects by name later:
 </p><ul class="itemize"><li class="li-itemize">
 value names (syntactic class <a class="syntax" href="#value-name"><span class="c011">value-name</span></a>),
 </li><li class="li-itemize">value constructors and exception constructors (class <a class="syntax" href="#constr-name"><span class="c011">constr-name</span></a>),
-</li><li class="li-itemize">labels (<a class="syntax" href="lex.html#label-name"><span class="c011">label-name</span></a>, defined in section ‍<a href="lex.html#sss%3Alabelname">7.1</a>),
+</li><li class="li-itemize">labels (<a class="syntax" href="lex.html#label-name"><span class="c011">label-name</span></a>, defined in section&nbsp;<a href="lex.html#sss%3Alabelname">7.1</a>),
 </li><li class="li-itemize">polymorphic variant tags (<a class="syntax" href="#tag-name"><span class="c011">tag-name</span></a>),
 </li><li class="li-itemize">type constructors (<a class="syntax" href="#typeconstr-name"><span class="c011">typeconstr-name</span></a>),
 </li><li class="li-itemize">record fields (<a class="syntax" href="#field-name"><span class="c011">field-name</span></a>),
@@ -214,7 +214,7 @@ are local to a class.
 
 </p>
 
-<div class="bottom-navigation"><a class="previous" href="values.html">« 7.2 Values</a><a class="next" href="types.html">7.4 Type expressions »</a></div>
+<div class="bottom-navigation"><a class="previous" href="values.html">« Values</a><a class="next" href="types.html">Type expressions »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/native.html
+++ b/site/releases/4.12/htmlman/native.html
@@ -5,20 +5,20 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍12 Native-code compilation (ocamlopt)</title>
+<title>OCaml - Native-code compilation (ocamlopt)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li class="active"><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li class="active"><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec310">Chapter ‍12 Native-code compilation (ocamlopt)</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍12 Native-code compilation (ocamlopt)</a></li>
-<li><a href="native.html#s%3Anative-overview">12.1 Overview of the compiler</a>
-</li><li><a href="native.html#s%3Anative-options">12.2 Options</a>
-</li><li><a href="native.html#s%3Anative-common-errors">12.3 Common errors</a>
-</li><li><a href="native.html#s%3Anative%3Arunning-executable">12.4 Running executables produced by ocamlopt</a>
-</li><li><a href="native.html#s%3Acompat-native-bytecode">12.5 Compatibility with the bytecode compiler</a>
+<h1 class="chapter" id="sec310"><span class="number">Chapter 12</span>Native-code compilation (ocamlopt)</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Native-code compilation (ocamlopt)</a></li>
+<li><a href="native.html#s%3Anative-overview"><span class="number">1</span>Overview of the compiler</a>
+</li><li><a href="native.html#s%3Anative-options"><span class="number">2</span>Options</a>
+</li><li><a href="native.html#s%3Anative-common-errors"><span class="number">3</span>Common errors</a>
+</li><li><a href="native.html#s%3Anative%3Arunning-executable"><span class="number">4</span>Running executables produced by ocamlopt</a>
+</li><li><a href="native.html#s%3Acompat-native-bytecode"><span class="number">5</span>Compatibility with the bytecode compiler</a>
 </li></ul></nav></header>
 <p> <a id="c:nativecomp"></a>
 </p><p>This chapter describes the OCaml high-performance
@@ -34,7 +34,7 @@ with bytecode object files produced by <span class="c004">ocamlc</span>: a progr
 compiled entirely with <span class="c004">ocamlopt</span> or entirely with <span class="c004">ocamlc</span>. Native-code
 object files produced by <span class="c004">ocamlopt</span> cannot be loaded in the toplevel
 system <span class="c004">ocaml</span>.</p>
-<h2 class="section" id="s:native-overview"><a class="section-anchor" href="#s:native-overview" aria-hidden="true"></a>12.1 Overview of the compiler</h2>
+<h2 class="section" id="s:native-overview"><a class="section-anchor" href="#s:native-overview" aria-hidden="true"></a><span class="number">1</span>Overview of the compiler</h2>
 <p>The <span class="c004">ocamlopt</span> command has a command-line interface very close to that
 of <span class="c004">ocamlc</span>. It accepts the same types of arguments, and processes them
 sequentially, after all options have been processed:</p><ul class="itemize"><li class="li-itemize">
@@ -55,7 +55,7 @@ should always be referred to under the name <span class="c010">x</span><span cla
 a <span class="c004">.o</span> or <span class="c004">.obj</span> file, <span class="c004">ocamlopt</span> assumes that it contains code compiled from C,
 not from OCaml).<p>The implementation is checked against the interface file <span class="c010">x</span><span class="c004">.mli</span>
 (if it exists) as described in the manual for <span class="c004">ocamlc</span>
-(chapter ‍<a href="comp.html#c%3Acamlc">9</a>).</p></li><li class="li-itemize">Arguments ending in <span class="c004">.cmx</span> are taken to be compiled object code. These
+(chapter&nbsp;<a href="comp.html#c%3Acamlc">9</a>).</p></li><li class="li-itemize">Arguments ending in <span class="c004">.cmx</span> are taken to be compiled object code. These
 files are linked together, along with the object files obtained
 by compiling <span class="c004">.ml</span> arguments (if any), and the OCaml standard
 library, to produce a native-code executable program. The order in
@@ -89,7 +89,7 @@ such as code layout, by transforming a <span class="c004">.cmir-linear</span> fi
 To continue compilation, the compiler can be invoked with (a possibly modified)
 <span class="c004">.cmir-linear</span> file as an argument, instead of the corresponding source file.
 </p></li></ul>
-<h2 class="section" id="s:native-options"><a class="section-anchor" href="#s:native-options" aria-hidden="true">﻿</a>12.2 Options</h2>
+<h2 class="section" id="s:native-options"><a class="section-anchor" href="#s:native-options" aria-hidden="true">﻿</a><span class="number">2</span>Options</h2>
 <p>The following command-line options are recognized by <span class="c004">ocamlopt</span>.
 The options <span class="c004">-pack</span>, <span class="c004">-a</span>, <span class="c004">-shared</span>, <span class="c004">-c</span> and <span class="c004">-output-obj</span> are mutually
 exclusive.</p><dl class="description"><dt class="dt-description">
@@ -189,7 +189,7 @@ names.
 Add debugging information while compiling and linking. This option is
 required in order to  produce stack backtraces when
 the program terminates on an uncaught exception (see
-section ‍<a href="runtime.html#s%3Aocamlrun-options">11.2</a>).
+section&nbsp;<a href="runtime.html#s%3Aocamlrun-options">11.2</a>).
 </dd><dt class="dt-description"><span class="c007">-i</span></dt><dd class="dd-description">
 Cause the compiler to print all defined names (with their inferred
 types or their definitions) when compiling an implementation (<span class="c004">.ml</span>
@@ -251,7 +251,7 @@ option is meant for use in the event that a pattern-match-heavy
 program leads to significant increases in compilation time.
 </dd><dt class="dt-description"><span class="c007">-no-alias-deps</span></dt><dd class="dd-description">
 Do not record dependencies for module aliases. See
-section ‍<a href="modulealias.html#s%3Amodule-alias">8.8</a> for more information.
+section&nbsp;<a href="modulealias.html#s%3Amodule-alias">8.8</a> for more information.
 </dd><dt class="dt-description"><span class="c007">-no-app-funct</span></dt><dd class="dd-description">
 Deactivates the applicative behaviour of functors. With this option,
 each functor application generates new types in its result and
@@ -328,8 +328,8 @@ were added at the top of each file.
 Cause the linker to produce a C object file instead of
 an executable file.
 This is useful to wrap OCaml code as a C library,
-callable from any C program. See chapter ‍<a href="intfc.html#c%3Aintf-c">18</a>,
-section ‍<a href="intfc.html#ss%3Ac-embedded-code">18.7.5</a>. The name of the output object file
+callable from any C program. See chapter&nbsp;<a href="intfc.html#c%3Aintf-c">18</a>,
+section&nbsp;<a href="intfc.html#ss%3Ac-embedded-code">18.7.5</a>. The name of the output object file
 must be set with the <span class="c004">-o</span> option.
 This option can also be used to produce a  compiled shared/dynamic library (<span class="c004">.so</span> extension, <span class="c004">.dll</span> under Windows).
 </dd><dt class="dt-description"><span class="c007">-pack</span></dt><dd class="dd-description">
@@ -362,7 +362,7 @@ errors, the intermediate file is deleted afterwards.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">-ppx</span> <span class="c010">command</span></span></dt><dd class="dd-description">
 After parsing, pipe the abstract syntax tree through the preprocessor
 <span class="c010">command</span>. The module <span class="c004">Ast_mapper</span>, described in
-chapter ‍<a href="parsing.html#c%3Aparsinglib">24</a>:
+chapter&nbsp;<a href="parsing.html#c%3Aparsinglib">24</a>:
 <a href="../api/compilerlibref/Ast_mapper.html"> <span class="c004">Ast_mapper</span> </a>
 ,
 implements the external interface of a preprocessor.</dd><dt class="dt-description"><span class="c007">-principal</span></dt><dd class="dd-description">
@@ -396,7 +396,7 @@ The currently supported passes and the corresponding file extensions are:
 <span class="c004">scheduling</span> (<span class="c004">.cmir-linear</span>).<p>This experimental feature enables external tools to inspect and manipulate
 compiler’s intermediate representation of the program
 using <span class="c004">compiler-libs</span> library (see
-chapter ‍<a href="parsing.html#c%3Aparsinglib">24</a> and
+chapter&nbsp;<a href="parsing.html#c%3Aparsinglib">24</a> and
 <a href="../api/compilerlibref/Compiler_libs.html"> <span class="c004">Compiler_libs</span> </a>
 ).
 </p></dd><dt class="dt-description"><span class="c007">-S</span></dt><dd class="dd-description">
@@ -664,10 +664,10 @@ Alternative executable to use on native
 Windows for <span class="c004">flexlink</span> instead of the
 configured value. Primarily used for bootstrapping.
 </dd></dl>
-<h2 class="section" id="s:native-common-errors"><a class="section-anchor" href="#s:native-common-errors" aria-hidden="true">﻿</a>12.3 Common errors</h2>
+<h2 class="section" id="s:native-common-errors"><a class="section-anchor" href="#s:native-common-errors" aria-hidden="true">﻿</a><span class="number">3</span>Common errors</h2>
 <p>The error messages are almost identical to those of <span class="c004">ocamlc</span>.
-See section ‍<a href="comp.html#s%3Acomp-errors">9.4</a>.</p>
-<h2 class="section" id="s:native:running-executable"><a class="section-anchor" href="#s:native:running-executable" aria-hidden="true">﻿</a>12.4 Running executables produced by ocamlopt</h2>
+See section&nbsp;<a href="comp.html#s%3Acomp-errors">9.4</a>.</p>
+<h2 class="section" id="s:native:running-executable"><a class="section-anchor" href="#s:native:running-executable" aria-hidden="true">﻿</a><span class="number">4</span>Running executables produced by ocamlopt</h2>
 <p>Executables generated by <span class="c004">ocamlopt</span> are native, stand-alone executable
 files that can be invoked directly. They do
 not depend on the <span class="c004">ocamlrun</span> bytecode runtime system nor on
@@ -675,14 +675,14 @@ dynamically-loaded C/OCaml stub libraries.</p><p>During execution of an <span cl
 the following environment variables are also consulted:
 </p><dl class="description"><dt class="dt-description">
 <span class="c007">OCAMLRUNPARAM</span></dt><dd class="dd-description"> Same usage as in <span class="c004">ocamlrun</span>
-(see section ‍<a href="runtime.html#s%3Aocamlrun-options">11.2</a>), except that option <span class="c004">l</span>
+(see section&nbsp;<a href="runtime.html#s%3Aocamlrun-options">11.2</a>), except that option <span class="c004">l</span>
 is ignored (the operating system’s stack size limit
 is used instead).
 </dd><dt class="dt-description"><span class="c007">CAMLRUNPARAM</span></dt><dd class="dd-description"> If <span class="c004">OCAMLRUNPARAM</span> is not found in the
 environment, then <span class="c004">CAMLRUNPARAM</span> will be used instead. If
 <span class="c004">CAMLRUNPARAM</span> is not found, then the default values will be used.
 </dd></dl>
-<h2 class="section" id="s:compat-native-bytecode"><a class="section-anchor" href="#s:compat-native-bytecode" aria-hidden="true">﻿</a>12.5 Compatibility with the bytecode compiler</h2>
+<h2 class="section" id="s:compat-native-bytecode"><a class="section-anchor" href="#s:compat-native-bytecode" aria-hidden="true">﻿</a><span class="number">5</span>Compatibility with the bytecode compiler</h2>
 <p>This section lists the known incompatibilities between the bytecode
 compiler and the native-code compiler. Except on those points, the two
 compilers should generate code that behave identically.</p><ul class="itemize"><li class="li-itemize">Signals are detected only when the program performs an
@@ -718,7 +718,7 @@ a best effort to trap stack overflows and raise the <span class="c004">Stack_ove
 exception, but sometimes it fails and a “segmentation fault” or
 another system fault occurs instead.</li></ul>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="runtime.html">« Chapter ‍11 The runtime system (ocamlrun)</a><a class="next" href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="runtime.html">« The runtime system (ocamlrun)</a><a class="next" href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/objectexamples.html
+++ b/site/releases/4.12/htmlman/objectexamples.html
@@ -5,37 +5,37 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍3 Objects in OCaml</title>
+<title>OCaml - Objects in OCaml</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍I An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">Chapter ‍1 The core language</a></li><li><a href="moduleexamples.html">Chapter ‍2 The module system</a></li><li class="active"><a href="objectexamples.html">Chapter ‍3 Objects in OCaml</a></li><li><a href="lablexamples.html">Chapter ‍4 Labels and variants</a></li><li><a href="polymorphism.html">Chapter ‍5 Polymorphism and its limitations</a></li><li><a href="advexamples.html">Chapter ‍6 Advanced examples with classes and modules</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li class="active"><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a></li><li><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec26">Chapter ‍3 Objects in OCaml</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍3 Objects in OCaml</a></li>
-<li><a href="objectexamples.html#s%3Aclasses-and-objects">3.1 Classes and objects</a>
-</li><li><a href="objectexamples.html#s%3Aimmediate-objects">3.2 Immediate objects</a>
-</li><li><a href="objectexamples.html#s%3Areference-to-self">3.3 Reference to self</a>
-</li><li><a href="objectexamples.html#s%3Ainitializers">3.4 Initializers</a>
-</li><li><a href="objectexamples.html#s%3Avirtual-methods">3.5 Virtual methods</a>
-</li><li><a href="objectexamples.html#s%3Aprivate-methods">3.6 Private methods</a>
-</li><li><a href="objectexamples.html#s%3Aclass-interfaces">3.7 Class interfaces</a>
-</li><li><a href="objectexamples.html#s%3Ainheritance">3.8 Inheritance</a>
-</li><li><a href="objectexamples.html#s%3Amultiple-inheritance">3.9 Multiple inheritance</a>
-</li><li><a href="objectexamples.html#s%3Aparameterized-classes">3.10 Parameterized classes</a>
-</li><li><a href="objectexamples.html#s%3Apolymorphic-methods">3.11 Polymorphic methods</a>
-</li><li><a href="objectexamples.html#s%3Ausing-coercions">3.12 Using coercions</a>
-</li><li><a href="objectexamples.html#s%3Afunctional-objects">3.13 Functional objects</a>
-</li><li><a href="objectexamples.html#s%3Acloning-objects">3.14 Cloning objects</a>
-</li><li><a href="objectexamples.html#s%3Arecursive-classes">3.15 Recursive classes</a>
-</li><li><a href="objectexamples.html#s%3Abinary-methods">3.16 Binary methods</a>
-</li><li><a href="objectexamples.html#s%3Afriends">3.17 Friends</a>
+<h1 class="chapter" id="sec26"><span class="number">Chapter 3</span>Objects in OCaml</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Objects in OCaml</a></li>
+<li><a href="objectexamples.html#s%3Aclasses-and-objects"><span class="number">1</span>Classes and objects</a>
+</li><li><a href="objectexamples.html#s%3Aimmediate-objects"><span class="number">2</span>Immediate objects</a>
+</li><li><a href="objectexamples.html#s%3Areference-to-self"><span class="number">3</span>Reference to self</a>
+</li><li><a href="objectexamples.html#s%3Ainitializers"><span class="number">4</span>Initializers</a>
+</li><li><a href="objectexamples.html#s%3Avirtual-methods"><span class="number">5</span>Virtual methods</a>
+</li><li><a href="objectexamples.html#s%3Aprivate-methods"><span class="number">6</span>Private methods</a>
+</li><li><a href="objectexamples.html#s%3Aclass-interfaces"><span class="number">7</span>Class interfaces</a>
+</li><li><a href="objectexamples.html#s%3Ainheritance"><span class="number">8</span>Inheritance</a>
+</li><li><a href="objectexamples.html#s%3Amultiple-inheritance"><span class="number">9</span>Multiple inheritance</a>
+</li><li><a href="objectexamples.html#s%3Aparameterized-classes"><span class="number">10</span>Parameterized classes</a>
+</li><li><a href="objectexamples.html#s%3Apolymorphic-methods"><span class="number">11</span>Polymorphic methods</a>
+</li><li><a href="objectexamples.html#s%3Ausing-coercions"><span class="number">12</span>Using coercions</a>
+</li><li><a href="objectexamples.html#s%3Afunctional-objects"><span class="number">13</span>Functional objects</a>
+</li><li><a href="objectexamples.html#s%3Acloning-objects"><span class="number">14</span>Cloning objects</a>
+</li><li><a href="objectexamples.html#s%3Arecursive-classes"><span class="number">15</span>Recursive classes</a>
+</li><li><a href="objectexamples.html#s%3Abinary-methods"><span class="number">16</span>Binary methods</a>
+</li><li><a href="objectexamples.html#s%3Afriends"><span class="number">17</span>Friends</a>
 </li></ul></nav></header>
 <p>
 <a id="c:objectexamples"></a>
 </p><p>
-<span class="c010">(Chapter written by Jérôme Vouillon, Didier Rémy and Jacques Garrigue)</span></p><p><br>
+</p><p><br>
 <br>
 </p><p>This chapter gives an overview of the object-oriented features of
 OCaml.</p><p>Note that the relationship between object, class and type in OCaml is
@@ -45,7 +45,7 @@ Object-oriented features are used much less frequently in OCaml than
 in those languages. OCaml has alternatives that are often more appropriate,
 such as modules and functors. Indeed, many OCaml programs do not use objects
 at all.</p>
-<h2 class="section" id="s:classes-and-objects"><a class="section-anchor" href="#s:classes-and-objects" aria-hidden="true"></a>3.1 Classes and objects</h2>
+<h2 class="section" id="s:classes-and-objects"><a class="section-anchor" href="#s:classes-and-objects" aria-hidden="true"></a><span class="number">1</span>Classes and objects</h2>
 <p>The class <span class="c004">point</span> below defines one instance variable <span class="c004">x</span> and two methods
 <span class="c004">get_x</span> and <span class="c004">move</span>. The initial value of the instance variable is <span class="c004">0</span>.
 The variable <span class="c004">x</span> is declared mutable, so the method <span class="c004">move</span> can change
@@ -351,8 +351,8 @@ inherited.</p><p>This ability provides class constructors as can be found in oth
 languages. Several constructors can be defined this way to build objects of
 the same class but with different initialization patterns; an
 alternative is to use initializers, as described below in
-section ‍<a href="#s%3Ainitializers">3.4</a>.</p>
-<h2 class="section" id="s:immediate-objects"><a class="section-anchor" href="#s:immediate-objects" aria-hidden="true">﻿</a>3.2 Immediate objects</h2>
+section&nbsp;<a href="#s%3Ainitializers">3.4</a>.</p>
+<h2 class="section" id="s:immediate-objects"><a class="section-anchor" href="#s:immediate-objects" aria-hidden="true">﻿</a><span class="number">2</span>Immediate objects</h2>
 <p>There is another, more direct way to create an object: create it
 without going through a class.</p><p>The syntax is exactly the same as for class expressions, but the
 result is a single object rather than a class. All the constructs
@@ -423,8 +423,8 @@ environment.
 </div><p>Immediate objects have two weaknesses compared to classes: their types
 are not abbreviated, and you cannot inherit from them. But these two
 weaknesses can be advantages in some situations, as we will see
-in sections ‍<a href="#s%3Areference-to-self">3.3</a> and ‍<a href="#s%3Aparameterized-classes">3.10</a>.</p>
-<h2 class="section" id="s:reference-to-self"><a class="section-anchor" href="#s:reference-to-self" aria-hidden="true">﻿</a>3.3 Reference to self</h2>
+in sections&nbsp;<a href="#s%3Areference-to-self">3.3</a> and&nbsp;<a href="#s%3Aparameterized-classes">3.10</a>.</p>
+<h2 class="section" id="s:reference-to-self"><a class="section-anchor" href="#s:reference-to-self" aria-hidden="true">﻿</a><span class="number">3</span>Reference to self</h2>
 <p>A method or an initializer can invoke methods on self (that is,
 the current object). For that, self must be explicitly bound, here to
 the variable <span class="c004">s</span> (<span class="c004">s</span> could be any identifier, even though we will
@@ -512,7 +512,7 @@ subclasses, you cannot fix it in advance. Here is a simple example.
 You can ignore the first two lines of the error message. What matters
 is the last one: putting self into an external reference would make it
 impossible to extend it through inheritance.
-We will see in section ‍<a href="#s%3Ausing-coercions">3.12</a> a workaround to this
+We will see in section&nbsp;<a href="#s%3Ausing-coercions">3.12</a> a workaround to this
 problem.
 Note however that, since immediate objects are not extensible, the
 problem does not occur with them.
@@ -534,7 +534,7 @@ problem does not occur with them.
 <div class="pre caml-output ok"><span class="ocamlkeyword">val</span> my_int : &lt; n : int; register : unit &gt; = &lt;obj&gt;</div></div>
 
 </div>
-<h2 class="section" id="s:initializers"><a class="section-anchor" href="#s:initializers" aria-hidden="true">﻿</a>3.4 Initializers</h2>
+<h2 class="section" id="s:initializers"><a class="section-anchor" href="#s:initializers" aria-hidden="true">﻿</a><span class="number">4</span>Initializers</h2>
 <p>Let-bindings within class definitions are evaluated before the object
 is constructed. It is also possible to evaluate an expression
 immediately after the object has been built. Such code is written as
@@ -583,8 +583,8 @@ access self and the instance variables.
 Initializers cannot be overridden. On the contrary, all initializers are
 evaluated sequentially.
 Initializers are particularly useful to enforce invariants.
-Another example can be seen in section ‍<a href="advexamples.html#s%3Aextended-bank-accounts">6.1</a>.</p>
-<h2 class="section" id="s:virtual-methods"><a class="section-anchor" href="#s:virtual-methods" aria-hidden="true">﻿</a>3.5 Virtual methods</h2>
+Another example can be seen in section&nbsp;<a href="advexamples.html#s%3Aextended-bank-accounts">6.1</a>.</p>
+<h2 class="section" id="s:virtual-methods"><a class="section-anchor" href="#s:virtual-methods" aria-hidden="true">﻿</a><span class="number">5</span>Virtual methods</h2>
 <p>It is possible to declare a method without actually defining it, using
 the keyword <span class="c004">virtual</span>. This method will be provided later in
 subclasses. A class containing virtual methods must be flagged
@@ -678,7 +678,7 @@ as with methods.
   <span class="ocamlkeyword">end</span></div></div>
 
 </div>
-<h2 class="section" id="s:private-methods"><a class="section-anchor" href="#s:private-methods" aria-hidden="true">﻿</a>3.6 Private methods</h2>
+<h2 class="section" id="s:private-methods"><a class="section-anchor" href="#s:private-methods" aria-hidden="true">﻿</a><span class="number">6</span>Private methods</h2>
 <p>Private methods are methods that do not appear in object interfaces.
 They can only be invoked from other methods of the same object.
 
@@ -743,7 +743,7 @@ class. This is a direct consequence of the independence between types
 and classes in OCaml: two unrelated classes may produce
 objects of the same type, and there is no way at the type level to
 ensure that an object comes from a specific class. However a possible
-encoding of friend methods is given in section ‍<a href="#s%3Afriends">3.17</a>.</p><p>Private methods are inherited (they are by default visible in subclasses),
+encoding of friend methods is given in section&nbsp;<a href="#s%3Afriends">3.17</a>.</p><p>Private methods are inherited (they are by default visible in subclasses),
 unless they are hidden by signature matching, as described below.</p><p>Private methods can be made public in a subclass.
 
 </p><div class="caml-example toplevel">
@@ -831,7 +831,7 @@ code, so yet another (heavier) solution would be:
 
 </div><p>Of course, private methods can also be virtual. Then, the keywords must
 appear in this order <span class="c004">method private virtual</span>.</p>
-<h2 class="section" id="s:class-interfaces"><a class="section-anchor" href="#s:class-interfaces" aria-hidden="true">﻿</a>3.7 Class interfaces</h2>
+<h2 class="section" id="s:class-interfaces"><a class="section-anchor" href="#s:class-interfaces" aria-hidden="true">﻿</a><span class="number">7</span>Class interfaces</h2>
 <p>Class interfaces are inferred from class definitions. They may also
 be defined directly and used to restrict the type of a class. Like class
 declarations, they also define a new type abbreviation.
@@ -936,7 +936,7 @@ signature, and used to restrict the inferred signature of a module.
 <div class="pre caml-output ok"><span class="ocamlkeyword">module</span> Point : POINT</div></div>
 
 </div>
-<h2 class="section" id="s:inheritance"><a class="section-anchor" href="#s:inheritance" aria-hidden="true">﻿</a>3.8 Inheritance</h2>
+<h2 class="section" id="s:inheritance"><a class="section-anchor" href="#s:inheritance" aria-hidden="true">﻿</a><span class="number">8</span>Inheritance</h2>
 <p>We illustrate inheritance by defining a class of colored points that
 inherits from the class of points. This class has all instance
 variables and all methods of class <span class="c004">point</span>, plus a new instance
@@ -1042,7 +1042,7 @@ Methods need not be declared previously, as shown by the example:
 <div class="pre caml-output ok"><span class="ocamlkeyword">val</span> incr : &lt; get_x : int; set_x : int -&gt; 'a; .. &gt; -&gt; 'a = &lt;<span class="ocamlkeyword">fun</span>&gt;</div></div>
 
 </div>
-<h2 class="section" id="s:multiple-inheritance"><a class="section-anchor" href="#s:multiple-inheritance" aria-hidden="true">﻿</a>3.9 Multiple inheritance</h2>
+<h2 class="section" id="s:multiple-inheritance"><a class="section-anchor" href="#s:multiple-inheritance" aria-hidden="true">﻿</a><span class="number">9</span>Multiple inheritance</h2>
 <p>Multiple inheritance is allowed. Only the last definition of a method
 is kept: the redefinition in a subclass of a method that was visible in
 the parent class overrides the definition in the parent class.
@@ -1159,7 +1159,7 @@ for <span class="c004">val</span> and <span class="c004">inherit</span>:
   <span class="ocamlkeyword">end</span></div></div>
 
 </div>
-<h2 class="section" id="s:parameterized-classes"><a class="section-anchor" href="#s:parameterized-classes" aria-hidden="true">﻿</a>3.10 Parameterized classes</h2>
+<h2 class="section" id="s:parameterized-classes"><a class="section-anchor" href="#s:parameterized-classes" aria-hidden="true">﻿</a><span class="number">10</span>Parameterized classes</h2>
 <p>Reference cells can be implemented as objects.
 The naive definition fails to typecheck:
 
@@ -1408,7 +1408,7 @@ explicitly given. It is again written between <span class="c004">[</span> and <s
   <span class="ocamlkeyword">end</span></div></div>
 
 </div>
-<h2 class="section" id="s:polymorphic-methods"><a class="section-anchor" href="#s:polymorphic-methods" aria-hidden="true">﻿</a>3.11 Polymorphic methods</h2>
+<h2 class="section" id="s:polymorphic-methods"><a class="section-anchor" href="#s:polymorphic-methods" aria-hidden="true">﻿</a><span class="number">11</span>Polymorphic methods</h2>
 <p>While parameterized classes may be polymorphic in their contents, they
 are not enough to allow polymorphism of method use.</p><p>A classical example is defining an iterator.
 
@@ -1658,7 +1658,7 @@ Only occurrences of quantified variables are required.
 
 </div><p>Another use of polymorphic methods is to allow some form of implicit
 subtyping in method arguments. We have already seen in
-section ‍<a href="#s%3Ainheritance">3.8</a> how some functions may be polymorphic in the
+section&nbsp;<a href="#s%3Ainheritance">3.8</a> how some functions may be polymorphic in the
 class of their argument. This can be extended to methods.
 
 </p><div class="caml-example toplevel">
@@ -1739,7 +1739,7 @@ inside object field it must be quantified independently.
 In method <span class="c004">m1</span>, <span class="c004">o</span> must be an object with at least a method <span class="c004">n1</span>,
 itself polymorphic. In method <span class="c004">m2</span>, the argument of <span class="c004">n2</span> and <span class="c004">x</span> must
 have the same type, which is quantified at the same level as <span class="c004">'a</span>.</p>
-<h2 class="section" id="s:using-coercions"><a class="section-anchor" href="#s:using-coercions" aria-hidden="true">﻿</a>3.12 Using coercions</h2>
+<h2 class="section" id="s:using-coercions"><a class="section-anchor" href="#s:using-coercions" aria-hidden="true">﻿</a><span class="number">12</span>Using coercions</h2>
 <p>Subtyping is never implicit. There are, however, two ways to perform
 subtyping. The most general construction is fully explicit: both the
 domain and the codomain of the type coercion must be given.</p><p>We have seen that points and colored points have incompatible types.
@@ -1952,7 +1952,7 @@ unrolled twice to obtain <span class="c004">&lt; m : &lt; m : c1; .. &gt;; .. &g
 You may also note that the type of <span class="c004">to_c2</span> is <span class="c004">#c2 -&gt; c2</span> while
 the type of <span class="c004">to_c1</span> is more general than <span class="c004">#c1 -&gt; c1</span>. This is not always true,
 since there are class types for which some instances of <span class="c004">#c</span> are not subtypes
-of <span class="c004">c</span>, as explained in section ‍<a href="#s%3Abinary-methods">3.16</a>. Yet, for
+of <span class="c004">c</span>, as explained in section&nbsp;<a href="#s%3Abinary-methods">3.16</a>. Yet, for
 parameterless classes the coercion <span class="c004">(_ :&gt; c)</span> is always more general than
 <span class="c004">(_ : #c :&gt; c)</span>.
 </p><p>A common problem may occur when one tries to define a coercion to a
@@ -2173,7 +2173,7 @@ The closer you get to it is:
 </div><p>
 
 with an extra type variable capturing the open object type.</p>
-<h2 class="section" id="s:functional-objects"><a class="section-anchor" href="#s:functional-objects" aria-hidden="true">﻿</a>3.13 Functional objects</h2>
+<h2 class="section" id="s:functional-objects"><a class="section-anchor" href="#s:functional-objects" aria-hidden="true">﻿</a><span class="number">13</span>Functional objects</h2>
 <p>It is possible to write a version of class <span class="c004">point</span> without assignments
 on the instance variables. The override construct <span class="c004">{&lt; ... &gt;}</span> returns a copy of
 “self” (that is, the current object), possibly changing the value of
@@ -2291,8 +2291,8 @@ the method <span class="c004">move</span> will
 keep returning an object of the parent class. On the contrary, in a
 subclass of <span class="c004">functional_point</span>, the method <span class="c004">move</span> will return an
 object of the subclass.</p><p>Functional update is often used in conjunction with binary methods
-as illustrated in section ‍<a href="advexamples.html#ss%3Astring-as-class">6.2.1</a>.</p>
-<h2 class="section" id="s:cloning-objects"><a class="section-anchor" href="#s:cloning-objects" aria-hidden="true">﻿</a>3.14 Cloning objects</h2>
+as illustrated in section&nbsp;<a href="advexamples.html#ss%3Astring-as-class">6.2.1</a>.</p>
+<h2 class="section" id="s:cloning-objects"><a class="section-anchor" href="#s:cloning-objects" aria-hidden="true">﻿</a><span class="number">14</span>Cloning objects</h2>
 <p>Objects can also be cloned, whether they are functional or imperative.
 The library function <span class="c004">Oo.copy</span> makes a shallow copy of an object. That is,
 it returns a new object that has the same methods and instance
@@ -2555,7 +2555,7 @@ add a method <span class="c004">clear</span> to manually erase all copies.)
 <div class="pre caml-output ok">- : int list = [2; 1; 0; 0; 0]</div></div>
 
 </div>
-<h2 class="section" id="s:recursive-classes"><a class="section-anchor" href="#s:recursive-classes" aria-hidden="true">﻿</a>3.15 Recursive classes</h2>
+<h2 class="section" id="s:recursive-classes"><a class="section-anchor" href="#s:recursive-classes" aria-hidden="true">﻿</a><span class="number">15</span>Recursive classes</h2>
 <p>Recursive classes can be used to define objects whose types are
 mutually recursive.
 
@@ -2589,7 +2589,7 @@ mutually recursive.
 
 Although their types are mutually recursive, the classes <span class="c004">widget</span> and
 <span class="c004">window</span> are themselves independent.</p>
-<h2 class="section" id="s:binary-methods"><a class="section-anchor" href="#s:binary-methods" aria-hidden="true">﻿</a>3.16 Binary methods</h2>
+<h2 class="section" id="s:binary-methods"><a class="section-anchor" href="#s:binary-methods" aria-hidden="true">﻿</a><span class="number">16</span>Binary methods</h2>
 <p>A binary method is a method which takes an argument of the same type
 as self. The class <span class="c004">comparable</span> below is a template for classes with a
 binary method <span class="c004">leq</span> of type <span class="c004">'a -&gt; bool</span> where the type variable <span class="c004">'a</span>
@@ -2727,7 +2727,7 @@ or <span class="c004">money2</span>.
 <div class="pre caml-output ok">- : float = 3.14</div></div>
 
 </div><p>More examples of binary methods can be found in
-sections ‍<a href="advexamples.html#ss%3Astring-as-class">6.2.1</a> and ‍<a href="advexamples.html#ss%3Aset-as-class">6.2.3</a>.</p><p>Note the use of override for method <span class="c004">times</span>.
+sections&nbsp;<a href="advexamples.html#ss%3Astring-as-class">6.2.1</a> and&nbsp;<a href="advexamples.html#ss%3Aset-as-class">6.2.3</a>.</p><p>Note the use of override for method <span class="c004">times</span>.
 Writing <span class="c004">new money2 (k *. repr)</span> instead of <span class="c004">{&lt; repr = k *. repr &gt;}</span>
 would not behave well with inheritance: in a subclass <span class="c004">money3</span> of <span class="c004">money2</span>
 the <span class="c004">times</span> method would return an object of class <span class="c004">money2</span> but not of class
@@ -2764,7 +2764,7 @@ direct definition:
   <span class="ocamlkeyword">end</span></div></div>
 
 </div>
-<h2 class="section" id="s:friends"><a class="section-anchor" href="#s:friends" aria-hidden="true">﻿</a>3.17 Friends</h2>
+<h2 class="section" id="s:friends"><a class="section-anchor" href="#s:friends" aria-hidden="true">﻿</a><span class="number">17</span>Friends</h2>
 <p>The above class <span class="c004">money</span> reveals a problem that often occurs with binary
 methods. In order to interact with other objects of the same class, the
 representation of <span class="c004">money</span> objects must be revealed, using a method such as
@@ -2843,7 +2843,7 @@ visibility of the representation using the module system.
 
 </div><p>
 
-Another example of friend functions may be found in section ‍<a href="advexamples.html#ss%3Aset-as-class">6.2.3</a>.
+Another example of friend functions may be found in section&nbsp;<a href="advexamples.html#ss%3Aset-as-class">6.2.3</a>.
 These examples occur when a group of objects (here
 objects of the same class) and functions should see each others internal
 representation, while their representation should be hidden from the
@@ -2851,10 +2851,10 @@ outside. The solution is always to define all friends in the same module,
 give access to the representation and use a signature constraint to make the
 representation abstract outside the module.</p>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="moduleexamples.html">« Chapter ‍2 The module system</a><a class="next" href="lablexamples.html">Chapter ‍4 Labels and variants »</a></div>
+<div class="bottom-navigation"><a class="previous" href="moduleexamples.html">« The module system</a><a class="next" href="lablexamples.html">Labels and variants »</a></div>
 
 
 
 
-<div class="copyright">Copyright © 2021 Institut National de
+<span class="authors c010">(Chapter written by Jérôme Vouillon, Didier Rémy and Jacques Garrigue)</span><div class="copyright">Copyright © 2021 Institut National de
 Recherche en Informatique et en Automatique</div></div></body></html>

--- a/site/releases/4.12/htmlman/ocamldoc.html
+++ b/site/releases/4.12/htmlman/ocamldoc.html
@@ -5,19 +5,19 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍15 The documentation generator (ocamldoc)</title>
+<title>OCaml - The documentation generator (ocamldoc)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li class="active"><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li class="active"><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec344">Chapter ‍15 The documentation generator (ocamldoc)</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍15 The documentation generator (ocamldoc)</a></li>
-<li><a href="ocamldoc.html#s%3Aocamldoc-usage">15.1 Usage</a>
-</li><li><a href="ocamldoc.html#s%3Aocamldoc-comments">15.2 Syntax of documentation comments</a>
-</li><li><a href="ocamldoc.html#s%3Aocamldoc-custom-generators">15.3 Custom generators</a>
-</li><li><a href="ocamldoc.html#s%3Aocamldoc-adding-flags">15.4 Adding command line options</a>
+<h1 class="chapter" id="sec344"><span class="number">Chapter 15</span>The documentation generator (ocamldoc)</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The documentation generator (ocamldoc)</a></li>
+<li><a href="ocamldoc.html#s%3Aocamldoc-usage"><span class="number">1</span>Usage</a>
+</li><li><a href="ocamldoc.html#s%3Aocamldoc-comments"><span class="number">2</span>Syntax of documentation comments</a>
+</li><li><a href="ocamldoc.html#s%3Aocamldoc-custom-generators"><span class="number">3</span>Custom generators</a>
+</li><li><a href="ocamldoc.html#s%3Aocamldoc-adding-flags"><span class="number">4</span>Adding command line options</a>
 </li></ul></nav></header>
 <p> <a id="c:ocamldoc"></a>
 </p><p>This chapter describes OCamldoc, a tool that generates documentation from
@@ -31,8 +31,8 @@ following parts of an OCaml source file: a type declaration, a value,
 a module, an exception, a module type, a type constructor, a record
 field, a class, a class type, a class method, a class value or a class
 inheritance clause.</p>
-<h2 class="section" id="s:ocamldoc-usage"><a class="section-anchor" href="#s:ocamldoc-usage" aria-hidden="true"></a>15.1 Usage</h2>
-<h3 class="subsection" id="ss:ocamldoc-invocation"><a class="section-anchor" href="#ss:ocamldoc-invocation" aria-hidden="true">﻿</a>15.1.1 Invocation</h3>
+<h2 class="section" id="s:ocamldoc-usage"><a class="section-anchor" href="#s:ocamldoc-usage" aria-hidden="true"></a><span class="number">1</span>Usage</h2>
+<h3 class="subsection" id="ss:ocamldoc-invocation"><a class="section-anchor" href="#ss:ocamldoc-invocation" aria-hidden="true">﻿</a><span class="number">1.1</span>Invocation</h3>
 <p>OCamldoc is invoked via the command <span class="c004">ocamldoc</span>, as follows:
 </p><pre>        ocamldoc <span class="c010">options sourcefiles</span>
 </pre><h4 class="subsubsection" id="sss:ocamldoc-output"><a class="section-anchor" href="#sss:ocamldoc-output" aria-hidden="true">﻿</a>Options for choosing the output format</h4>
@@ -213,7 +213,7 @@ types, instead of pages for all elements.</dd><dt class="dt-description"><span c
 Set the suffix used for generated man filenames. Default is ’<span class="c004">3o</span>’,
 as in <span class="c004">List.3o</span>.</dd><dt class="dt-description"><span class="c014"><span class="c004">-man-section</span> <span class="c010">section</span></span></dt><dd class="dd-description">
 Set the section number used for generated man filenames. Default is ’<span class="c004">3</span>’.</dd></dl>
-<h3 class="subsection" id="ss:ocamldoc-merge"><a class="section-anchor" href="#ss:ocamldoc-merge" aria-hidden="true">﻿</a>15.1.2 Merging of module information</h3>
+<h3 class="subsection" id="ss:ocamldoc-merge"><a class="section-anchor" href="#ss:ocamldoc-merge" aria-hidden="true">﻿</a><span class="number">1.2</span>Merging of module information</h3>
 <p>Information on a module can be extracted either from the <span class="c004">.mli</span> or <span class="c004">.ml</span>
 file, or both, depending on the files given on the command line.
 When both <span class="c004">.mli</span> and <span class="c004">.ml</span> files are given for the same module,
@@ -232,7 +232,7 @@ If a description is present in the <span class="c004">.ml</span> file and not in
 <span class="c004">.mli</span> file, the <span class="c004">.ml</span> description is kept.
 In either case, all the information given in the <span class="c004">.mli</span> file is kept.
 </li></ul>
-<h3 class="subsection" id="ss:ocamldoc-rules"><a class="section-anchor" href="#ss:ocamldoc-rules" aria-hidden="true">﻿</a>15.1.3 Coding rules</h3>
+<h3 class="subsection" id="ss:ocamldoc-rules"><a class="section-anchor" href="#ss:ocamldoc-rules" aria-hidden="true">﻿</a><span class="number">1.3</span>Coding rules</h3>
 <p>
 The following rules must be respected in order to avoid name clashes
 resulting in cross-reference errors:
@@ -271,12 +271,12 @@ In this case, OCamldoc will associate <span class="c004">Bar.x</span> to the <sp
 <span class="c004">Foo</span> defined just above, instead of to the <span class="c004">Bar.x</span> defined in the
 opened module <span class="c004">Foo</span>.
 </li></ul>
-<h2 class="section" id="s:ocamldoc-comments"><a class="section-anchor" href="#s:ocamldoc-comments" aria-hidden="true">﻿</a>15.2 Syntax of documentation comments</h2>
+<h2 class="section" id="s:ocamldoc-comments"><a class="section-anchor" href="#s:ocamldoc-comments" aria-hidden="true">﻿</a><span class="number">2</span>Syntax of documentation comments</h2>
 <p>Comments containing documentation material are called <em>special
 comments</em> and are written between <span class="c004">(**</span> and <span class="c004">*)</span>. Special comments
 must start exactly with <span class="c004">(**</span>. Comments beginning with <span class="c004">(</span> and more
 than two <span class="c004">*</span> are ignored.</p>
-<h3 class="subsection" id="ss:ocamldoc-placement"><a class="section-anchor" href="#ss:ocamldoc-placement" aria-hidden="true">﻿</a>15.2.1 Placement of documentation comments</h3>
+<h3 class="subsection" id="ss:ocamldoc-placement"><a class="section-anchor" href="#ss:ocamldoc-placement" aria-hidden="true">﻿</a><span class="number">2.1</span>Placement of documentation comments</h3>
 <p>
 OCamldoc can associate comments to some elements of the language
 encountered in the source files. The association is made according to
@@ -286,7 +286,7 @@ locations of comments in <span class="c004">.mli</span> and <span class="c004">.
 <p>
 A special comment is associated to an element if it is placed before or
 after the element.<br>
-A special comment before an element is associated to this element if ‍:
+A special comment before an element is associated to this element if&nbsp;:
 </p><ul class="itemize"><li class="li-itemize">
 There is no blank line or another special comment between the special
 comment and the element. However, a regular comment can occur between
@@ -499,7 +499,7 @@ in a <span class="c004">.ml</span> file.</p><div class="caml-example verbatim">
   <span class="ocamlkeyword">end</span></div></div>
 
 </div>
-<h3 class="subsection" id="ss:ocamldoc-stop"><a class="section-anchor" href="#ss:ocamldoc-stop" aria-hidden="true">﻿</a>15.2.2 The Stop special comment</h3>
+<h3 class="subsection" id="ss:ocamldoc-stop"><a class="section-anchor" href="#ss:ocamldoc-stop" aria-hidden="true">﻿</a><span class="number">2.2</span>The Stop special comment</h3>
 <p>
 The special comment <span class="c004">(**/**)</span> tells OCamldoc to discard
 elements placed after this comment, up to the end of the current
@@ -538,7 +538,7 @@ toggled off the "no documentation mode". *)</span>
 
 </div><p>The <span class="c007">-no-stop</span> option to <span class="c004">ocamldoc</span> causes the Stop special
 comments to be ignored.</p>
-<h3 class="subsection" id="ss:ocamldoc-syntax"><a class="section-anchor" href="#ss:ocamldoc-syntax" aria-hidden="true">﻿</a>15.2.3 Syntax of documentation comments</h3>
+<h3 class="subsection" id="ss:ocamldoc-syntax"><a class="section-anchor" href="#ss:ocamldoc-syntax" aria-hidden="true">﻿</a><span class="number">2.3</span>Syntax of documentation comments</h3>
 <p>The inside of documentation comments <span class="c004">(**</span>…<span class="c004">*)</span> consists of
 free-form text with optional formatting annotations, followed by
 optional <em>tags</em> giving more specific information about parameters,
@@ -555,7 +555,7 @@ relevant to the documented element are simply ignored. For instance,
 all tags are ignored when documenting type constructors, record
 fields, and class inheritance clauses. Similarly, a <span class="c004">@param</span> tag on a
 class instance variable is ignored.</p><p>At last, <span class="c004">(**)</span> is the empty documentation comment.</p>
-<h3 class="subsection" id="ss:ocamldoc-formatting"><a class="section-anchor" href="#ss:ocamldoc-formatting" aria-hidden="true">﻿</a>15.2.4 Text formatting</h3>
+<h3 class="subsection" id="ss:ocamldoc-formatting"><a class="section-anchor" href="#ss:ocamldoc-formatting" aria-hidden="true">﻿</a><span class="number">2.4</span>Text formatting</h3>
 <p>Here is the BNF grammar for the simple markup language used to format
 text descriptions.</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" id="text"><span class="c011">text</span></a></td><td class="c016">::=</td><td class="c018"> {<a class="syntax" href="#text-element"><span class="c011">text-element</span></a>}<sup>+</sup>
@@ -602,7 +602,7 @@ must be	escaped by a ’<span class="c004">\</span>’</td></tr>
 </tbody></table><p> <br>
 
 </p>
-<h4 class="subsubsection" id="sss:ocamldoc-list"><a class="section-anchor" href="#sss:ocamldoc-list" aria-hidden="true">﻿</a>15.2.4.1 List formatting</h4>
+<h4 class="subsubsection" id="sss:ocamldoc-list"><a class="section-anchor" href="#sss:ocamldoc-list" aria-hidden="true">﻿</a>15.<span class="number">4.1</span>List formatting</h4>
 <div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" id="list"><span class="c011">list</span></a></td><td class="c016">::=</td><td class="c018">
  </td></tr>
@@ -628,7 +628,7 @@ The list is ended by the blank line.*)
 The same shortcut is available for enumerated lists, using ’<span class="c004">+</span>’
 instead of ’<span class="c004">-</span>’.
 Note that only one list can be defined by this shortcut in nested lists.</p>
-<h4 class="subsubsection" id="sss:ocamldoc-crossref"><a class="section-anchor" href="#sss:ocamldoc-crossref" aria-hidden="true">﻿</a>15.2.4.2 Cross-reference formatting</h4>
+<h4 class="subsubsection" id="sss:ocamldoc-crossref"><a class="section-anchor" href="#sss:ocamldoc-crossref" aria-hidden="true">﻿</a>15.<span class="number">4.2</span>Cross-reference formatting</h4>
 <p>Cross-references are fully qualified element names, as in the example
 <span class="c004">{!Foo.Bar.t}</span>. This is an ambiguous reference as it may designate
 a type name, a value name, a class name, etc. It is possible to make
@@ -657,7 +657,7 @@ to avoid the ambiguity of several types having the same constructor
 names. For example, the constructor <span class="c004">Node</span> of the type <span class="c004">tree</span> will be
 referenced as <span class="c004">{!tree.Node}</span> or <span class="c004">{!const:tree.Node}</span>, or possibly
 <span class="c004">{!Mod1.Mod2.tree.Node}</span> from outside the module.</p>
-<h4 class="subsubsection" id="sss:ocamldoc-preamble"><a class="section-anchor" href="#sss:ocamldoc-preamble" aria-hidden="true">﻿</a>15.2.4.3 First sentence</h4>
+<h4 class="subsubsection" id="sss:ocamldoc-preamble"><a class="section-anchor" href="#sss:ocamldoc-preamble" aria-hidden="true">﻿</a>15.<span class="number">4.3</span>First sentence</h4>
 <p>In the description of a value, type, exception, module, module type, class
 or class type, the <em>first sentence</em> is sometimes used in indexes, or
 when just a part of the description is needed. The first sentence
@@ -676,13 +676,13 @@ outside of the following text formatting :
  <span class="c003"><span class="c004">{!</span> <span class="c011">string</span> <span class="c004">}</span></span> ,
  <span class="c005">{^</span> <a class="syntax" href="#text"><span class="c011">text</span></a> <span class="c005">}</span> ,
  <span class="c005">{_</span> <a class="syntax" href="#text"><span class="c011">text</span></a> <span class="c005">}</span> .</p>
-<h4 class="subsubsection" id="sss:ocamldoc-target-specific-syntax"><a class="section-anchor" href="#sss:ocamldoc-target-specific-syntax" aria-hidden="true">﻿</a>15.2.4.4 Target-specific formatting</h4>
+<h4 class="subsubsection" id="sss:ocamldoc-target-specific-syntax"><a class="section-anchor" href="#sss:ocamldoc-target-specific-syntax" aria-hidden="true">﻿</a>15.<span class="number">4.4</span>Target-specific formatting</h4>
 <p>The content inside <span class="c004">{%foo: ... %}</span> is target-specific and will only be
 interpreted by the backend <span class="c004">foo</span>, and ignored by the others. The
 backends of the distribution are <span class="c004">latex</span>, <span class="c004">html</span>, <span class="c004">texi</span> and <span class="c004">man</span>. If
 no target is specified (syntax <span class="c004">{% ... %}</span>), <span class="c004">latex</span> is chosen by
 default. Custom generators may support their own target prefix.</p>
-<h4 class="subsubsection" id="sss:ocamldoc-html-tags"><a class="section-anchor" href="#sss:ocamldoc-html-tags" aria-hidden="true">﻿</a>15.2.4.5 Recognized HTML tags</h4>
+<h4 class="subsubsection" id="sss:ocamldoc-html-tags"><a class="section-anchor" href="#sss:ocamldoc-html-tags" aria-hidden="true">﻿</a>15.<span class="number">4.5</span>Recognized HTML tags</h4>
 <p>
 The HTML tags <span class="c004">&lt;b&gt;..&lt;/b&gt;</span>,
 <span class="c004">&lt;code&gt;..&lt;/code&gt;</span>,
@@ -700,7 +700,7 @@ The HTML tags <span class="c004">&lt;b&gt;..&lt;/b&gt;</span>,
  <span class="c005">{li ..}</span> ,
  <span class="c005">{C ..}</span>  and
 <span class="c004">{[0-9] ..}</span>.</p>
-<h3 class="subsection" id="ss:ocamldoc-tags"><a class="section-anchor" href="#ss:ocamldoc-tags" aria-hidden="true">﻿</a>15.2.5 Documentation tags (@-tags)</h3>
+<h3 class="subsection" id="ss:ocamldoc-tags"><a class="section-anchor" href="#ss:ocamldoc-tags" aria-hidden="true">﻿</a><span class="number">2.5</span>Documentation tags (@-tags)</h3>
 <h4 class="subsubsection" id="sss:ocamldoc-builtin-tags"><a class="section-anchor" href="#sss:ocamldoc-builtin-tags" aria-hidden="true">﻿</a>Predefined tags</h4>
 <p>
 The following table gives the list of predefined @-tags, with their
@@ -754,7 +754,7 @@ comment, as in:
 </pre><p>
 To handle custom tags, you need to define a custom generator,
 as explained in section <a href="#ss%3Aocamldoc-handling-custom-tags">15.3.2</a>.</p>
-<h2 class="section" id="s:ocamldoc-custom-generators"><a class="section-anchor" href="#s:ocamldoc-custom-generators" aria-hidden="true">﻿</a>15.3 Custom generators</h2>
+<h2 class="section" id="s:ocamldoc-custom-generators"><a class="section-anchor" href="#s:ocamldoc-custom-generators" aria-hidden="true">﻿</a><span class="number">3</span>Custom generators</h2>
 <p>OCamldoc operates in two steps:
 </p><ol class="enumerate" type="1"><li class="li-enumerate">
 analysis of the source files;
@@ -768,23 +768,23 @@ the <span class="c004">Odoc_info</span> module, which gives access to all the ty
 representing the elements found in the given modules, with their associated
 description.</p><p>The files you can use to define custom generators are installed in the
 <span class="c004">ocamldoc</span> sub-directory of the OCaml standard library.</p>
-<h3 class="subsection" id="ss:ocamldoc-generators"><a class="section-anchor" href="#ss:ocamldoc-generators" aria-hidden="true">﻿</a>15.3.1 The generator modules</h3>
+<h3 class="subsection" id="ss:ocamldoc-generators"><a class="section-anchor" href="#ss:ocamldoc-generators" aria-hidden="true">﻿</a><span class="number">3.1</span>The generator modules</h3>
 <p>
 The type of a generator module depends on the kind of generated documentation.
 Here is the list of generator module types, with the name of the generator
-class in the module ‍:
+class in the module&nbsp;:
 </p><ul class="itemize"><li class="li-itemize">
-for HTML ‍: <span class="c004">Odoc_html.Html_generator</span> (class <span class="c004">html</span>),
-</li><li class="li-itemize">for L<sup>A</sup>T<sub>E</sub>X ‍: <span class="c004">Odoc_latex.Latex_generator</span> (class <span class="c004">latex</span>),
-</li><li class="li-itemize">for TeXinfo ‍: <span class="c004">Odoc_texi.Texi_generator</span> (class <span class="c004">texi</span>),
-</li><li class="li-itemize">for man pages ‍: <span class="c004">Odoc_man.Man_generator</span> (class <span class="c004">man</span>),
-</li><li class="li-itemize">for graphviz (dot) ‍: <span class="c004">Odoc_dot.Dot_generator</span> (class <span class="c004">dot</span>),
-</li><li class="li-itemize">for other kinds ‍: <span class="c004">Odoc_gen.Base</span> (class <span class="c004">generator</span>).
+for HTML&nbsp;: <span class="c004">Odoc_html.Html_generator</span> (class <span class="c004">html</span>),
+</li><li class="li-itemize">for L<sup>A</sup>T<sub>E</sub>X&nbsp;: <span class="c004">Odoc_latex.Latex_generator</span> (class <span class="c004">latex</span>),
+</li><li class="li-itemize">for TeXinfo&nbsp;: <span class="c004">Odoc_texi.Texi_generator</span> (class <span class="c004">texi</span>),
+</li><li class="li-itemize">for man pages&nbsp;: <span class="c004">Odoc_man.Man_generator</span> (class <span class="c004">man</span>),
+</li><li class="li-itemize">for graphviz (dot)&nbsp;: <span class="c004">Odoc_dot.Dot_generator</span> (class <span class="c004">dot</span>),
+</li><li class="li-itemize">for other kinds&nbsp;: <span class="c004">Odoc_gen.Base</span> (class <span class="c004">generator</span>).
 </li></ul><p>
 That is, to define a new generator, one must implement a module with
 the expected signature, and with the given generator class, providing
 the <span class="c004">generate</span> method as entry point to make the generator generates
-documentation for a given list of modules ‍:</p><pre>        method generate : Odoc_info.Module.t_module list -&gt; unit
+documentation for a given list of modules&nbsp;:</p><pre>        method generate : Odoc_info.Module.t_module list -&gt; unit
 </pre><p>
 This method will be called with the list of analysed and possibly
 merged <span class="c004">Odoc_info.t_module</span> structures.</p><p>It is recommended to inherit from the current generator of the same
@@ -792,7 +792,7 @@ kind as the one you want to define. Doing so, it is possible to
 load various custom generators to combine improvements brought by each one.</p><p>This is done using first class modules (see chapter <a href="firstclassmodules.html#s%3Afirst-class-modules">8.5</a>).</p><p>The easiest way to define a custom generator is the following this example,
 here extending the current HTML generator. We don’t have to know if this is
 the original HTML generator defined in ocamldoc or if it has been extended
-already by a previously loaded custom generator ‍:</p><pre>module Generator (G : Odoc_html.Html_generator) =
+already by a previously loaded custom generator&nbsp;:</p><pre>module Generator (G : Odoc_html.Html_generator) =
 struct
   class html =
     object(self)
@@ -811,16 +811,16 @@ let _ = Odoc_args.extend_html_generator (module Generator : Odoc_gen.Html_functo
 </pre><p>
 To know which methods to override and/or which methods are available,
 have a look at the different base implementations, depending on the
-kind of generator you are extending ‍:
+kind of generator you are extending&nbsp;:
 
 </p><ul class="itemize"><li class="li-itemize">
-for HTML ‍: <a href="https://github.com/ocaml/ocaml/blob/4.12/ocamldoc/odoc_html.ml"><span class="c004">odoc_html.ml</span></a>,
-</li><li class="li-itemize">for L<sup>A</sup>T<sub>E</sub>X ‍: <a href="https://github.com/ocaml/ocaml/blob/4.12/ocamldoc/odoc_latex.ml"><span class="c004">odoc_latex.ml</span></a>,
-</li><li class="li-itemize">for TeXinfo ‍: <a href="https://github.com/ocaml/ocaml/blob/4.12/ocamldoc/odoc_texi.ml"><span class="c004">odoc_texi.ml</span></a>,
-</li><li class="li-itemize">for man pages ‍: <a href="https://github.com/ocaml/ocaml/blob/4.12/ocamldoc/odoc_man.ml"><span class="c004">odoc_man.ml</span></a>,
-</li><li class="li-itemize">for graphviz (dot) ‍: <a href="https://github.com/ocaml/ocaml/blob/4.12/ocamldoc/odoc_dot.ml"><span class="c004">odoc_dot.ml</span></a>.
+for HTML&nbsp;: <a href="https://github.com/ocaml/ocaml/blob/4.12/ocamldoc/odoc_html.ml"><span class="c004">odoc_html.ml</span></a>,
+</li><li class="li-itemize">for L<sup>A</sup>T<sub>E</sub>X&nbsp;: <a href="https://github.com/ocaml/ocaml/blob/4.12/ocamldoc/odoc_latex.ml"><span class="c004">odoc_latex.ml</span></a>,
+</li><li class="li-itemize">for TeXinfo&nbsp;: <a href="https://github.com/ocaml/ocaml/blob/4.12/ocamldoc/odoc_texi.ml"><span class="c004">odoc_texi.ml</span></a>,
+</li><li class="li-itemize">for man pages&nbsp;: <a href="https://github.com/ocaml/ocaml/blob/4.12/ocamldoc/odoc_man.ml"><span class="c004">odoc_man.ml</span></a>,
+</li><li class="li-itemize">for graphviz (dot)&nbsp;: <a href="https://github.com/ocaml/ocaml/blob/4.12/ocamldoc/odoc_dot.ml"><span class="c004">odoc_dot.ml</span></a>.
 </li></ul>
-<h3 class="subsection" id="ss:ocamldoc-handling-custom-tags"><a class="section-anchor" href="#ss:ocamldoc-handling-custom-tags" aria-hidden="true">﻿</a>15.3.2 Handling custom tags</h3>
+<h3 class="subsection" id="ss:ocamldoc-handling-custom-tags"><a class="section-anchor" href="#ss:ocamldoc-handling-custom-tags" aria-hidden="true">﻿</a><span class="number">3.2</span>Handling custom tags</h3>
 <p>Making a custom generator handle custom tags (see
 <a href="#sss%3Aocamldoc-custom-tags">15.2.5</a>) is very simple.</p><h4 class="subsubsection" id="sss:ocamldoc-html-generator"><a class="section-anchor" href="#sss:ocamldoc-html-generator" aria-hidden="true">﻿</a>For HTML</h4>
 <p>
@@ -852,7 +852,7 @@ prints a warning message on <span class="c004">stderr</span>.</p>
 <h4 class="subsubsection" id="sss:ocamldoc-other-generators"><a class="section-anchor" href="#sss:ocamldoc-other-generators" aria-hidden="true">﻿</a>For other generators</h4>
 <p>
 You can act the same way for other kinds of generators.</p>
-<h2 class="section" id="s:ocamldoc-adding-flags"><a class="section-anchor" href="#s:ocamldoc-adding-flags" aria-hidden="true">﻿</a>15.4 Adding command line options</h2>
+<h2 class="section" id="s:ocamldoc-adding-flags"><a class="section-anchor" href="#s:ocamldoc-adding-flags" aria-hidden="true">﻿</a><span class="number">4</span>Adding command line options</h2>
 <p>
 The command line analysis is performed after loading the module containing the
 documentation generator, thus allowing command line options to be added to the
@@ -860,14 +860,14 @@ list of existing ones. Adding an option can be done with the function
 </p><pre>        Odoc_args.add_option : string * Arg.spec * string -&gt; unit
 </pre><p>Note: Existing command line options can be redefined using
 this function.</p>
-<h3 class="subsection" id="ss:ocamldoc-compilation-and-usage"><a class="section-anchor" href="#ss:ocamldoc-compilation-and-usage" aria-hidden="true">﻿</a>15.4.1 Compilation and usage</h3>
+<h3 class="subsection" id="ss:ocamldoc-compilation-and-usage"><a class="section-anchor" href="#ss:ocamldoc-compilation-and-usage" aria-hidden="true">﻿</a><span class="number">4.1</span>Compilation and usage</h3>
 <h4 class="subsubsection" id="sss:ocamldoc-generator-class"><a class="section-anchor" href="#sss:ocamldoc-generator-class" aria-hidden="true">﻿</a>Defining a custom generator class in one file</h4>
 <p>
 Let <span class="c004">custom.ml</span> be the file defining a new generator class.
-Compilation of <span class="c004">custom.ml</span> can be performed by the following command ‍:
+Compilation of <span class="c004">custom.ml</span> can be performed by the following command&nbsp;:
 </p><pre>        ocamlc -I +ocamldoc -c custom.ml
 </pre><p>
-The file <span class="c004">custom.cmo</span> is created and can be used this way ‍:
+The file <span class="c004">custom.cmo</span> is created and can be used this way&nbsp;:
 </p><pre>        ocamldoc -g custom.cmo <span class="c010">other-options source-files</span>
 </pre><p>
 Options selecting a built-in generator to <span class="c004">ocamldoc</span>, such as
@@ -880,7 +880,7 @@ It is possible to define a generator class in several modules, which
 are defined in several files <span class="c010">file</span><sub>1</sub><span class="c004">.ml</span>[<span class="c004">i</span>],
 <span class="c010">file</span><sub>2</sub><span class="c004">.ml</span>[<span class="c004">i</span>], ..., <span class="c010">file</span><sub><span class="c010">n</span></sub><span class="c004">.ml</span>[<span class="c004">i</span>]. A <span class="c004">.cma</span>
 library file must be created, including all these files.</p><p>The following commands create the <span class="c004">custom.cma</span> file from files
-<span class="c010">file</span><sub>1</sub><span class="c004">.ml</span>[<span class="c004">i</span>], ..., <span class="c010">file</span><sub><span class="c010">n</span></sub><span class="c004">.ml</span>[<span class="c004">i</span>] ‍:
+<span class="c010">file</span><sub>1</sub><span class="c004">.ml</span>[<span class="c004">i</span>], ..., <span class="c010">file</span><sub><span class="c010">n</span></sub><span class="c004">.ml</span>[<span class="c004">i</span>]&nbsp;:
 </p><pre>ocamlc -I +ocamldoc -c <span class="c010">file</span><sub>1</sub>.ml[i]
 ocamlc -I +ocamldoc -c <span class="c010">file</span><sub>2</sub>.ml[i]
 ...
@@ -891,7 +891,7 @@ Then, the following command uses <span class="c004">custom.cma</span> as custom 
 </p><pre>        ocamldoc -g custom.cma <span class="c010">other-options source-files</span>
 </pre>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="depend.html">« Chapter ‍14 Dependency generator (ocamldep)</a><a class="next" href="debugger.html">Chapter ‍16 The debugger (ocamldebug) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="depend.html">« Dependency generator (ocamldep)</a><a class="next" href="debugger.html">The debugger (ocamldebug) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/old.html
+++ b/site/releases/4.12/htmlman/old.html
@@ -5,31 +5,31 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</title>
+<title>OCaml - Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍IV The OCaml library</nav><ul id="part-menu"><li><a href="core.html">Chapter ‍22 The core library</a></li><li><a href="stdlib.html">Chapter ‍23 The standard library</a></li><li><a href="parsing.html">Chapter ‍24 The compiler front-end</a></li><li><a href="libunix.html">Chapter ‍25 The unix library: Unix system calls</a></li><li><a href="libstr.html">Chapter ‍26 The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">Chapter ‍27 The threads library</a></li><li><a href="libdynlink.html">Chapter ‍28 The dynlink library: dynamic loading and linking of object files</a></li><li class="active"><a href="old.html">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li class="active"><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec574">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li>
-<li><a href="old.html#s%3Agraphics-removed">29.1 The Graphics Library</a>
-</li><li><a href="old.html#s%3Abigarray-moved">29.2 The Bigarray Library</a>
-</li><li><a href="old.html#sec577">29.3 The Num Library</a>
-</li><li><a href="old.html#s%3Alabltk-removed">29.4 The Labltk Library and OCamlBrowser</a>
+<h1 class="chapter" id="sec574"><span class="number">Chapter 29</span>Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li>
+<li><a href="old.html#s%3Agraphics-removed"><span class="number">1</span>The Graphics Library</a>
+</li><li><a href="old.html#s%3Abigarray-moved"><span class="number">2</span>The Bigarray Library</a>
+</li><li><a href="old.html#sec577"><span class="number">3</span>The Num Library</a>
+</li><li><a href="old.html#s%3Alabltk-removed"><span class="number">4</span>The Labltk Library and OCamlBrowser</a>
 </li></ul></nav></header>
 <p>This chapter describes three libraries which were formerly part of the OCaml
 distribution (Graphics, Num, and LablTk), and a library which has now become
 part of OCaml’s standard library, and is documented there (Bigarray).</p>
-<h2 class="section" id="s:graphics-removed"><a class="section-anchor" href="#s:graphics-removed" aria-hidden="true"></a>29.1 The Graphics Library</h2>
+<h2 class="section" id="s:graphics-removed"><a class="section-anchor" href="#s:graphics-removed" aria-hidden="true"></a><span class="number">1</span>The Graphics Library</h2>
 <p>Since OCaml 4.09, the <span class="c004">graphics</span> library is distributed as an external
 package. Its new home is:</p><p><a href="https://github.com/ocaml/graphics"><span class="c004">https://github.com/ocaml/graphics</span></a></p><p>If you are using the opam package manager, you should install the
 corresponding <span class="c004">graphics</span> package:</p><pre>        opam install graphics
 </pre><p>Before OCaml 4.09, this package simply ensures that the <span class="c004">graphics</span>
 library was installed by the compiler, and starting from OCaml 4.09
 this package effectively provides the <span class="c004">graphics</span> library.</p>
-<h2 class="section" id="s:bigarray-moved"><a class="section-anchor" href="#s:bigarray-moved" aria-hidden="true">﻿</a>29.2 The Bigarray Library</h2>
+<h2 class="section" id="s:bigarray-moved"><a class="section-anchor" href="#s:bigarray-moved" aria-hidden="true">﻿</a><span class="number">2</span>The Bigarray Library</h2>
 <p>As of OCaml 4.07, the <span class="c004">bigarray</span> library has been integrated into OCaml’s
 standard library.</p><p>The <span class="c004">bigarray</span> functionality may now be found in the standard library
 <a href="../api/Bigarray.html"><span class="c004">Bigarray</span> module</a>,
@@ -49,7 +49,7 @@ For interactive use of the <span class="c004">bigarray</span> compatibility libr
 </pre><p>
 or (if dynamic linking of C libraries is supported on your platform),
 start <span class="c004">ocaml</span> and type <span class="c004">#load "bigarray.cma";;</span>.</p>
-<h2 class="section" id="sec577"><a class="section-anchor" href="#sec577" aria-hidden="true">﻿</a>29.3 The Num Library</h2>
+<h2 class="section" id="sec577"><a class="section-anchor" href="#sec577" aria-hidden="true">﻿</a><span class="number">3</span>The Num Library</h2>
 <p>The <span class="c004">num</span> library implements integer arithmetic and rational
 arithmetic in arbitrary precision. It was split off the core
 OCaml distribution starting with the 4.06.0 release, and can now be found
@@ -58,13 +58,13 @@ at <a href="https://github.com/ocaml/num"><span class="c004">https://github.com/
 library, and older applications that already use <span class="c004">Num</span> are encouraged to
 switch to <span class="c004">Zarith</span>. <span class="c004">Zarith</span> delivers much better performance than <span class="c004">Num</span>
 and has a nicer API.</p>
-<h2 class="section" id="s:labltk-removed"><a class="section-anchor" href="#s:labltk-removed" aria-hidden="true">﻿</a>29.4 The Labltk Library and OCamlBrowser</h2>
+<h2 class="section" id="s:labltk-removed"><a class="section-anchor" href="#s:labltk-removed" aria-hidden="true">﻿</a><span class="number">4</span>The Labltk Library and OCamlBrowser</h2>
 <p>Since OCaml version 4.02, the OCamlBrowser tool and the Labltk library
 are distributed separately from the OCaml compiler. The project is now
 hosted at <a href="https://github.com/garrigue/labltk"><span class="c004">https://github.com/garrigue/labltk</span></a>.
 </p>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="libdynlink.html">« Chapter ‍28 The dynlink library: dynamic loading and linking of object files</a><a class="next" href="manual067.html">manual067.html</a></div>
+<div class="bottom-navigation"><a class="previous" href="libdynlink.html">« The dynlink library: dynamic loading and linking of object files</a><a class="next" href="manual067.html">manual067.html</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/overridingopen.html
+++ b/site/releases/4.12/htmlman/overridingopen.html
@@ -5,43 +5,43 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:explicit-overriding-open"><a class="section-anchor" href="#s:explicit-overriding-open" aria-hidden="true"></a>8.9 Overriding in open statements</h2>
+<h2 class="section" id="s:explicit-overriding-open"><a class="section-anchor" href="#s:explicit-overriding-open" aria-hidden="true"></a><span class="number">9</span>Overriding in open statements</h2>
 <p>
 <a id="hevea_manual.kwd224"></a>
 </p><p>(Introduced in OCaml 4.01)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -86,7 +86,7 @@ character after the <span class="c005">open</span> keyword indicates that such a
 intentional and should not trigger the warning.</p><p>This is also available (since OCaml 4.06) for local opens in class
 expressions and class type expressions.</p>
 
-<div class="bottom-navigation"><a class="previous" href="modulealias.html">« 8.8 Type-level module aliases</a><a class="next" href="gadts.html">8.10 Generalized algebraic datatypes »</a></div>
+<div class="bottom-navigation"><a class="previous" href="modulealias.html">« Type-level module aliases</a><a class="next" href="gadts.html">Generalized algebraic datatypes »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/parsing.html
+++ b/site/releases/4.12/htmlman/parsing.html
@@ -5,20 +5,20 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍24 The compiler front-end</title>
+<title>OCaml - The compiler front-end</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍IV The OCaml library</nav><ul id="part-menu"><li><a href="core.html">Chapter ‍22 The core library</a></li><li><a href="stdlib.html">Chapter ‍23 The standard library</a></li><li class="active"><a href="parsing.html">Chapter ‍24 The compiler front-end</a></li><li><a href="libunix.html">Chapter ‍25 The unix library: Unix system calls</a></li><li><a href="libstr.html">Chapter ‍26 The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">Chapter ‍27 The threads library</a></li><li><a href="libdynlink.html">Chapter ‍28 The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li class="active"><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
 
 
 
 
-<h1 class="chapter" id="sec569">Chapter ‍24 The compiler front-end</h1>
+<h1 class="chapter" id="sec569"><span class="number">Chapter 24</span>The compiler front-end</h1>
 <p> <a id="c:parsinglib"></a></p><p>
 <a id="Compiler-underscorelibs"></a> </p><p>This chapter describes the OCaml front-end, which declares the abstract
 syntax tree used by the compiler, provides a way to parse, print
 and pretty-print OCaml code, and ultimately allows one to write abstract
-syntax tree preprocessors invoked via the <span class="c004">-ppx</span> flag (see chapters ‍<a href="comp.html#c%3Acamlc">9</a>
-and ‍<a href="native.html#c%3Anativecomp">12</a>).</p><p>It is important to note that the exported front-end interface follows the evolution of the OCaml language and implementation, and thus does not provide <span class="c014">any</span> backwards compatibility guarantees.</p><p>The front-end is a part of <span class="c004">compiler-libs</span> library.
+syntax tree preprocessors invoked via the <span class="c004">-ppx</span> flag (see chapters&nbsp;<a href="comp.html#c%3Acamlc">9</a>
+and&nbsp;<a href="native.html#c%3Anativecomp">12</a>).</p><p>It is important to note that the exported front-end interface follows the evolution of the OCaml language and implementation, and thus does not provide <span class="c014">any</span> backwards compatibility guarantees.</p><p>The front-end is a part of <span class="c004">compiler-libs</span> library.
 Programs that use the <span class="c004">compiler-libs</span> library should be built as follows:
 </p><pre>        ocamlfind ocamlc <span class="c010">other options</span> -package compiler-libs.common <span class="c010">other files</span>
         ocamlfind ocamlopt <span class="c010">other options</span> -package compiler-libs.common <span class="c010">other files</span>
@@ -40,7 +40,7 @@ type<br>
 </li><li class="li-links"><a href="../api/compilerlibref/Pprintast.html">Module <span class="c004">Pprintast</span>: OCaml syntax printing</a>
 </li></ul>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="stdlib.html">« Chapter ‍23 The standard library</a><a class="next" href="libunix.html">Chapter ‍25 The unix library: Unix system calls »</a></div>
+<div class="bottom-navigation"><a class="previous" href="stdlib.html">« The standard library</a><a class="next" href="libunix.html">The unix library: Unix system calls »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/patterns.html
+++ b/site/releases/4.12/htmlman/patterns.html
@@ -5,32 +5,32 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:patterns"><a class="section-anchor" href="#s:patterns" aria-hidden="true"></a>7.6 Patterns</h2>
+<h2 class="section" id="s:patterns"><a class="section-anchor" href="#s:patterns" aria-hidden="true"></a><span class="number">6</span>Patterns</h2>
 <p>
 <a id="hevea_manual.kwd15"></a>
 </p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
@@ -92,7 +92,7 @@ higher precedences come first.
 <div class="center"><table class="c000 cellpadding1" border="1"><tbody><tr><td class="c015"><span class="c014">Operator</span></td><td class="c015"><span class="c014">Associativity</span> </td></tr>
 <tr><td class="c017">
 <span class="c004">..</span></td><td class="c017">– </td></tr>
-<tr><td class="c017"><span class="c004">lazy</span> (see section ‍<a href="#sss%3Apat-lazy">7.6</a>)</td><td class="c017">– </td></tr>
+<tr><td class="c017"><span class="c004">lazy</span> (see section&nbsp;<a href="#sss%3Apat-lazy">7.6</a>)</td><td class="c017">– </td></tr>
 <tr><td class="c017">Constructor application, Tag application</td><td class="c017">right </td></tr>
 <tr><td class="c017"><span class="c004">::</span></td><td class="c017">right </td></tr>
 <tr><td class="c017"><span class="c004">,</span></td><td class="c017">– </td></tr>
@@ -129,9 +129,9 @@ the two patterns <a class="syntax" href="#pattern"><span class="c011">pattern</s
 must bind exactly the same identifiers to values having the same types.
 Matching is performed from left to right.
 More precisely,
-in case some value ‍<span class="c010">v</span> matches <a class="syntax" href="#pattern"><span class="c011">pattern</span></a><sub>1</sub> <span class="c005">|</span>  <a class="syntax" href="#pattern"><span class="c011">pattern</span></a><sub>2</sub>, the bindings
+in case some value&nbsp;<span class="c010">v</span> matches <a class="syntax" href="#pattern"><span class="c011">pattern</span></a><sub>1</sub> <span class="c005">|</span>  <a class="syntax" href="#pattern"><span class="c011">pattern</span></a><sub>2</sub>, the bindings
 performed are those of <a class="syntax" href="#pattern"><span class="c011">pattern</span></a><sub>1</sub> when <span class="c010">v</span> matches <a class="syntax" href="#pattern"><span class="c011">pattern</span></a><sub>1</sub>.
-Otherwise, value ‍<span class="c010">v</span> matches <a class="syntax" href="#pattern"><span class="c011">pattern</span></a><sub>2</sub> whose bindings are performed.</p><h4 class="subsubsection" id="sss:pat-variant"><a class="section-anchor" href="#sss:pat-variant" aria-hidden="true">﻿</a>Variant patterns</h4>
+Otherwise, value&nbsp;<span class="c010">v</span> matches <a class="syntax" href="#pattern"><span class="c011">pattern</span></a><sub>2</sub> whose bindings are performed.</p><h4 class="subsubsection" id="sss:pat-variant"><a class="section-anchor" href="#sss:pat-variant" aria-hidden="true">﻿</a>Variant patterns</h4>
 <p>The pattern <a class="syntax" href="names.html#constr"><span class="c011">constr</span></a> <span class="c005">(</span>  <a class="syntax" href="#pattern"><span class="c011">pattern</span></a><sub>1</sub> <span class="c005">,</span> … <span class="c005">,</span>  <a class="syntax" href="#pattern"><span class="c011">pattern</span></a><sub><span class="c010">n</span></sub> <span class="c005">)</span> matches
 all variants whose
 constructor is equal to <a class="syntax" href="names.html#constr"><span class="c011">constr</span></a>, and whose arguments match
@@ -225,7 +225,7 @@ equivalent to <a class="syntax" href="names.html#module-path"><span class="c011"
 
 </p>
 
-<div class="bottom-navigation"><a class="previous" href="const.html">« 7.5 Constants</a><a class="next" href="expr.html">7.7 Expressions »</a></div>
+<div class="bottom-navigation"><a class="previous" href="const.html">« Constants</a><a class="next" href="expr.html">Expressions »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/polymorphism.html
+++ b/site/releases/4.12/htmlman/polymorphism.html
@@ -5,18 +5,18 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍5 Polymorphism and its limitations</title>
+<title>OCaml - Polymorphism and its limitations</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍I An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">Chapter ‍1 The core language</a></li><li><a href="moduleexamples.html">Chapter ‍2 The module system</a></li><li><a href="objectexamples.html">Chapter ‍3 Objects in OCaml</a></li><li><a href="lablexamples.html">Chapter ‍4 Labels and variants</a></li><li class="active"><a href="polymorphism.html">Chapter ‍5 Polymorphism and its limitations</a></li><li><a href="advexamples.html">Chapter ‍6 Advanced examples with classes and modules</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li class="active"><a href="polymorphism.html">Polymorphism and its limitations</a></li><li><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec53">Chapter ‍5 Polymorphism and its limitations</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍5 Polymorphism and its limitations</a></li>
-<li><a href="polymorphism.html#s%3Aweak-polymorphism">5.1 Weak polymorphism and mutation</a>
-</li><li><a href="polymorphism.html#s%3Apolymorphic-recursion">5.2 Polymorphic recursion</a>
-</li><li><a href="polymorphism.html#s%3Ahigher-rank-poly">5.3 Higher-rank polymorphic functions</a>
+<h1 class="chapter" id="sec53"><span class="number">Chapter 5</span>Polymorphism and its limitations</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Polymorphism and its limitations</a></li>
+<li><a href="polymorphism.html#s%3Aweak-polymorphism"><span class="number">1</span>Weak polymorphism and mutation</a>
+</li><li><a href="polymorphism.html#s%3Apolymorphic-recursion"><span class="number">2</span>Polymorphic recursion</a>
+</li><li><a href="polymorphism.html#s%3Ahigher-rank-poly"><span class="number">3</span>Higher-rank polymorphic functions</a>
 </li></ul></nav></header>
 <p><a id="c:polymorphism"></a>
 </p><p><br>
@@ -28,8 +28,8 @@ than expected. Such non-genericity can stem either from interactions
 between side-effect and typing or the difficulties of implicit polymorphic
 recursion and higher-rank polymorphism.</p><p>This chapter details each of these situations and, if it is possible,
 how to recover genericity.</p>
-<h2 class="section" id="s:weak-polymorphism"><a class="section-anchor" href="#s:weak-polymorphism" aria-hidden="true"></a>5.1 Weak polymorphism and mutation</h2>
-<h3 class="subsection" id="ss:weak-types"><a class="section-anchor" href="#ss:weak-types" aria-hidden="true">﻿</a>5.1.1 Weakly polymorphic types</h3>
+<h2 class="section" id="s:weak-polymorphism"><a class="section-anchor" href="#s:weak-polymorphism" aria-hidden="true"></a><span class="number">1</span>Weak polymorphism and mutation</h2>
+<h3 class="subsection" id="ss:weak-types"><a class="section-anchor" href="#ss:weak-types" aria-hidden="true">﻿</a><span class="number">1.1</span>Weakly polymorphic types</h3>
 <p>
 Maybe the most frequent examples of non-genericity derive from the
 interactions between polymorphic types and mutation. A simple example
@@ -198,7 +198,7 @@ specify the type at declaration time:
 Otherwise, they will pick out the type of first use. If there is a mistake
 at this point, this can result in confusing type errors when later, correct
 uses are flagged as errors.</p>
-<h3 class="subsection" id="ss:valuerestriction"><a class="section-anchor" href="#ss:valuerestriction" aria-hidden="true">﻿</a>5.1.2 The value restriction</h3>
+<h3 class="subsection" id="ss:valuerestriction"><a class="section-anchor" href="#ss:valuerestriction" aria-hidden="true">﻿</a><span class="number">1.2</span>The value restriction</h3>
 <p>Identifying the exact context in which polymorphic types should be
 replaced by weak types in a modular way is a difficult question. Indeed
 the type system must handle the possibility that functions may hide persistent
@@ -278,7 +278,7 @@ function:
 With this argument, <span class="c004">id_again</span> is seen as a function definition by the type
 checker and can therefore be generalized. This kind of manipulation is called
 eta-expansion in lambda calculus and is sometimes referred under this name.</p>
-<h3 class="subsection" id="ss:relaxed-value-restriction"><a class="section-anchor" href="#ss:relaxed-value-restriction" aria-hidden="true">﻿</a>5.1.3 The relaxed value restriction</h3>
+<h3 class="subsection" id="ss:relaxed-value-restriction"><a class="section-anchor" href="#ss:relaxed-value-restriction" aria-hidden="true">﻿</a><span class="number">1.3</span>The relaxed value restriction</h3>
 <p>There is another partial solution to the problem of unnecessary weak type,
 which is implemented directly within the type checker. Briefly, it is possible
 to prove that weak types that only appear as type parameters in covariant
@@ -312,7 +312,7 @@ Remark that the type inferred for <span class="c004">empty</span> is <span class
 that should have occurred with the value restriction since <span class="c004">f ()</span> is a
 function application.</p><p>The value restriction combined with this generalization for covariant type
 parameters is called the relaxed value restriction.</p>
-<h3 class="subsection" id="ss:variance-and-value-restriction"><a class="section-anchor" href="#ss:variance-and-value-restriction" aria-hidden="true">﻿</a>5.1.4 Variance and value restriction</h3>
+<h3 class="subsection" id="ss:variance-and-value-restriction"><a class="section-anchor" href="#ss:variance-and-value-restriction" aria-hidden="true">﻿</a><span class="number">1.4</span>Variance and value restriction</h3>
 <p>
 Variance describes how type constructors behave with respect to subtyping.
 Consider for instance a pair of type <span class="c004">x</span> and <span class="c004">xy</span> with <span class="c004">x</span> a subtype of <span class="c004">xy</span>,
@@ -478,7 +478,7 @@ For a better description, interested readers can consult the original
 article by Jacques Garrigue on
 <a href="http://www.math.nagoya-u.ac.jp/~garrigue/papers/morepoly-long.pdf"><span class="c004">http://www.math.nagoya-u.ac.jp/~garrigue/papers/morepoly-long.pdf</span></a></p><p>Together, the relaxed value restriction and type parameter covariance
 help to avoid eta-expansion in many situations.</p>
-<h3 class="subsection" id="ss:variance:abstract-data-types"><a class="section-anchor" href="#ss:variance:abstract-data-types" aria-hidden="true">﻿</a>5.1.5 Abstract data types</h3>
+<h3 class="subsection" id="ss:variance:abstract-data-types"><a class="section-anchor" href="#ss:variance:abstract-data-types" aria-hidden="true">﻿</a><span class="number">1.5</span>Abstract data types</h3>
 <p>
 Moreover, when the type definitions are exposed, the type checker
 is able to infer variance information on its own and one can benefit from
@@ -565,7 +565,7 @@ in <span class="c004">'a</span>. Consequently, the relaxed value restriction doe
 <div class="pre caml-output ok">- : 'a List2.t = &lt;abstr&gt;</div></div>
 
 </div>
-<h2 class="section" id="s:polymorphic-recursion"><a class="section-anchor" href="#s:polymorphic-recursion" aria-hidden="true">﻿</a>5.2 Polymorphic recursion</h2>
+<h2 class="section" id="s:polymorphic-recursion"><a class="section-anchor" href="#s:polymorphic-recursion" aria-hidden="true">﻿</a><span class="number">2</span>Polymorphic recursion</h2>
 <p>The second major class of non-genericity is directly related to the problem
 of type inference for polymorphic functions. In some circumstances, the type
 inferred by OCaml might be not general enough to allow the definition of
@@ -668,7 +668,7 @@ non-regularity of the type constructor <span class="c004">nested</span>. This cr
 the type checker had introduced a new type variable <span class="c004">'a</span> only at the
 <em>definition</em> of the function <span class="c004">depth</span> whereas, here, we need a
 different type variable for every <em>application</em> of the function <span class="c004">depth</span>.</p>
-<h3 class="subsection" id="ss:explicit-polymorphism"><a class="section-anchor" href="#ss:explicit-polymorphism" aria-hidden="true">﻿</a>5.2.1 Explicitly polymorphic annotations</h3>
+<h3 class="subsection" id="ss:explicit-polymorphism"><a class="section-anchor" href="#ss:explicit-polymorphism" aria-hidden="true">﻿</a><span class="number">2.1</span>Explicitly polymorphic annotations</h3>
 <p>
 The solution of this conundrum is to use an explicitly polymorphic type
 annotation for the type <span class="c004">'a</span>:
@@ -770,7 +770,7 @@ universally quantified type variables:
 <div class="pre caml-output ok">- : int = 2</div></div>
 
 </div>
-<h3 class="subsection" id="ss:recursive-poly-examples"><a class="section-anchor" href="#ss:recursive-poly-examples" aria-hidden="true">﻿</a>5.2.2 More examples</h3>
+<h3 class="subsection" id="ss:recursive-poly-examples"><a class="section-anchor" href="#ss:recursive-poly-examples" aria-hidden="true">﻿</a><span class="number">2.2</span>More examples</h3>
 <p>
 With explicit polymorphic annotations, it becomes possible to implement
 any recursive function that depends only on the structure of the nested
@@ -845,7 +845,7 @@ list lengths of the nested list:
 <div class="pre caml-output ok">- : int nested = Nested (List [[2; 1]; [0; 1; 3]; [0]])</div></div>
 
 </div>
-<h2 class="section" id="s:higher-rank-poly"><a class="section-anchor" href="#s:higher-rank-poly" aria-hidden="true">﻿</a>5.3 Higher-rank polymorphic functions</h2>
+<h2 class="section" id="s:higher-rank-poly"><a class="section-anchor" href="#s:higher-rank-poly" aria-hidden="true">﻿</a><span class="number">3</span>Higher-rank polymorphic functions</h2>
 <p>Explicit polymorphic annotations are however not sufficient to cover all
 the cases where the inferred type of a function is less general than
 expected. A similar problem arises when using polymorphic functions as arguments
@@ -1016,7 +1016,7 @@ or the object one:
 
 </div>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="lablexamples.html">« Chapter ‍4 Labels and variants</a><a class="next" href="advexamples.html">Chapter ‍6 Advanced examples with classes and modules »</a></div>
+<div class="bottom-navigation"><a class="previous" href="lablexamples.html">« Labels and variants</a><a class="next" href="advexamples.html">Advanced examples with classes and modules »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/privatetypes.html
+++ b/site/releases/4.12/htmlman/privatetypes.html
@@ -5,47 +5,47 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:private-types"><a class="section-anchor" href="#s:private-types" aria-hidden="true"></a>8.3 Private types</h2>
+<h2 class="section" id="s:private-types"><a class="section-anchor" href="#s:private-types" aria-hidden="true"></a><span class="number">3</span>Private types</h2>
 <ul>
-<li><a href="privatetypes.html#ss%3Aprivate-types-variant">8.3.1 Private variant and record types</a>
-</li><li><a href="privatetypes.html#ss%3Aprivate-types-abbrev">8.3.2 Private type abbreviations</a>
-</li><li><a href="privatetypes.html#ss%3Aprivate-rows">8.3.3 Private row types</a>
+<li><a href="privatetypes.html#ss%3Aprivate-types-variant"><span class="number">3.1</span>Private variant and record types</a>
+</li><li><a href="privatetypes.html#ss%3Aprivate-types-abbrev"><span class="number">3.2</span>Private type abbreviations</a>
+</li><li><a href="privatetypes.html#ss%3Aprivate-rows"><span class="number">3.3</span>Private row types</a>
 </li></ul>
 <p>
 <a id="hevea_manual.kwd208"></a></p><p>Private type declarations in module signatures, of the form
@@ -56,10 +56,10 @@ between abstract type declarations, where no information is revealed
 on the type implementation, and data type definitions and type
 abbreviations, where all aspects of the type implementation are
 publicized. Private type declarations come in three flavors: for
-variant and record types (section ‍<a href="#ss%3Aprivate-types-variant">8.3.1</a>),
-for type abbreviations (section ‍<a href="#ss%3Aprivate-types-abbrev">8.3.2</a>),
-and for row types (section ‍<a href="#ss%3Aprivate-rows">8.3.3</a>).</p>
-<h3 class="subsection" id="ss:private-types-variant"><a class="section-anchor" href="#ss:private-types-variant" aria-hidden="true">﻿</a>8.3.1 Private variant and record types</h3>
+variant and record types (section&nbsp;<a href="#ss%3Aprivate-types-variant">8.3.1</a>),
+for type abbreviations (section&nbsp;<a href="#ss%3Aprivate-types-abbrev">8.3.2</a>),
+and for row types (section&nbsp;<a href="#ss%3Aprivate-rows">8.3.3</a>).</p>
+<h3 class="subsection" id="ss:private-types-variant"><a class="section-anchor" href="#ss:private-types-variant" aria-hidden="true">﻿</a><span class="number">3.1</span>Private variant and record types</h3>
 <p>(Introduced in Objective Caml 3.07)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="typedecl.html#type-representation"><span class="c011">type-representation</span></a></td><td class="c016">::=</td><td class="c018">
 ...
@@ -102,7 +102,7 @@ Here, the <span class="c005">private</span> declaration ensures that in any valu
 handled like abstract types. That is, if a private type has
 parameters, their variance is the one explicitly given by prefixing
 the parameter by a ‘<span class="c004">+</span>’ or a ‘<span class="c004">-</span>’, it is invariant otherwise.</p>
-<h3 class="subsection" id="ss:private-types-abbrev"><a class="section-anchor" href="#ss:private-types-abbrev" aria-hidden="true">﻿</a>8.3.2 Private type abbreviations</h3>
+<h3 class="subsection" id="ss:private-types-abbrev"><a class="section-anchor" href="#ss:private-types-abbrev" aria-hidden="true">﻿</a><span class="number">3.2</span>Private type abbreviations</h3>
 <p>(Introduced in Objective Caml 3.11)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="typedecl.html#type-equation"><span class="c011">type-equation</span></a></td><td class="c016">::=</td><td class="c018">
 ...
@@ -147,7 +147,7 @@ and will only work in presence of private abbreviations if neither the
 type of <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a> nor <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a> contain any type variables. If they do,
 you must use the full form <span class="c005">(</span> <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a><sub>1</sub> <span class="c005">:&gt;</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a><sub>2</sub> <span class="c005">)</span> where
 <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a><sub>1</sub> is the expected type of <a class="syntax" href="expr.html#expr"><span class="c011">expr</span></a>. Concretely, this would be <span class="c004">(x : N.t :&gt; int)</span> and <span class="c004">(l : N.t list :&gt; int list)</span> for the above examples.</p>
-<h3 class="subsection" id="ss:private-rows"><a class="section-anchor" href="#ss:private-rows" aria-hidden="true">﻿</a>8.3.3 Private row types</h3>
+<h3 class="subsection" id="ss:private-rows"><a class="section-anchor" href="#ss:private-rows" aria-hidden="true">﻿</a><span class="number">3.3</span>Private row types</h3>
 <p>
 <a id="hevea_manual.kwd209"></a></p><p>(Introduced in Objective Caml 3.09)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="typedecl.html#type-equation"><span class="c011">type-equation</span></a></td><td class="c016">::=</td><td class="c018">
@@ -248,7 +248,7 @@ patter-matching on a [v], one should assume that any of the
 constructors of [t] could be present.</p><p>Similarly to abstract types, the variance of type parameters
 is not inferred, and must be given explicitly.</p>
 
-<div class="bottom-navigation"><a class="previous" href="manual024.html">« 8.2 Recursive modules</a><a class="next" href="locallyabstract.html">8.4 Locally abstract types »</a></div>
+<div class="bottom-navigation"><a class="previous" href="manual024.html">« Recursive modules</a><a class="next" href="locallyabstract.html">Locally abstract types »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/profil.html
+++ b/site/releases/4.12/htmlman/profil.html
@@ -5,29 +5,29 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍17 Profiling (ocamlprof)</title>
+<title>OCaml - Profiling (ocamlprof)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li class="active"><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li class="active"><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec412">Chapter ‍17 Profiling (ocamlprof)</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍17 Profiling (ocamlprof)</a></li>
-<li><a href="profil.html#s%3Aocamlprof-compiling">17.1 Compiling for profiling</a>
-</li><li><a href="profil.html#s%3Aocamlprof-profiling">17.2 Profiling an execution</a>
-</li><li><a href="profil.html#s%3Aocamlprof-printing">17.3 Printing profiling information</a>
-</li><li><a href="profil.html#s%3Aocamlprof-time-profiling">17.4 Time profiling</a>
+<h1 class="chapter" id="sec412"><span class="number">Chapter 17</span>Profiling (ocamlprof)</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Profiling (ocamlprof)</a></li>
+<li><a href="profil.html#s%3Aocamlprof-compiling"><span class="number">1</span>Compiling for profiling</a>
+</li><li><a href="profil.html#s%3Aocamlprof-profiling"><span class="number">2</span>Profiling an execution</a>
+</li><li><a href="profil.html#s%3Aocamlprof-printing"><span class="number">3</span>Printing profiling information</a>
+</li><li><a href="profil.html#s%3Aocamlprof-time-profiling"><span class="number">4</span>Time profiling</a>
 </li></ul></nav></header>
 <p> <a id="c:profiler"></a>
 </p><p>This chapter describes how the execution of OCaml
 programs can be profiled, by recording how many times functions are
 called, branches of conditionals are taken, …</p>
-<h2 class="section" id="s:ocamlprof-compiling"><a class="section-anchor" href="#s:ocamlprof-compiling" aria-hidden="true"></a>17.1 Compiling for profiling</h2>
+<h2 class="section" id="s:ocamlprof-compiling"><a class="section-anchor" href="#s:ocamlprof-compiling" aria-hidden="true"></a><span class="number">1</span>Compiling for profiling</h2>
 <p>Before profiling an execution, the program must be compiled in
 profiling mode, using the <span class="c004">ocamlcp</span> front-end to the <span class="c004">ocamlc</span> compiler
-(see chapter ‍<a href="comp.html#c%3Acamlc">9</a>) or the <span class="c004">ocamloptp</span> front-end to the
-<span class="c004">ocamlopt</span> compiler (see chapter ‍<a href="native.html#c%3Anativecomp">12</a>). When compiling
+(see chapter&nbsp;<a href="comp.html#c%3Acamlc">9</a>) or the <span class="c004">ocamloptp</span> front-end to the
+<span class="c004">ocamlopt</span> compiler (see chapter&nbsp;<a href="native.html#c%3Anativecomp">12</a>). When compiling
 modules separately, <span class="c004">ocamlcp</span> or <span class="c004">ocamloptp</span> must be used when
 compiling the modules (production of <span class="c004">.cmo</span> or <span class="c004">.cmx</span> files), and can
 also be used (though this is not strictly necessary) when linking them
@@ -68,7 +68,7 @@ also accepts the <span class="c004">-p</span> option, with the same arguments an
 <span class="c004">-P</span>.</p><p>The <span class="c004">ocamlcp</span> and <span class="c004">ocamloptp</span> commands also accept all the options of
 the corresponding <span class="c004">ocamlc</span> or <span class="c004">ocamlopt</span> compiler, except the <span class="c004">-pp</span>
 (preprocessing) option.</p>
-<h2 class="section" id="s:ocamlprof-profiling"><a class="section-anchor" href="#s:ocamlprof-profiling" aria-hidden="true">﻿</a>17.2 Profiling an execution</h2>
+<h2 class="section" id="s:ocamlprof-profiling"><a class="section-anchor" href="#s:ocamlprof-profiling" aria-hidden="true">﻿</a><span class="number">2</span>Profiling an execution</h2>
 <p>Running an executable that has been compiled with <span class="c004">ocamlcp</span> or
 <span class="c004">ocamloptp</span> records the execution counts for the specified parts of
 the program and saves them in a file called <span class="c004">ocamlprof.dump</span> in the
@@ -81,7 +81,7 @@ instance, the profiling of several executions of a program on
 different inputs. Note that dump files produced by byte-code
 executables (compiled with <span class="c004">ocamlcp</span>) are compatible with the dump
 files produced by native executables (compiled with <span class="c004">ocamloptp</span>).</p>
-<h2 class="section" id="s:ocamlprof-printing"><a class="section-anchor" href="#s:ocamlprof-printing" aria-hidden="true">﻿</a>17.3 Printing profiling information</h2>
+<h2 class="section" id="s:ocamlprof-printing"><a class="section-anchor" href="#s:ocamlprof-printing" aria-hidden="true">﻿</a><span class="number">3</span>Printing profiling information</h2>
 <p>The <span class="c004">ocamlprof</span> command produces a source listing of the program modules
 where execution counts have been inserted as comments. For instance,
 </p><pre>        ocamlprof foo.ml
@@ -105,7 +105,7 @@ Print version string and exit.</dd><dt class="dt-description"><span class="c007"
 Print short version number and exit.</dd><dt class="dt-description"><span class="c014"><span class="c004">-help</span> or <span class="c004">--help</span></span></dt><dd class="dd-description">
 Display a short usage summary and exit.
 </dd></dl>
-<h2 class="section" id="s:ocamlprof-time-profiling"><a class="section-anchor" href="#s:ocamlprof-time-profiling" aria-hidden="true">﻿</a>17.4 Time profiling</h2>
+<h2 class="section" id="s:ocamlprof-time-profiling"><a class="section-anchor" href="#s:ocamlprof-time-profiling" aria-hidden="true">﻿</a><span class="number">4</span>Time profiling</h2>
 <p>Profiling with <span class="c004">ocamlprof</span> only records execution counts, not the actual
 time spent within each function. There is currently no way to perform
 time profiling on bytecode programs generated by <span class="c004">ocamlc</span>. For time
@@ -115,7 +115,7 @@ with <span class="c004">gprof</span> is no longer supported.
 
 </p>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="debugger.html">« Chapter ‍16 The debugger (ocamldebug)</a><a class="next" href="intfc.html">Chapter ‍18 Interfacing C with OCaml »</a></div>
+<div class="bottom-navigation"><a class="previous" href="debugger.html">« The debugger (ocamldebug)</a><a class="next" href="intfc.html">Interfacing C with OCaml »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/runtime.html
+++ b/site/releases/4.12/htmlman/runtime.html
@@ -5,24 +5,24 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍11 The runtime system (ocamlrun)</title>
+<title>OCaml - The runtime system (ocamlrun)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li class="active"><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li class="active"><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec305">Chapter ‍11 The runtime system (ocamlrun)</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍11 The runtime system (ocamlrun)</a></li>
-<li><a href="runtime.html#s%3Aocamlrun-overview">11.1 Overview</a>
-</li><li><a href="runtime.html#s%3Aocamlrun-options">11.2 Options</a>
-</li><li><a href="runtime.html#s%3Aocamlrun-dllpath">11.3 Dynamic loading of shared libraries</a>
-</li><li><a href="runtime.html#s%3Aocamlrun-common-errors">11.4 Common errors</a>
+<h1 class="chapter" id="sec305"><span class="number">Chapter 11</span>The runtime system (ocamlrun)</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The runtime system (ocamlrun)</a></li>
+<li><a href="runtime.html#s%3Aocamlrun-overview"><span class="number">1</span>Overview</a>
+</li><li><a href="runtime.html#s%3Aocamlrun-options"><span class="number">2</span>Options</a>
+</li><li><a href="runtime.html#s%3Aocamlrun-dllpath"><span class="number">3</span>Dynamic loading of shared libraries</a>
+</li><li><a href="runtime.html#s%3Aocamlrun-common-errors"><span class="number">4</span>Common errors</a>
 </li></ul></nav></header>
 <p> <a id="c:runtime"></a>
 </p><p>The <span class="c004">ocamlrun</span> command executes bytecode files produced by the
 linking phase of the <span class="c004">ocamlc</span> command.</p>
-<h2 class="section" id="s:ocamlrun-overview"><a class="section-anchor" href="#s:ocamlrun-overview" aria-hidden="true"></a>11.1 Overview</h2>
+<h2 class="section" id="s:ocamlrun-overview"><a class="section-anchor" href="#s:ocamlrun-overview" aria-hidden="true"></a><span class="number">1</span>Overview</h2>
 <p>The <span class="c004">ocamlrun</span> command comprises three main parts: the bytecode
 interpreter, that actually executes bytecode files; the memory
 allocator and garbage collector; and a set of C functions that
@@ -35,7 +35,7 @@ executable path as well as in the current directory.) The remaining
 arguments are passed to the OCaml program, in the string array
 <span class="c004">Sys.argv</span>. Element 0 of this array is the name of the
 bytecode executable file; elements 1 to <span class="c010">n</span> are the remaining
-arguments <span class="c010">arg</span><sub>1</sub> to <span class="c010">arg</span><sub><span class="c010">n</span></sub>.</p><p>As mentioned in chapter ‍<a href="comp.html#c%3Acamlc">9</a>, the bytecode executable files
+arguments <span class="c010">arg</span><sub>1</sub> to <span class="c010">arg</span><sub><span class="c010">n</span></sub>.</p><p>As mentioned in chapter&nbsp;<a href="comp.html#c%3Acamlc">9</a>, the bytecode executable files
 produced by the <span class="c004">ocamlc</span> command are self-executable, and manage to
 launch the <span class="c004">ocamlrun</span> command on themselves automatically. That is,
 assuming <span class="c004">a.out</span> is a bytecode executable file,
@@ -51,7 +51,7 @@ self-executable only if their name ends in <span class="c004">.exe</span>. It is
 to always give <span class="c004">.exe</span> names to bytecode executables, e.g. compile
 with <span class="c004">ocamlc -o myprog.exe ...</span> rather than <span class="c004">ocamlc -o myprog ...</span>.
 </blockquote>
-<h2 class="section" id="s:ocamlrun-options"><a class="section-anchor" href="#s:ocamlrun-options" aria-hidden="true">﻿</a>11.2 Options</h2>
+<h2 class="section" id="s:ocamlrun-options"><a class="section-anchor" href="#s:ocamlrun-options" aria-hidden="true">﻿</a><span class="number">2</span>Options</h2>
 <p>
 The following command-line options are recognized by <span class="c004">ocamlrun</span>.</p><dl class="description"><dt class="dt-description"><span class="c007">-b</span></dt><dd class="dd-description">
 When the program aborts due to an uncaught exception, print a detailed
@@ -64,7 +64,7 @@ in the <span class="c004">OCAMLRUNPARAM</span> environment variable (see below).
 </dd><dt class="dt-description"><span class="c014"><span class="c004">-I</span> <span class="c010">dir</span></span></dt><dd class="dd-description">
 Search the directory <span class="c010">dir</span> for dynamically-loaded libraries,
 in addition to the standard search path (see
-section ‍<a href="#s%3Aocamlrun-dllpath">11.3</a>).
+section&nbsp;<a href="#s%3Aocamlrun-dllpath">11.3</a>).
 </dd><dt class="dt-description"><span class="c007">-m</span></dt><dd class="dd-description">
 Print the magic number of the bytecode executable given as argument
 and exit.
@@ -82,10 +82,10 @@ Print version string and exit.
 </dd><dt class="dt-description"><span class="c007">-vnum</span></dt><dd class="dd-description">
 Print short version number and exit.</dd></dl><p>The following environment variables are also consulted:</p><dl class="description"><dt class="dt-description">
 <span class="c007">CAML_LD_LIBRARY_PATH</span></dt><dd class="dd-description"> Additional directories to search for
-dynamically-loaded libraries (see section ‍<a href="#s%3Aocamlrun-dllpath">11.3</a>).</dd><dt class="dt-description"><span class="c007">OCAMLLIB</span></dt><dd class="dd-description"> The directory containing the OCaml standard
+dynamically-loaded libraries (see section&nbsp;<a href="#s%3Aocamlrun-dllpath">11.3</a>).</dd><dt class="dt-description"><span class="c007">OCAMLLIB</span></dt><dd class="dd-description"> The directory containing the OCaml standard
 library. (If <span class="c004">OCAMLLIB</span> is not set, <span class="c004">CAMLLIB</span> will be used instead.)
 Used to locate the <span class="c004">ld.conf</span> configuration file for
-dynamic loading (see section ‍<a href="#s%3Aocamlrun-dllpath">11.3</a>). If not set,
+dynamic loading (see section&nbsp;<a href="#s%3Aocamlrun-dllpath">11.3</a>). If not set,
 default to the library directory specified when compiling OCaml.</dd><dt class="dt-description"><span class="c007">OCAMLRUNPARAM</span></dt><dd class="dd-description"> Set the runtime system options
 and garbage collection parameters.
 (If <span class="c004">OCAMLRUNPARAM</span> is not set, <span class="c004">CAMLRUNPARAM</span> will be used instead.)
@@ -149,7 +149,7 @@ executable file, resolving shared libraries).
 </dd><dt class="dt-description"><span class="c014">1024 (= 0x400)</span></dt><dd class="dd-description"> Output GC statistics at program exit.
 </dd></dl>
 </dd><dt class="dt-description"><span class="c014">c</span></dt><dd class="dd-description"> (<span class="c004">cleanup_on_exit</span>) Shut the runtime down gracefully on exit (see
-<span class="c004">caml_shutdown</span> in section ‍<a href="intfc.html#ss%3Ac-embedded-code">18.7.5</a>). The option also enables
+<span class="c004">caml_shutdown</span> in section&nbsp;<a href="intfc.html#ss%3Ac-embedded-code">18.7.5</a>). The option also enables
 pooling (as in <span class="c004">caml_startup_pooled</span>). This mode can be used to detect
 leaks with a third-party memory debugger.
 </dd><dt class="dt-description"><span class="c014">M</span></dt><dd class="dd-description"> (<span class="c004">custom_major_ratio</span>) Target ratio of floating garbage to
@@ -180,19 +180,19 @@ if the equal sign or the number is missing, the value is taken as 1;
 if the multiplier is not recognized, it is ignored.</p><p>For example, on a 32-bit machine, under <span class="c004">bash</span> the command
 </p><pre>        export OCAMLRUNPARAM='b,s=256k,v=0x015'
 </pre><p> tells a subsequent <span class="c004">ocamlrun</span> to print backtraces for uncaught exceptions,
-set its initial minor heap size to 1 ‍megabyte and
+set its initial minor heap size to 1&nbsp;megabyte and
 print a message at the start of each major GC cycle, when the heap
 size changes, and when compaction is triggered.</p></dd><dt class="dt-description"><span class="c007">CAMLRUNPARAM</span></dt><dd class="dd-description"> If <span class="c004">OCAMLRUNPARAM</span> is not found in the
 environment, then <span class="c004">CAMLRUNPARAM</span> will be used instead. If
 <span class="c004">CAMLRUNPARAM</span> is also not found, then the default values will be used.</dd><dt class="dt-description"><span class="c007">PATH</span></dt><dd class="dd-description"> List of directories searched to find the bytecode
 executable file.
 </dd></dl>
-<h2 class="section" id="s:ocamlrun-dllpath"><a class="section-anchor" href="#s:ocamlrun-dllpath" aria-hidden="true">﻿</a>11.3 Dynamic loading of shared libraries</h2>
+<h2 class="section" id="s:ocamlrun-dllpath"><a class="section-anchor" href="#s:ocamlrun-dllpath" aria-hidden="true">﻿</a><span class="number">3</span>Dynamic loading of shared libraries</h2>
 <p>On platforms that support dynamic loading, <span class="c004">ocamlrun</span> can link
 dynamically with C shared libraries (DLLs) providing additional C primitives
 beyond those provided by the standard runtime system. The names for
 these libraries are provided at link time as described in
-section ‍<a href="intfc.html#ss%3Adynlink-c-code">18.1.4</a>), and recorded in the bytecode executable
+section&nbsp;<a href="intfc.html#ss%3Adynlink-c-code">18.1.4</a>), and recorded in the bytecode executable
 file; <span class="c004">ocamlrun</span>, then, locates these libraries and resolves references
 to their primitives when the bytecode executable program starts.</p><p>The <span class="c004">ocamlrun</span> command searches shared libraries in the following
 directories, in the order indicated:
@@ -220,7 +220,7 @@ variable <span class="c004">LD_LIBRARY_PATH</span>. Under Windows, these include
 system directories, plus the directories listed in the <span class="c004">PATH</span>
 environment variable.
 </li></ol>
-<h2 class="section" id="s:ocamlrun-common-errors"><a class="section-anchor" href="#s:ocamlrun-common-errors" aria-hidden="true">﻿</a>11.4 Common errors</h2>
+<h2 class="section" id="s:ocamlrun-common-errors"><a class="section-anchor" href="#s:ocamlrun-common-errors" aria-hidden="true">﻿</a><span class="number">4</span>Common errors</h2>
 <p>This section describes and explains the most frequently encountered
 error messages.</p><dl class="description"><dt class="dt-description"><span class="c014"><span class="c010">filename</span><span class="c004">: no such file or directory</span></span></dt><dd class="dd-description">
 If <span class="c010">filename</span> is the name of a self-executable bytecode file, this
@@ -245,7 +245,7 @@ integer arguments
 (arguments of more complex types are not correctly printed).
 To locate the context of the uncaught exception, compile the program
 with the <span class="c004">-g</span> option and either run it again under the <span class="c004">ocamldebug</span>
-debugger (see chapter ‍<a href="debugger.html#c%3Adebugger">16</a>), or run it with <span class="c004">ocamlrun -b</span>
+debugger (see chapter&nbsp;<a href="debugger.html#c%3Adebugger">16</a>), or run it with <span class="c004">ocamlrun -b</span>
 or with the <span class="c004">OCAMLRUNPARAM</span> environment variable set to <span class="c004">b=1</span>.</dd><dt class="dt-description"><span class="c007">Out of memory</span></dt><dd class="dd-description">
 The program being executed requires more memory than available. Either
 the program builds excessively large data structures; or the program
@@ -266,7 +266,7 @@ structure with too many (infinitely many?) cells. If it displays few
 heap size, this is probably an attempt to build an excessively large
 array, string or byte sequence.</p></dd></dl>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="toplevel.html">« Chapter ‍10 The toplevel system or REPL (ocaml)</a><a class="next" href="native.html">Chapter ‍12 Native-code compilation (ocamlopt) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="toplevel.html">« The toplevel system or REPL (ocaml)</a><a class="next" href="native.html">Native-code compilation (ocamlopt) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/signaturesubstitution.html
+++ b/site/releases/4.12/htmlman/signaturesubstitution.html
@@ -5,53 +5,53 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍8 Language extensions</title>
+<title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li><a href="language.html">Chapter ‍7 The OCaml language</a></li><li class="active"><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec238">Chapter ‍8 Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍8 Language extensions</a></li>
-<li><a href="letrecvalues.html#start-section">8.1 Recursive definitions of values</a>
-</li><li><a href="manual024.html#start-section">8.2 Recursive modules</a>
-</li><li><a href="privatetypes.html#start-section">8.3 Private types</a>
-</li><li><a href="locallyabstract.html#start-section">8.4 Locally abstract types</a>
-</li><li><a href="firstclassmodules.html#start-section">8.5 First-class modules</a>
-</li><li><a href="moduletypeof.html#start-section">8.6 Recovering the type of a module</a>
-</li><li><a href="signaturesubstitution.html#start-section">8.7 Substituting inside a signature</a>
-</li><li><a href="modulealias.html#start-section">8.8 Type-level module aliases</a>
-</li><li><a href="overridingopen.html#start-section">8.9 Overriding in open statements</a>
-</li><li><a href="gadts.html#start-section">8.10 Generalized algebraic datatypes</a>
-</li><li><a href="bigarray.html#start-section">8.11 Syntax for Bigarray access</a>
-</li><li><a href="attributes.html#start-section">8.12 Attributes</a>
-</li><li><a href="extensionnodes.html#start-section">8.13 Extension nodes</a>
-</li><li><a href="extensiblevariants.html#start-section">8.14 Extensible variant types</a>
-</li><li><a href="generativefunctors.html#start-section">8.15 Generative functors</a>
-</li><li><a href="extensionsyntax.html#start-section">8.16 Extension-only syntax</a>
-</li><li><a href="inlinerecords.html#start-section">8.17 Inline records</a>
-</li><li><a href="doccomments.html#start-section">8.18 Documentation comments</a>
-</li><li><a href="indexops.html#start-section">8.19 Extended indexing operators </a>
-</li><li><a href="emptyvariants.html#start-section">8.20 Empty variant types</a>
-</li><li><a href="alerts.html#start-section">8.21 Alerts</a>
-</li><li><a href="generalizedopens.html#start-section">8.22 Generalized open statements</a>
-</li><li><a href="bindingops.html#start-section">8.23 Binding operators</a>
+<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
+</li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
+</li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>
+</li><li><a href="locallyabstract.html#start-section"><span class="number">4</span>Locally abstract types</a>
+</li><li><a href="firstclassmodules.html#start-section"><span class="number">5</span>First-class modules</a>
+</li><li><a href="moduletypeof.html#start-section"><span class="number">6</span>Recovering the type of a module</a>
+</li><li><a href="signaturesubstitution.html#start-section"><span class="number">7</span>Substituting inside a signature</a>
+</li><li><a href="modulealias.html#start-section"><span class="number">8</span>Type-level module aliases</a>
+</li><li><a href="overridingopen.html#start-section"><span class="number">9</span>Overriding in open statements</a>
+</li><li><a href="gadts.html#start-section"><span class="number">10</span>Generalized algebraic datatypes</a>
+</li><li><a href="bigarray.html#start-section"><span class="number">11</span>Syntax for Bigarray access</a>
+</li><li><a href="attributes.html#start-section"><span class="number">12</span>Attributes</a>
+</li><li><a href="extensionnodes.html#start-section"><span class="number">13</span>Extension nodes</a>
+</li><li><a href="extensiblevariants.html#start-section"><span class="number">14</span>Extensible variant types</a>
+</li><li><a href="generativefunctors.html#start-section"><span class="number">15</span>Generative functors</a>
+</li><li><a href="extensionsyntax.html#start-section"><span class="number">16</span>Extension-only syntax</a>
+</li><li><a href="inlinerecords.html#start-section"><span class="number">17</span>Inline records</a>
+</li><li><a href="doccomments.html#start-section"><span class="number">18</span>Documentation comments</a>
+</li><li><a href="indexops.html#start-section"><span class="number">19</span>Extended indexing operators </a>
+</li><li><a href="emptyvariants.html#start-section"><span class="number">20</span>Empty variant types</a>
+</li><li><a href="alerts.html#start-section"><span class="number">21</span>Alerts</a>
+</li><li><a href="generalizedopens.html#start-section"><span class="number">22</span>Generalized open statements</a>
+</li><li><a href="bindingops.html#start-section"><span class="number">23</span>Binding operators</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:signature-substitution"><a class="section-anchor" href="#s:signature-substitution" aria-hidden="true"></a>8.7 Substituting inside a signature</h2>
+<h2 class="section" id="s:signature-substitution"><a class="section-anchor" href="#s:signature-substitution" aria-hidden="true"></a><span class="number">7</span>Substituting inside a signature</h2>
 <ul>
-<li><a href="signaturesubstitution.html#ss%3Adestructive-substitution">8.7.1 Destructive substitutions</a>
-</li><li><a href="signaturesubstitution.html#ss%3Alocal-substitution">8.7.2 Local substitution declarations</a>
+<li><a href="signaturesubstitution.html#ss%3Adestructive-substitution"><span class="number">7.1</span>Destructive substitutions</a>
+</li><li><a href="signaturesubstitution.html#ss%3Alocal-substitution"><span class="number">7.2</span>Local substitution declarations</a>
 </li></ul>
 <p>
 <a id="hevea_manual.kwd220"></a>
 <a id="hevea_manual.kwd221"></a>
 <a id="hevea_manual.kwd222"></a>
 </p>
-<h3 class="subsection" id="ss:destructive-substitution"><a class="section-anchor" href="#ss:destructive-substitution" aria-hidden="true">﻿</a>8.7.1 Destructive substitutions</h3>
+<h3 class="subsection" id="ss:destructive-substitution"><a class="section-anchor" href="#ss:destructive-substitution" aria-hidden="true">﻿</a><span class="number">7.1</span>Destructive substitutions</h3>
 <p>(Introduced in OCaml 3.12, generalized in 4.06)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="modtypes.html#mod-constraint"><span class="c011">mod-constraint</span></a></td><td class="c016">::=</td><td class="c018">
 ...
@@ -146,7 +146,7 @@ same type.
 <div class="pre caml-output ok"><span class="ocamlkeyword">module</span> <span class="ocamlkeyword">type</span> CompareInt = <span class="ocamlkeyword">sig</span> <span class="ocamlkeyword">val</span> compare : int -&gt; int -&gt; int <span class="ocamlkeyword">end</span></div></div>
 
 </div>
-<h3 class="subsection" id="ss:local-substitution"><a class="section-anchor" href="#ss:local-substitution" aria-hidden="true">﻿</a>8.7.2 Local substitution declarations</h3>
+<h3 class="subsection" id="ss:local-substitution"><a class="section-anchor" href="#ss:local-substitution" aria-hidden="true">﻿</a><span class="number">7.2</span>Local substitution declarations</h3>
 <p>(Introduced in OCaml 4.08)</p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" href="modtypes.html#specification"><span class="c011">specification</span></a></td><td class="c016">::=</td><td class="c018">
 ...
@@ -201,7 +201,7 @@ recursive, so substitutions like the following are rejected:</p><div class="caml
 
 </div>
 
-<div class="bottom-navigation"><a class="previous" href="moduletypeof.html">« 8.6 Recovering the type of a module</a><a class="next" href="modulealias.html">8.8 Type-level module aliases »</a></div>
+<div class="bottom-navigation"><a class="previous" href="moduletypeof.html">« Recovering the type of a module</a><a class="next" href="modulealias.html">Type-level module aliases »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/stdlib.html
+++ b/site/releases/4.12/htmlman/stdlib.html
@@ -5,14 +5,14 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍23 The standard library</title>
+<title>OCaml - The standard library</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍IV The OCaml library</nav><ul id="part-menu"><li><a href="core.html">Chapter ‍22 The core library</a></li><li class="active"><a href="stdlib.html">Chapter ‍23 The standard library</a></li><li><a href="parsing.html">Chapter ‍24 The compiler front-end</a></li><li><a href="libunix.html">Chapter ‍25 The unix library: Unix system calls</a></li><li><a href="libstr.html">Chapter ‍26 The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">Chapter ‍27 The threads library</a></li><li><a href="libdynlink.html">Chapter ‍28 The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Chapter ‍29 Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li class="active"><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
 
 
 
 
-<h1 class="chapter" id="sec568">Chapter ‍23 The standard library</h1>
+<h1 class="chapter" id="sec568"><span class="number">Chapter 23</span>The standard library</h1>
 <p> <a id="c:stdlib"></a></p><p>This chapter describes the functions provided by the OCaml
 standard library. The modules from the standard library are
 automatically linked with the user’s object code files by the <span class="c004">ocamlc</span>
@@ -78,7 +78,7 @@ provided by these modules, or to add <span class="c004">open</span> directives.<
 </li><li class="li-links"><a href="../api/Weak.html">Module <span class="c004">Weak</span>: arrays of weak pointers</a>
 </li></ul>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="core.html">« Chapter ‍22 The core library</a><a class="next" href="parsing.html">Chapter ‍24 The compiler front-end »</a></div>
+<div class="bottom-navigation"><a class="previous" href="core.html">« The core library</a><a class="next" href="parsing.html">The compiler front-end »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/toplevel.html
+++ b/site/releases/4.12/htmlman/toplevel.html
@@ -5,21 +5,21 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍10 The toplevel system or REPL (ocaml)</title>
+<title>OCaml - The toplevel system or REPL (ocaml)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍III The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Chapter ‍9 Batch compilation (ocamlc)</a></li><li class="active"><a href="toplevel.html">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">Chapter ‍11 The runtime system (ocamlrun)</a></li><li><a href="native.html">Chapter ‍12 Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Chapter ‍13 Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Chapter ‍14 Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">Chapter ‍15 The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">Chapter ‍16 The debugger (ocamldebug)</a></li><li><a href="profil.html">Chapter ‍17 Profiling (ocamlprof)</a></li><li><a href="intfc.html">Chapter ‍18 Interfacing C with OCaml</a></li><li><a href="flambda.html">Chapter ‍19 Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Chapter ‍20 Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Chapter ‍21 Runtime tracing with the instrumented runtime</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li class="active"><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec297">Chapter ‍10 The toplevel system or REPL (ocaml)</h1>
-<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍10 The toplevel system or REPL (ocaml)</a></li>
-<li><a href="toplevel.html#s%3Atoplevel-options">10.1 Options</a>
-</li><li><a href="toplevel.html#s%3Atoplevel-directives">10.2 Toplevel directives</a>
-</li><li><a href="toplevel.html#s%3Atoplevel-modules">10.3 The toplevel and the module system</a>
-</li><li><a href="toplevel.html#s%3Atoplevel-common-errors">10.4 Common errors</a>
-</li><li><a href="toplevel.html#s%3Acustom-toplevel">10.5 Building custom toplevel systems: <span class="c004">ocamlmktop</span></a>
-</li><li><a href="toplevel.html#s%3Aocamlnat">10.6 The native toplevel: <span class="c004">ocamlnat</span> (experimental)</a>
+<h1 class="chapter" id="sec297"><span class="number">Chapter 10</span>The toplevel system or REPL (ocaml)</h1>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The toplevel system or REPL (ocaml)</a></li>
+<li><a href="toplevel.html#s%3Atoplevel-options"><span class="number">1</span>Options</a>
+</li><li><a href="toplevel.html#s%3Atoplevel-directives"><span class="number">2</span>Toplevel directives</a>
+</li><li><a href="toplevel.html#s%3Atoplevel-modules"><span class="number">3</span>The toplevel and the module system</a>
+</li><li><a href="toplevel.html#s%3Atoplevel-common-errors"><span class="number">4</span>Common errors</a>
+</li><li><a href="toplevel.html#s%3Acustom-toplevel"><span class="number">5</span>Building custom toplevel systems: <span class="c004">ocamlmktop</span></a>
+</li><li><a href="toplevel.html#s%3Aocamlnat"><span class="number">6</span>The native toplevel: <span class="c004">ocamlnat</span> (experimental)</a>
 </li></ul></nav></header>
 <p> <a id="c:camllight"></a>
 </p><p>This chapter describes the toplevel system for OCaml, that permits
@@ -56,12 +56,12 @@ module expressions. The definition can bind value names, type names,
 an exception, a module name, or a module type name. The toplevel
 system performs the bindings, then prints the types and values (if
 any) for the names thus defined.</p><p>A phrase may also consist in a value expression
-(section ‍<a href="expr.html#s%3Avalue-expr">7.7</a>). It is simply evaluated
+(section&nbsp;<a href="expr.html#s%3Avalue-expr">7.7</a>). It is simply evaluated
 without performing any bindings, and its value is
 printed.</p><p>Finally, a phrase can also consist in a toplevel directive,
 starting with <span class="c005">#</span> (the sharp sign). These directives control the
 behavior of the toplevel; they are listed below in
-section ‍<a href="#s%3Atoplevel-directives">10.2</a>.</p><blockquote class="quote"><span class="c008">Unix:</span> 
+section&nbsp;<a href="#s%3Atoplevel-directives">10.2</a>.</p><blockquote class="quote"><span class="c008">Unix:</span> 
 The toplevel system is started by the command <span class="c004">ocaml</span>, as follows:
 <pre>        ocaml <span class="c010">options objects</span>                # interactive mode
         ocaml <span class="c010">options objects scriptfile</span>        # script mode
@@ -73,11 +73,11 @@ loaded into the interpreter immediately after <span class="c010">options</span> 
 enters interactive mode: phrases are read on standard input, results
 are printed on standard output, errors on standard error. End-of-file
 on standard input terminates <span class="c004">ocaml</span> (see also the <span class="c004">#quit</span> directive
-in section ‍<a href="#s%3Atoplevel-directives">10.2</a>).</p><p>On start-up (before the first phrase is read), if the file
+in section&nbsp;<a href="#s%3Atoplevel-directives">10.2</a>).</p><p>On start-up (before the first phrase is read), if the file
 <span class="c004">.ocamlinit</span> exists in the current directory,
 its contents are read as a sequence of OCaml phrases
 and executed as per the <span class="c004">#use</span> directive
-described in section ‍<a href="#s%3Atoplevel-directives">10.2</a>.
+described in section&nbsp;<a href="#s%3Atoplevel-directives">10.2</a>.
 The evaluation outcode for each phrase are not displayed.
 If the current directory does not contain an <span class="c004">.ocamlinit</span> file,
 the file <span class="c004">XDG_CONFIG_HOME/ocaml/init.ml</span> is looked up according
@@ -94,7 +94,7 @@ by sending the <span class="c004">INTR</span> signal to the <span class="c004">o
 then immediately returns to the <span class="c004">#</span> prompt.</p><p>If <span class="c010">scriptfile</span> is given on the command-line to <span class="c004">ocaml</span>, the toplevel
 system enters script mode: the contents of the file are read as a
 sequence of OCaml phrases and executed, as per the <span class="c004">#use</span>
-directive (section ‍<a href="#s%3Atoplevel-directives">10.2</a>). The outcome of the
+directive (section&nbsp;<a href="#s%3Atoplevel-directives">10.2</a>). The outcome of the
 evaluation is not printed. On reaching the end of file, the <span class="c004">ocaml</span>
 command exits immediately. No commands are read from standard input.
 <span class="c004">Sys.argv</span> is transformed, ignoring all OCaml parameters, and
@@ -108,7 +108,7 @@ scripts. A better solution is to put the following as the first line
 of the script:
 </p><pre>        #!/usr/local/bin/ocamlrun /usr/local/bin/ocaml
 </pre></blockquote>
-<h2 class="section" id="s:toplevel-options"><a class="section-anchor" href="#s:toplevel-options" aria-hidden="true"></a>10.1 Options</h2>
+<h2 class="section" id="s:toplevel-options"><a class="section-anchor" href="#s:toplevel-options" aria-hidden="true"></a><span class="number">1</span>Options</h2>
 <p>The following command-line options are recognized by the <span class="c004">ocaml</span> command.
 </p><dl class="description"><dt class="dt-description">
 <span class="c007">-absname</span></dt><dd class="dd-description">
@@ -131,7 +131,7 @@ but before the standard library directory. See also option <span class="c004">-n
 standard library directory. For instance, <span class="c004">-I +unix</span> adds the
 subdirectory <span class="c004">unix</span> of the standard library to the search path.</p><p>Directories can also be added to the list once
 the toplevel is running with the <span class="c004">#directory</span> directive
-(section ‍<a href="#s%3Atoplevel-directives">10.2</a>).
+(section&nbsp;<a href="#s%3Atoplevel-directives">10.2</a>).
 </p></dd><dt class="dt-description"><span class="c014"><span class="c004">-init</span> <span class="c010">file</span></span></dt><dd class="dd-description">
 Load the given file instead of the default initialization file.
 The default file is <span class="c004">.ocamlinit</span> in the current directory if it
@@ -160,7 +160,7 @@ directories searched for source and compiled files.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">-ppx</span> <span class="c010">command</span></span></dt><dd class="dd-description">
 After parsing, pipe the abstract syntax tree through the preprocessor
 <span class="c010">command</span>. The module <span class="c004">Ast_mapper</span>, described in
-chapter ‍<a href="parsing.html#c%3Aparsinglib">24</a>:
+chapter&nbsp;<a href="parsing.html#c%3Aparsinglib">24</a>:
 <a href="../api/compilerlibref/Ast_mapper.html"> <span class="c004">Ast_mapper</span> </a>
 ,
 implements the external interface of a preprocessor.</dd><dt class="dt-description"><span class="c007">-principal</span></dt><dd class="dd-description">
@@ -374,7 +374,7 @@ and look up its capabilities in the terminal database.</dd><dt class="dt-descrip
 <span class="c004">.ocamlinit</span> lookup procedure (see above).
 </dd></dl>
 </blockquote>
-<h2 class="section" id="s:toplevel-directives"><a class="section-anchor" href="#s:toplevel-directives" aria-hidden="true">﻿</a>10.2 Toplevel directives</h2>
+<h2 class="section" id="s:toplevel-directives"><a class="section-anchor" href="#s:toplevel-directives" aria-hidden="true">﻿</a><span class="number">2</span>Toplevel directives</h2>
 <p>The following directives control the toplevel behavior, load files in
 memory, and trace program execution.</p><p><span class="c014">Note:</span> all directives start with a <span class="c004">#</span> (sharp) symbol. This <span class="c004">#</span>
 must be typed before the directive, and must not be confused with the
@@ -480,11 +480,11 @@ unsoundness of the type system.</dd><dt class="dt-description"><span class="c014
 Treat as errors the warnings enabled by the argument and as normal
 warnings the warnings disabled by the argument.</dd><dt class="dt-description"><span class="c014"><span class="c004">#warnings "</span><span class="c010">warning-list</span><span class="c004">";;</span></span></dt><dd class="dd-description">
 Enable or disable warnings according to the argument.</dd></dl></dd></dl>
-<h2 class="section" id="s:toplevel-modules"><a class="section-anchor" href="#s:toplevel-modules" aria-hidden="true">﻿</a>10.3 The toplevel and the module system</h2>
+<h2 class="section" id="s:toplevel-modules"><a class="section-anchor" href="#s:toplevel-modules" aria-hidden="true">﻿</a><span class="number">3</span>The toplevel and the module system</h2>
 <p>Toplevel phrases can refer to identifiers defined in compilation units
 with the same mechanisms as for separately compiled units: either by
 using qualified names (<span class="c004">Modulename.localname</span>), or by using
-the <span class="c004">open</span> construct and unqualified names (see section ‍<a href="names.html#s%3Anames">7.3</a>).</p><p>However, before referencing another compilation unit, an
+the <span class="c004">open</span> construct and unqualified names (see section&nbsp;<a href="names.html#s%3Anames">7.3</a>).</p><p>However, before referencing another compilation unit, an
 implementation of that unit must be present in memory.
 At start-up, the toplevel system contains implementations for all the
 modules in the the standard library. Implementations for user modules
@@ -496,7 +496,7 @@ implementation of <span class="c010">Mod</span>, and does not cause any error if
 implementation of <span class="c010">Mod</span> has been loaded. The error
 “reference to undefined global <span class="c010">Mod</span>” will occur only when
 executing a value or module definition that refers to <span class="c010">Mod</span>.</p>
-<h2 class="section" id="s:toplevel-common-errors"><a class="section-anchor" href="#s:toplevel-common-errors" aria-hidden="true">﻿</a>10.4 Common errors</h2>
+<h2 class="section" id="s:toplevel-common-errors"><a class="section-anchor" href="#s:toplevel-common-errors" aria-hidden="true">﻿</a><span class="number">4</span>Common errors</h2>
 <p>This section describes and explains the most frequently encountered
 error messages.</p><dl class="description"><dt class="dt-description"><span class="c014">Cannot find file <span class="c010">filename</span></span></dt><dd class="dd-description">
 The named file could not be found in the current directory, nor in the
@@ -509,10 +509,10 @@ does not exist yet. Fix: compile <span class="c010">mod</span><span class="c004"
 because you haven’t specified the directories to look into. Fix: use
 the <span class="c004">#directory</span> directive to add the correct directories to the
 search path.</p></dd><dt class="dt-description"><span class="c014">This expression has type </span><span class="c010">t</span><sub>1</sub><span class="c014">, but is used with type </span><span class="c010">t</span><sub>2</sub></dt><dd class="dd-description">
-See section ‍<a href="comp.html#s%3Acomp-errors">9.4</a>.</dd><dt class="dt-description"><span class="c014">Reference to undefined global <span class="c010">mod</span></span></dt><dd class="dd-description">
+See section&nbsp;<a href="comp.html#s%3Acomp-errors">9.4</a>.</dd><dt class="dt-description"><span class="c014">Reference to undefined global <span class="c010">mod</span></span></dt><dd class="dd-description">
 You have neglected to load in memory an implementation for a module
-with <span class="c004">#load</span>. See section ‍<a href="#s%3Atoplevel-modules">10.3</a> above.</dd></dl>
-<h2 class="section" id="s:custom-toplevel"><a class="section-anchor" href="#s:custom-toplevel" aria-hidden="true">﻿</a>10.5 Building custom toplevel systems: <span class="c004">ocamlmktop</span></h2>
+with <span class="c004">#load</span>. See section&nbsp;<a href="#s%3Atoplevel-modules">10.3</a> above.</dd></dl>
+<h2 class="section" id="s:custom-toplevel"><a class="section-anchor" href="#s:custom-toplevel" aria-hidden="true">﻿</a><span class="number">5</span>Building custom toplevel systems: <span class="c004">ocamlmktop</span></h2>
 <p>The <span class="c004">ocamlmktop</span> command builds OCaml toplevels that
 contain user code preloaded at start-up.</p><p>The <span class="c004">ocamlmktop</span> command takes as argument a set of <span class="c004">.cmo</span> and <span class="c004">.cma</span>
 files, and links them with the object files that implement the OCaml toplevel.
@@ -532,21 +532,21 @@ if you had typed:
 not opened, though; you still have to do
 </p><pre>        open Foo;;
 </pre><p>yourself, if this is what you wish.</p>
-<h3 class="subsection" id="ss:ocamlmktop-options"><a class="section-anchor" href="#ss:ocamlmktop-options" aria-hidden="true">﻿</a>10.5.1 Options</h3>
+<h3 class="subsection" id="ss:ocamlmktop-options"><a class="section-anchor" href="#ss:ocamlmktop-options" aria-hidden="true">﻿</a><span class="number">5.1</span>Options</h3>
 <p>The following command-line options are recognized by <span class="c004">ocamlmktop</span>.</p><dl class="description"><dt class="dt-description"><span class="c014"><span class="c004">-cclib</span> <span class="c010">libname</span></span></dt><dd class="dd-description">
 Pass the <span class="c004">-l</span><span class="c010">libname</span> option to the C linker when linking in
 “custom runtime” mode. See the corresponding option for
-<span class="c004">ocamlc</span>, in chapter ‍<a href="comp.html#c%3Acamlc">9</a>.</dd><dt class="dt-description"><span class="c014"><span class="c004">-ccopt</span> <span class="c010">option</span></span></dt><dd class="dd-description">
+<span class="c004">ocamlc</span>, in chapter&nbsp;<a href="comp.html#c%3Acamlc">9</a>.</dd><dt class="dt-description"><span class="c014"><span class="c004">-ccopt</span> <span class="c010">option</span></span></dt><dd class="dd-description">
 Pass the given option to the C compiler and linker, when linking in
 “custom runtime” mode. See the corresponding option for
-<span class="c004">ocamlc</span>, in chapter ‍<a href="comp.html#c%3Acamlc">9</a>.</dd><dt class="dt-description"><span class="c007">-custom</span></dt><dd class="dd-description">
+<span class="c004">ocamlc</span>, in chapter&nbsp;<a href="comp.html#c%3Acamlc">9</a>.</dd><dt class="dt-description"><span class="c007">-custom</span></dt><dd class="dd-description">
 Link in “custom runtime” mode. See the corresponding option for
-<span class="c004">ocamlc</span>, in chapter ‍<a href="comp.html#c%3Acamlc">9</a>.</dd><dt class="dt-description"><span class="c014"><span class="c004">-I</span> <span class="c010">directory</span></span></dt><dd class="dd-description">
+<span class="c004">ocamlc</span>, in chapter&nbsp;<a href="comp.html#c%3Acamlc">9</a>.</dd><dt class="dt-description"><span class="c014"><span class="c004">-I</span> <span class="c010">directory</span></span></dt><dd class="dd-description">
 Add the given directory to the list of directories searched for
 compiled object code files (<span class="c004">.cmo</span> and <span class="c004">.cma</span>).</dd><dt class="dt-description"><span class="c014"><span class="c004">-o</span> <span class="c010">exec-file</span></span></dt><dd class="dd-description">
 Specify the name of the toplevel file produced by the linker.
 The default is <span class="c004">a.out</span>.</dd></dl>
-<h2 class="section" id="s:ocamlnat"><a class="section-anchor" href="#s:ocamlnat" aria-hidden="true">﻿</a>10.6 The native toplevel: <span class="c004">ocamlnat</span> (experimental)</h2>
+<h2 class="section" id="s:ocamlnat"><a class="section-anchor" href="#s:ocamlnat" aria-hidden="true">﻿</a><span class="number">6</span>The native toplevel: <span class="c004">ocamlnat</span> (experimental)</h2>
 <p><span class="c014">This section describes a tool that is not yet officially supported but may be found useful.</span></p><p>OCaml code executing in the traditional toplevel system uses the bytecode
 interpreter. When increased performance is required, or for testing
 programs that will only execute correctly when compiled to native code,
@@ -562,7 +562,7 @@ installation directory) may be invoked directly rather than using
 
 </p>
 <hr>
-<div class="bottom-navigation"><a class="previous" href="comp.html">« Chapter ‍9 Batch compilation (ocamlc)</a><a class="next" href="runtime.html">Chapter ‍11 The runtime system (ocamlrun) »</a></div>
+<div class="bottom-navigation"><a class="previous" href="comp.html">« Batch compilation (ocamlc)</a><a class="next" href="runtime.html">The runtime system (ocamlrun) »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/typedecl.html
+++ b/site/releases/4.12/htmlman/typedecl.html
@@ -5,38 +5,38 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:tydef"><a class="section-anchor" href="#s:tydef" aria-hidden="true"></a>7.8 Type and exception definitions</h2>
+<h2 class="section" id="s:tydef"><a class="section-anchor" href="#s:tydef" aria-hidden="true"></a><span class="number">8</span>Type and exception definitions</h2>
 <ul>
-<li><a href="typedecl.html#ss%3Atypedefs">7.8.1 Type definitions</a>
-</li><li><a href="typedecl.html#ss%3Aexndef">7.8.2 Exception definitions</a>
+<li><a href="typedecl.html#ss%3Atypedefs"><span class="number">8.1</span>Type definitions</a>
+</li><li><a href="typedecl.html#ss%3Aexndef"><span class="number">8.2</span>Exception definitions</a>
 </li></ul>
 
-<h3 class="subsection" id="ss:typedefs"><a class="section-anchor" href="#ss:typedefs" aria-hidden="true">﻿</a>7.8.1 Type definitions</h3>
+<h3 class="subsection" id="ss:typedefs"><a class="section-anchor" href="#ss:typedefs" aria-hidden="true">﻿</a><span class="number">8.1</span>Type definitions</h3>
 <p>Type definitions bind type constructors to data types: either
 variant types, record types, type abbreviations, or abstract data
 types. They also bind the value constructors and record fields
@@ -199,17 +199,17 @@ a record value is created or modified. Extracted values may have their
 types instantiated.</p><p>The two components of a type definition, the optional equation and the
 optional representation, can be combined independently, giving
 rise to four typical situations:</p><dl class="description"><dt class="dt-description">
-<span class="c014">Abstract type: no equation, no representation.</span></dt><dd class="dd-description">  ‍<br>
+<span class="c014">Abstract type: no equation, no representation.</span></dt><dd class="dd-description"> &nbsp;<br>
 When appearing in a module signature, this definition specifies
 nothing on the type constructor, besides its number of parameters:
 its representation is hidden and it is assumed incompatible with any
-other type.</dd><dt class="dt-description"><span class="c014">Type abbreviation: an equation, no representation.</span></dt><dd class="dd-description">  ‍<br>
+other type.</dd><dt class="dt-description"><span class="c014">Type abbreviation: an equation, no representation.</span></dt><dd class="dd-description"> &nbsp;<br>
 This defines the type constructor as an abbreviation for the type
-expression on the right of the <span class="c005">=</span> sign.</dd><dt class="dt-description"><span class="c014">New variant type or record type: no equation, a representation.</span></dt><dd class="dd-description">  ‍<br>
+expression on the right of the <span class="c005">=</span> sign.</dd><dt class="dt-description"><span class="c014">New variant type or record type: no equation, a representation.</span></dt><dd class="dd-description"> &nbsp;<br>
 This generates a new type constructor and defines associated
 constructors or fields, through which values of that type can be
 directly built or inspected.</dd><dt class="dt-description"><span class="c014">Re-exported variant type or record type: an equation,
-a representation.</span></dt><dd class="dd-description">  ‍<br>
+a representation.</span></dt><dd class="dd-description"> &nbsp;<br>
 In this case, the type constructor is defined as an abbreviation for
 the type expression given in the equation, but in addition the
 constructors or fields given in the representation remain attached to
@@ -256,7 +256,7 @@ type parameters. Any actual type argument corresponding to the type
 parameter <a class="syntax" href="lex.html#ident"><span class="c011">ident</span></a> has to be an instance of <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a> (more precisely,
 <a class="syntax" href="lex.html#ident"><span class="c011">ident</span></a> and <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a> are unified). Type variables of <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a> can
 appear in the type equation and the type declaration.</p>
-<h3 class="subsection" id="ss:exndef"><a class="section-anchor" href="#ss:exndef" aria-hidden="true">﻿</a>7.8.2 Exception definitions</h3>
+<h3 class="subsection" id="ss:exndef"><a class="section-anchor" href="#ss:exndef" aria-hidden="true">﻿</a><span class="number">8.2</span>Exception definitions</h3>
 <p>
 <a id="hevea_manual.kwd100"></a></p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" id="exception-definition"><span class="c011">exception-definition</span></a></td><td class="c016">::=</td><td class="c018">
@@ -274,7 +274,7 @@ gives an alternate name to an existing exception.
 
 </p>
 
-<div class="bottom-navigation"><a class="previous" href="expr.html">« 7.7 Expressions</a><a class="next" href="classes.html">7.9 Classes »</a></div>
+<div class="bottom-navigation"><a class="previous" href="expr.html">« Expressions</a><a class="next" href="classes.html">Classes »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/types.html
+++ b/site/releases/4.12/htmlman/types.html
@@ -5,32 +5,32 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:typexpr"><a class="section-anchor" href="#s:typexpr" aria-hidden="true"></a>7.4 Type expressions</h2>
+<h2 class="section" id="s:typexpr"><a class="section-anchor" href="#s:typexpr" aria-hidden="true"></a><span class="number">4</span>Type expressions</h2>
 <p>
 <a id="hevea_manual.kwd7"></a></p><div class="syntax"><table class="display dcenter"><tbody><tr class="c020"><td class="dcell"><table class="c001 cellpading0"><tbody><tr><td class="c019">
 <a class="syntax" id="typexpr"><span class="c011">typexpr</span></a></td><td class="c016">::=</td><td class="c018">
@@ -108,7 +108,7 @@ variables is restricted to the type expression where they appear:
 1) for universal (explicitly polymorphic) type variables;
 2) for type variables that only appear in public method specifications
 (as those variables will be made universal, as described in
-section ‍<a href="classes.html#sss%3Aclty-meth">7.9.1</a>);
+section&nbsp;<a href="classes.html#sss%3Aclty-meth">7.9.1</a>);
 3) for variables used as aliases, when the type they are aliased to
 would be invalid in the scope of the enclosing definition (<span class="c010">i.e.</span>
 when it contains free universal type variables, or locally
@@ -233,11 +233,11 @@ and <span class="c003"><span class="c004">#</span><span class="c011">t</span><sp
 <p>There are no type expressions describing (defined) variant types nor
 record types, since those are always named, i.e. defined before use
 and referred to by name. Type definitions are described in
-section ‍<a href="typedecl.html#ss%3Atypedefs">7.8.1</a>.
+section&nbsp;<a href="typedecl.html#ss%3Atypedefs">7.8.1</a>.
 
 </p>
 
-<div class="bottom-navigation"><a class="previous" href="names.html">« 7.3 Names</a><a class="next" href="const.html">7.5 Constants »</a></div>
+<div class="bottom-navigation"><a class="previous" href="names.html">« Names</a><a class="next" href="const.html">Constants »</a></div>
 
 
 

--- a/site/releases/4.12/htmlman/values.html
+++ b/site/releases/4.12/htmlman/values.html
@@ -5,45 +5,45 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Chapter ‍7 The OCaml language</title>
+<title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>Part ‍II The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">Chapter ‍7 The OCaml language</a></li><li><a href="extn.html">Chapter ‍8 Language extensions</a></li></ul>
+<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
 
 
 
 
-<h1 class="chapter" id="sec73">Chapter ‍7 The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Chapter ‍7 The OCaml language</a></li>
-<li><a href="lex.html#start-section">7.1 Lexical conventions</a>
-</li><li><a href="values.html#start-section">7.2 Values</a>
-</li><li><a href="names.html#start-section">7.3 Names</a>
-</li><li><a href="types.html#start-section">7.4 Type expressions</a>
-</li><li><a href="const.html#start-section">7.5 Constants</a>
-</li><li><a href="patterns.html#start-section">7.6 Patterns</a>
-</li><li><a href="expr.html#start-section">7.7 Expressions</a>
-</li><li><a href="typedecl.html#start-section">7.8 Type and exception definitions</a>
-</li><li><a href="classes.html#start-section">7.9 Classes</a>
-</li><li><a href="modtypes.html#start-section">7.10 Module types (module specifications)</a>
-</li><li><a href="modules.html#start-section">7.11 Module expressions (module implementations)</a>
-</li><li><a href="compunit.html#start-section">7.12 Compilation units</a>
+<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
+</li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
+</li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
+</li><li><a href="types.html#start-section"><span class="number">4</span>Type expressions</a>
+</li><li><a href="const.html#start-section"><span class="number">5</span>Constants</a>
+</li><li><a href="patterns.html#start-section"><span class="number">6</span>Patterns</a>
+</li><li><a href="expr.html#start-section"><span class="number">7</span>Expressions</a>
+</li><li><a href="typedecl.html#start-section"><span class="number">8</span>Type and exception definitions</a>
+</li><li><a href="classes.html#start-section"><span class="number">9</span>Classes</a>
+</li><li><a href="modtypes.html#start-section"><span class="number">10</span>Module types (module specifications)</a>
+</li><li><a href="modules.html#start-section"><span class="number">11</span>Module expressions (module implementations)</a>
+</li><li><a href="compunit.html#start-section"><span class="number">12</span>Compilation units</a>
 </li></ul></nav></header><a id="start-section"></a><section id="section">
 
 
 
 
-<h2 class="section" id="s:values"><a class="section-anchor" href="#s:values" aria-hidden="true"></a>7.2 Values</h2>
+<h2 class="section" id="s:values"><a class="section-anchor" href="#s:values" aria-hidden="true"></a><span class="number">2</span>Values</h2>
 <ul>
-<li><a href="values.html#ss%3Avalues%3Abase">7.2.1 Base values</a>
-</li><li><a href="values.html#ss%3Avalues%3Atuple">7.2.2 Tuples</a>
-</li><li><a href="values.html#ss%3Avalues%3Arecords">7.2.3 Records</a>
-</li><li><a href="values.html#ss%3Avalues%3Aarray">7.2.4 Arrays</a>
-</li><li><a href="values.html#ss%3Avalues%3Avariant">7.2.5 Variant values</a>
-</li><li><a href="values.html#ss%3Avalues%3Apolyvars">7.2.6 Polymorphic variants</a>
-</li><li><a href="values.html#ss%3Avalues%3Afun">7.2.7 Functions</a>
-</li><li><a href="values.html#ss%3Avalues%3Aobj">7.2.8 Objects</a>
+<li><a href="values.html#ss%3Avalues%3Abase"><span class="number">2.1</span>Base values</a>
+</li><li><a href="values.html#ss%3Avalues%3Atuple"><span class="number">2.2</span>Tuples</a>
+</li><li><a href="values.html#ss%3Avalues%3Arecords"><span class="number">2.3</span>Records</a>
+</li><li><a href="values.html#ss%3Avalues%3Aarray"><span class="number">2.4</span>Arrays</a>
+</li><li><a href="values.html#ss%3Avalues%3Avariant"><span class="number">2.5</span>Variant values</a>
+</li><li><a href="values.html#ss%3Avalues%3Apolyvars"><span class="number">2.6</span>Polymorphic variants</a>
+</li><li><a href="values.html#ss%3Avalues%3Afun"><span class="number">2.7</span>Functions</a>
+</li><li><a href="values.html#ss%3Avalues%3Aobj"><span class="number">2.8</span>Objects</a>
 </li></ul>
 <p>This section describes the kinds of values that are manipulated by
 OCaml programs.</p>
-<h3 class="subsection" id="ss:values:base"><a class="section-anchor" href="#ss:values:base" aria-hidden="true">﻿</a>7.2.1 Base values</h3>
+<h3 class="subsection" id="ss:values:base"><a class="section-anchor" href="#ss:values:base" aria-hidden="true">﻿</a><span class="number">2.1</span>Base values</h3>
 <h4 class="subsubsection" id="sss:values:integer"><a class="section-anchor" href="#sss:values:integer" aria-hidden="true">﻿</a>Integer numbers</h4>
 <p>Integer values are integer numbers from −2<sup>30</sup> to 2<sup>30</sup>−1, that
 is −1073741824 to 1073741823. The implementation may support a
@@ -61,23 +61,23 @@ between 128 and 255 following the ISO 8859-1 standard.</p><h4 class="subsubsecti
 implementation supports strings containing up to 2<sup>24</sup> − 5
 characters (16777211 characters); on 64-bit platforms, the limit is
 2<sup>57</sup> − 9.</p>
-<h3 class="subsection" id="ss:values:tuple"><a class="section-anchor" href="#ss:values:tuple" aria-hidden="true">﻿</a>7.2.2 Tuples</h3>
+<h3 class="subsection" id="ss:values:tuple"><a class="section-anchor" href="#ss:values:tuple" aria-hidden="true">﻿</a><span class="number">2.2</span>Tuples</h3>
 <p>Tuples of values are written <span class="c005">(</span><span class="c011">v</span><sub>1</sub><span class="c005">,</span> …<span class="c005">,</span> <span class="c011">v</span><sub><span class="c010">n</span></sub><span class="c005">)</span>, standing for the
 <span class="c010">n</span>-tuple of values <span class="c011">v</span><sub>1</sub> to <span class="c011">v</span><sub><span class="c010">n</span></sub>. The current implementation
 supports tuple of up to 2<sup>22</sup> − 1 elements (4194303 elements).</p>
-<h3 class="subsection" id="ss:values:records"><a class="section-anchor" href="#ss:values:records" aria-hidden="true">﻿</a>7.2.3 Records</h3>
+<h3 class="subsection" id="ss:values:records"><a class="section-anchor" href="#ss:values:records" aria-hidden="true">﻿</a><span class="number">2.3</span>Records</h3>
 <p>Record values are labeled tuples of values. The record value written
 <span class="c005">{</span> <a class="syntax" href="names.html#field"><span class="c011">field</span></a><sub>1</sub> <span class="c005">=</span> <span class="c011">v</span><sub>1</sub><span class="c005">;</span> …<span class="c005">;</span>  <a class="syntax" href="names.html#field"><span class="c011">field</span></a><sub><span class="c010">n</span></sub> <span class="c005">=</span> <span class="c011">v</span><sub><span class="c010">n</span></sub> <span class="c005">}</span> associates the value
 <span class="c011">v</span><sub><span class="c010">i</span></sub> to the record field <a class="syntax" href="names.html#field"><span class="c011">field</span></a><sub><span class="c010">i</span></sub>, for <span class="c010">i</span> = 1 … <span class="c010">n</span>. The current
 implementation supports records with up to 2<sup>22</sup> − 1 fields
 (4194303 fields).</p>
-<h3 class="subsection" id="ss:values:array"><a class="section-anchor" href="#ss:values:array" aria-hidden="true">﻿</a>7.2.4 Arrays</h3>
+<h3 class="subsection" id="ss:values:array"><a class="section-anchor" href="#ss:values:array" aria-hidden="true">﻿</a><span class="number">2.4</span>Arrays</h3>
 <p>Arrays are finite, variable-sized sequences of values of the same
 type. The current implementation supports arrays containing up to
 2<sup>22</sup> − 1 elements (4194303 elements) unless the elements are
 floating-point numbers (2097151 elements in this case); on 64-bit
 platforms, the limit is 2<sup>54</sup> − 1 for all arrays.</p>
-<h3 class="subsection" id="ss:values:variant"><a class="section-anchor" href="#ss:values:variant" aria-hidden="true">﻿</a>7.2.5 Variant values</h3>
+<h3 class="subsection" id="ss:values:variant"><a class="section-anchor" href="#ss:values:variant" aria-hidden="true">﻿</a><span class="number">2.5</span>Variant values</h3>
 <p>Variant values are either a constant constructor, or a non-constant
 constructor applied to a number of values. The former case is written
 <a class="syntax" href="names.html#constr"><span class="c011">constr</span></a>; the latter case is written <a class="syntax" href="names.html#constr"><span class="c011">constr</span></a> <span class="c005">(</span><span class="c011">v</span><sub>1</sub><span class="c005">,</span> ... <span class="c005">,</span> <span class="c011">v</span><sub><span class="c010">n</span></sub>
@@ -94,14 +94,14 @@ constructors:
 <tr><td class="c017"><span class="c004">[]</span></td><td class="c017">the empty list </td></tr>
 </tbody></table></div></div><p>The current implementation limits each variant type to have at most
 246 non-constant constructors and 2<sup>30</sup>−1 constant constructors.</p>
-<h3 class="subsection" id="ss:values:polyvars"><a class="section-anchor" href="#ss:values:polyvars" aria-hidden="true">﻿</a>7.2.6 Polymorphic variants</h3>
+<h3 class="subsection" id="ss:values:polyvars"><a class="section-anchor" href="#ss:values:polyvars" aria-hidden="true">﻿</a><span class="number">2.6</span>Polymorphic variants</h3>
 <p>Polymorphic variants are an alternate form of variant values, not
 belonging explicitly to a predefined variant type, and following
 specific typing rules. They can be either constant, written
 <span class="c005">`</span><a class="syntax" href="names.html#tag-name"><span class="c011">tag-name</span></a>, or non-constant, written <span class="c005">`</span><a class="syntax" href="names.html#tag-name"><span class="c011">tag-name</span></a><span class="c003"><span class="c004">(</span><span class="c011">v</span><span class="c004">)</span></span>.</p>
-<h3 class="subsection" id="ss:values:fun"><a class="section-anchor" href="#ss:values:fun" aria-hidden="true">﻿</a>7.2.7 Functions</h3>
+<h3 class="subsection" id="ss:values:fun"><a class="section-anchor" href="#ss:values:fun" aria-hidden="true">﻿</a><span class="number">2.7</span>Functions</h3>
 <p>Functional values are mappings from values to values.</p>
-<h3 class="subsection" id="ss:values:obj"><a class="section-anchor" href="#ss:values:obj" aria-hidden="true">﻿</a>7.2.8 Objects</h3>
+<h3 class="subsection" id="ss:values:obj"><a class="section-anchor" href="#ss:values:obj" aria-hidden="true">﻿</a><span class="number">2.8</span>Objects</h3>
 <p>Objects are composed of a hidden internal state which is a
 record of instance variables, and a set of methods for accessing and
 modifying these variables. The structure of an object is described by
@@ -109,7 +109,7 @@ the toplevel class that created it.
 
 </p>
 
-<div class="bottom-navigation"><a class="previous" href="lex.html">« 7.1 Lexical conventions</a><a class="next" href="names.html">7.3 Names »</a></div>
+<div class="bottom-navigation"><a class="previous" href="lex.html">« Lexical conventions</a><a class="next" href="names.html">Names »</a></div>
 
 
 

--- a/site/releases/4.12/manual
+++ b/site/releases/4.12/manual
@@ -1,0 +1,1 @@
+./htmlman


### PR DESCRIPTION
This PR fixes few issues that appeared during the switch to the post-processed manual:

 * remove redundant chapter numbers (https://github.com/ocaml/ocaml/issues/10254 and https://github.com/ocaml/ocaml/pull/10282)
 * replace ▷ bullets with either ○ or ◇(ocaml/ocaml.org#1279 and https://github.com/ocaml/ocaml/pull/10300)
 * remove duplicated # in code examples (https://github.com/ocaml/ocaml/pull/10282)
 * use ⋈ for debugger events (https://github.com/ocaml/ocaml/pull/10288)
 
I have also added a symlink between releases/4.12/manual and releases/4.12/htmlman to resolve https://github.com/ocaml/ocaml.org/issues/1257 while keeping the old location for the versioned manuals.
 
cc @sanette 



