### PR TITLE
Improved the ocaml.org/learn/portability.html page

### DIFF
--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -1728,19 +1728,37 @@ table {
   background-color: transparent;
   border-collapse: collapse;
   border-spacing: 0;
+  /* Added these */
+  border: 1px solid #ddd;
 }
 .table {
   width: 100%;
   margin-bottom: 24px;
   font-family: Lato, sans-serif;
 }
-.table th,
+/* .table th,
 .table td {
   padding: 8px;
   line-height: 24px;
   text-align: center;
   vertical-align: center;
+} */
+
+/* Added these */
+th, td {
+  text-align: left;
+  padding: 8px;
 }
+/* Added these too */
+tr:nth-child(even){
+  background-color: #f2f2f2
+}
+
+/* Also added these */
+th{
+  background-color: #f2f2f2
+}
+
 .table td {
   border-top: 1px transparent solid;
   border-bottom: 1px transparent solid;

--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -1728,7 +1728,6 @@ table {
   background-color: transparent;
   border-collapse: collapse;
   border-spacing: 0;
-  /* Added these */
   border: 1px solid #ddd;
 }
 .table {
@@ -1736,25 +1735,16 @@ table {
   margin-bottom: 24px;
   font-family: Lato, sans-serif;
 }
-/* .table th,
-.table td {
-  padding: 8px;
-  line-height: 24px;
-  text-align: center;
-  vertical-align: center;
-} */
-
-/* Added these */
 th, td {
   text-align: left;
   padding: 8px;
 }
-/* Added these too */
+
 tr:nth-child(even){
   background-color: #f2f2f2
 }
 
-/* Also added these */
+
 th{
   background-color: #f2f2f2
 }

--- a/site/learn/portability.md
+++ b/site/learn/portability.md
@@ -24,6 +24,7 @@ processor/operating system combinations:
 <tbody>
 <tr class="odd">
 <td align="left">Tier 1 platforms<br /> (actively used and maintained by the core Caml team):</td>
+<td></td>
 </tr>
 <tr class="even">
 <td align="left">AMD64 (Intel and AMD x86 processors in 64-bit mode)</td>
@@ -43,6 +44,7 @@ processor/operating system combinations:
 </tr>
 <tr class="even">
 <td align="left">Tier 2 platforms<br /> (maintained but less actively, with help from users):</td>
+<td></td>
 </tr>
 <tr class="odd">
 <td align="left">AMD64</td>
@@ -87,6 +89,7 @@ Each of these ports exists for either Win32 or Win64 platforms.
 
 Here is a summary of the main differences between these ports:
 
+<div style="overflow-x:auto;">
 <table width="100%">
 <thead>
 <tr class="header">
@@ -135,6 +138,7 @@ Here is a summary of the main differences between these ports:
 </tr>
 </tbody>
 </table>
+</div>
 <br/>
 
 Note (*): Cygwin-generated `.exe` files refer to a DLL that is distributed


### PR DESCRIPTION
Improved the ocaml.org/learn/portability.html page

# Issue Description
The tables on the learn/portability page has a couple of tables which are quite difficult to read and comprehend and also not responsive on mobile devices.

Fixes #1336

## Changes Made

I made changes in the table, th, tr and td tags respectively in the bootstrap.css file
I made changes in the portability.md file by adding a div tag as a parent container to the second table on the learn/portability page  and inserted the second table in the div tag giving it a style of "overflow-x : auto" to make the table responsive on mobile devices. 

Before:

![113113312-d4ab6100-9212-11eb-9553-f4ce92ec3254](https://user-images.githubusercontent.com/57226464/113944781-0321d100-97fd-11eb-81d0-9c7744494b5a.png)

![113113362-e7259a80-9212-11eb-8356-57b594b87ba9](https://user-images.githubusercontent.com/57226464/113944805-0c12a280-97fd-11eb-837b-3a7dd5d6c0a2.png)

After:
![Screenshot from 2021-04-08 00-00-07](https://user-images.githubusercontent.com/57226464/113945089-87745400-97fd-11eb-99f5-5b95c57bbbda.png)

![Screenshot from 2021-04-08 00-01-28](https://user-images.githubusercontent.com/57226464/113945117-9824ca00-97fd-11eb-9c2a-72bf1aa88a62.png)

and on mobile view:

![mobileview](https://user-images.githubusercontent.com/57226464/113945154-a7a41300-97fd-11eb-98a4-f88d322ff44d.png)



* **Please check if the PR fulfills these requirements**

- [ ] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
