### PR TITLE
map overflow fixed on https://ocaml.org/learn/teaching-ocaml.html 

### DIFF
--- a/site/learn/teaching-ocaml.md
+++ b/site/learn/teaching-ocaml.md
@@ -99,7 +99,7 @@ _(Tip: Click on the relevant layer (e.g., US,EU), search for your
 University, click on the marker and click on "Add to map", fill in the
 info fields and you are done!)_
 
-<iframe src="https://www.google.com/maps/d/embed?mid=zk8_K4G_usic.kkzYvEvqV44Q" width="640" height="480"></iframe>
+<iframe src="https://www.google.com/maps/d/embed?mid=zk8_K4G_usic.kkzYvEvqV44Q" width="100%" height="480" top="0" left="0" position="relative"></iframe>
 
 
 # Resources


### PR DESCRIPTION
# There was map overflow on https://ocaml.org/learn/teaching-ocaml.html on smaller screens.

Fixes #1426

## Before
![i-5-new](https://user-images.githubusercontent.com/63343906/113665375-0157f080-96cb-11eb-964b-7e47f506c10f.gif)

## After
![newone](https://user-images.githubusercontent.com/63343906/113666883-978d1600-96cd-11eb-9604-313f5551d384.gif)



* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
