### PR TITLE
Fixed alignment of links in community and images of hosting providers in Contributors

### DIFF
--- a/site/contributors.md
+++ b/site/contributors.md
@@ -16,21 +16,21 @@ Hosting
   </div>
   <div style="padding: 24px 0px" class="row">
     <div class="span6">
-      <p style="text-align: center;"><img width="150" src="/img/aws_300x180.png" alt="Amazon Web Services"></p>
+      <p style="text-align: center;"><img width="200" height="300" src="/img/aws_300x180.png" alt="Amazon Web Services"></p>
       <h2 class="lead"style="text-align: center;">AWS: arm64 VM hosting</h2>
     </div>
     <div class="span6">
-      <p style="text-align: center;"><img width="300" height="100" src="/img/uni-of-cam-computer-lab_488x169.png" alt="University of Cambridge Computer Laboratory"></p>
+      <p style="text-align: center;"><img width="350" src="/img/uni-of-cam-computer-lab_488x169.png" alt="University of Cambridge Computer Laboratory"></p>
       <h2 class="lead"style="text-align: center;">University of Cambridge: machine hosting</h2>
     </div>
   </div>
   <div style="padding: 24px 0px" class="row">
     <div class="span6">
-      <p style="text-align: center;"><img width="275" src="/img/ibm_390x186.jpg" alt="IBM"></p>
+      <p style="text-align: center;"><img width="250" src="/img/ibm_390x186.jpg" alt="IBM"></p>
       <h2 class="lead"style="text-align: center;">IBM: PowerPC (POWER8/9) machines</h2>
     </div>
     <div class="span6">
-      <p style="text-align: center;"><img width="300" height="100" src="/img/rackspace_300x109.jpg" alt="Rackspace"></p>
+      <p style="text-align: center;"><img width="329" src="/img/rackspace_300x109.jpg" alt="Rackspace"></p>
       <h2 class="lead"style="text-align: center;">Provided hosting from 2012 to 2020</h2>
     </div>
   </div>

--- a/site/img/colour-transparent-icon.svg
+++ b/site/img/colour-transparent-icon.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 17.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="165.543px" height="144.277px" viewBox="0 0 165.543 144.277" enable-background="new 0 0 165.543 144.277"
+	 width="100px" height="100px" viewBox="0 0 165.543 144.277" enable-background="new 0 0 165.543 144.277"
 	 xml:space="preserve">
 <g>
 	<path fill="none" d="M82.91,97.9l0.023-0.061C82.899,97.685,82.887,97.65,82.91,97.9z"/>


### PR DESCRIPTION
# Issue Description
Fixes issues #1440 and #1441.

## Changes Made
* The dimensions of color-transparent-icon.svg has been changed to fix #1441.
* The dimensions of the images of IBM, AWS, Rackspace and University of Cambridge in Contributors page has been changed to fix #1440.

# Issue #1440 
## Before:
![image](https://user-images.githubusercontent.com/34683520/113980492-2c297c80-9864-11eb-80d5-78486293d065.png)

## After:
![image](https://user-images.githubusercontent.com/34683520/113979982-95f55680-9863-11eb-86ce-23f1f8d690a6.png)

# Issue #1441 
## Before:
![image](https://user-images.githubusercontent.com/34683520/113980373-043a1900-9864-11eb-9037-d267f4ece70b.png)

##After:
![image](https://user-images.githubusercontent.com/34683520/113980248-e1a80000-9863-11eb-9f69-28cf600eeab6.png)


* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
