### PR TITLE
Updated dimension of colour-transparent-icon.svg to realign links in community

### DIFF
--- a/site/img/OCaml_Sticker.svg
+++ b/site/img/OCaml_Sticker.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 20.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100px" height="100px" viewBox="0 0 150 150" style="enable-background:new 0 0 141.7 141.7;" xml:space="preserve">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+     width="100px" height="100px" viewBox="0 0 150 150" style="enable-background:new 0 0 141.7 141.7;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
 	.st1{fill:#494545;}

--- a/site/img/OCaml_Sticker.svg
+++ b/site/img/OCaml_Sticker.svg
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 20.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 141.7 141.7" style="enable-background:new 0 0 141.7 141.7;" xml:space="preserve">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100px" height="100px" viewBox="0 0 150 150" style="enable-background:new 0 0 141.7 141.7;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
 	.st1{fill:#494545;}

--- a/site/img/colour-transparent-icon.svg
+++ b/site/img/colour-transparent-icon.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 17.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="165.543px" height="144.277px" viewBox="0 0 165.543 144.277" enable-background="new 0 0 165.543 144.277"
+	 width="100px" height="100px" viewBox="0 0 165.543 144.277" enable-background="new 0 0 165.543 144.277"
 	 xml:space="preserve">
 <g>
 	<path fill="none" d="M82.91,97.9l0.023-0.061C82.899,97.685,82.887,97.65,82.91,97.9z"/>

--- a/site/img/colour-transparent-icon.svg
+++ b/site/img/colour-transparent-icon.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 17.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 0 165.543 144.277" enable-background="new 0 0 165.543 144.277"
+	 width="100px" height="100px" viewBox="0 0 175 190" enable-background="new 0 0 165.543 144.277"
 	 xml:space="preserve">
 <g>
 	<path fill="none" d="M82.91,97.9l0.023-0.061C82.899,97.685,82.887,97.65,82.91,97.9z"/>


### PR DESCRIPTION
# Issue Description
To realign the two links to make them in line since it looked quite odd.

Fixes #1441 

## Before:
![image](https://user-images.githubusercontent.com/34683520/113980373-043a1900-9864-11eb-9037-d267f4ece70b.png)

## After:
* Without aligning the top of the images
![image](https://user-images.githubusercontent.com/34683520/113980248-e1a80000-9863-11eb-9f69-28cf600eeab6.png)
* After aligning the top of the images
![image](https://user-images.githubusercontent.com/34683520/114124893-07d8a900-9913-11eb-9910-e78044b31f9d.png)

## Changes Made
The dimensions of color-transparent-icon.svg and OCaml_Sticker.svg has been changed.

## Testing Platform
This has been tested on desktop and mobile devices.

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
