### PR TITLE
Made the function of the version selector on the documentation page more obvious

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -48,23 +48,23 @@
     background-color:lightgray;
 }
 
-#opamdoc-contents .expander {
-  width:1.5em;
-  height:1.5em;
-  border-radius:0.3em;
-  font-weight: bold;
-  font-family:Sans;
-  line-height:16px;
+#opamdoc-contents .expander { 
+  width:1.5em; 
+  height:1.5em; 
+  border-radius:0.3em; 
+  font-weight: bold; 
+  font-family:Sans; 
+  line-height:16px; 
 }
 #opamdoc-contents .expanding_sig { border-spacing: 5px 1px }
 #opamdoc-contents .expanding_sig td { vertical-align: text-top }
-#opamdoc-contents .expanding_include_0 td { vertical-align: text-top }
-#opamdoc-contents .expanding_include_1 td { vertical-align: text-top }
-#opamdoc-contents .expanding_include_2 td { vertical-align: text-top }
-#opamdoc-contents .expanding_include_3 td { vertical-align: text-top }
-#opamdoc-contents .expanding_include_4 td { vertical-align: text-top }
-#opamdoc-contents .expanding_include_5 td { vertical-align: text-top }
-#opamdoc-contents .expanding_include_6 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_0 td { vertical-align: text-top } 
+#opamdoc-contents .expanding_include_1 td { vertical-align: text-top } 
+#opamdoc-contents .expanding_include_2 td { vertical-align: text-top } 
+#opamdoc-contents .expanding_include_3 td { vertical-align: text-top } 
+#opamdoc-contents .expanding_include_4 td { vertical-align: text-top } 
+#opamdoc-contents .expanding_include_5 td { vertical-align: text-top } 
+#opamdoc-contents .expanding_include_6 td { vertical-align: text-top } 
 #opamdoc-contents table.expanding_include_0, table.expanding_include_1, table.expanding_include_2, table.expanding_include_3,
 table.expanding_include_4, table.expanding_include_5, table.expanding_include_6 {
   border-top: thin dashed;
@@ -72,12 +72,12 @@ table.expanding_include_4, table.expanding_include_5, table.expanding_include_6 
   border-collapse: collapse;
 }
 #opamdoc-contents table.expanding_include_0 { background-color: #FFF5F5; }
-#opamdoc-contents table.expanding_include_1 { background-color: #F5F5FF; }
-#opamdoc-contents table.expanding_include_2 { background-color: #F5FFF5; }
-#opamdoc-contents table.expanding_include_3 { background-color: #FFF5FF; }
-#opamdoc-contents table.expanding_include_4 { background-color: #FFFFF5; }
-#opamdoc-contents table.expanding_include_5 { background-color: #F5FFFF; }
-#opamdoc-contents table.expanding_include_6 { background-color: #FFF5EB; }
+#opamdoc-contents table.expanding_include_1 { background-color: #F5F5FF; } 
+#opamdoc-contents table.expanding_include_2 { background-color: #F5FFF5; } 
+#opamdoc-contents table.expanding_include_3 { background-color: #FFF5FF; } 
+#opamdoc-contents table.expanding_include_4 { background-color: #FFFFF5; } 
+#opamdoc-contents table.expanding_include_5 { background-color: #F5FFFF; } 
+#opamdoc-contents table.expanding_include_6 { background-color: #FFF5EB; } 
 #opamdoc-contents td.edge_column { border-right: 3px solid lightgrey }
 
 /* end of section for opam-doc */
@@ -112,7 +112,7 @@ h1 code, h2 code, h3 code, h4 code, h5 code, h5 code { font-size: 80%; }
 .string .governing,
 .ocaml .st {
   color: #a95472;
-  font-weight: normal;
+  font-weight: normal;  
 }
 .warning { color : Red ; font-weight : bold }
 .info { margin-left : 3em; margin-right: 3em }
@@ -281,13 +281,13 @@ html.svg a.edit-this-page:hover {
   justify-content: flex-end;
 }
 
-/*
+/* 
 This styling overrides bootstrap style which removes outline
 when an element is in focus
 */
 a:focus{
   outline: 0.2rem solid #c77a27;
-
+ 
  }
  .navbar .edit-this-page:focus{
    background-color: #6e5437;

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -48,23 +48,23 @@
     background-color:lightgray;
 }
 
-#opamdoc-contents .expander { 
-  width:1.5em; 
-  height:1.5em; 
-  border-radius:0.3em; 
-  font-weight: bold; 
-  font-family:Sans; 
-  line-height:16px; 
+#opamdoc-contents .expander {
+  width:1.5em;
+  height:1.5em;
+  border-radius:0.3em;
+  font-weight: bold;
+  font-family:Sans;
+  line-height:16px;
 }
 #opamdoc-contents .expanding_sig { border-spacing: 5px 1px }
 #opamdoc-contents .expanding_sig td { vertical-align: text-top }
-#opamdoc-contents .expanding_include_0 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_1 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_2 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_3 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_4 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_5 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_6 td { vertical-align: text-top } 
+#opamdoc-contents .expanding_include_0 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_1 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_2 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_3 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_4 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_5 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_6 td { vertical-align: text-top }
 #opamdoc-contents table.expanding_include_0, table.expanding_include_1, table.expanding_include_2, table.expanding_include_3,
 table.expanding_include_4, table.expanding_include_5, table.expanding_include_6 {
   border-top: thin dashed;
@@ -72,12 +72,12 @@ table.expanding_include_4, table.expanding_include_5, table.expanding_include_6 
   border-collapse: collapse;
 }
 #opamdoc-contents table.expanding_include_0 { background-color: #FFF5F5; }
-#opamdoc-contents table.expanding_include_1 { background-color: #F5F5FF; } 
-#opamdoc-contents table.expanding_include_2 { background-color: #F5FFF5; } 
-#opamdoc-contents table.expanding_include_3 { background-color: #FFF5FF; } 
-#opamdoc-contents table.expanding_include_4 { background-color: #FFFFF5; } 
-#opamdoc-contents table.expanding_include_5 { background-color: #F5FFFF; } 
-#opamdoc-contents table.expanding_include_6 { background-color: #FFF5EB; } 
+#opamdoc-contents table.expanding_include_1 { background-color: #F5F5FF; }
+#opamdoc-contents table.expanding_include_2 { background-color: #F5FFF5; }
+#opamdoc-contents table.expanding_include_3 { background-color: #FFF5FF; }
+#opamdoc-contents table.expanding_include_4 { background-color: #FFFFF5; }
+#opamdoc-contents table.expanding_include_5 { background-color: #F5FFFF; }
+#opamdoc-contents table.expanding_include_6 { background-color: #FFF5EB; }
 #opamdoc-contents td.edge_column { border-right: 3px solid lightgrey }
 
 /* end of section for opam-doc */
@@ -112,7 +112,7 @@ h1 code, h2 code, h3 code, h4 code, h5 code, h5 code { font-size: 80%; }
 .string .governing,
 .ocaml .st {
   color: #a95472;
-  font-weight: normal;  
+  font-weight: normal;
 }
 .warning { color : Red ; font-weight : bold }
 .info { margin-left : 3em; margin-right: 3em }
@@ -281,13 +281,13 @@ html.svg a.edit-this-page:hover {
   justify-content: flex-end;
 }
 
-/* 
+/*
 This styling overrides bootstrap style which removes outline
 when an element is in focus
 */
 a:focus{
   outline: 0.2rem solid #c77a27;
- 
+
  }
  .navbar .edit-this-page:focus{
    background-color: #6e5437;

--- a/site/docs/version_selector.js
+++ b/site/docs/version_selector.js
@@ -109,16 +109,16 @@ function fill_selector(){
 //This function adds the selected version from the version selector to all
 //the links that change when a particular version is selected.
 function getSelectedVersion() {
-    let arr = ['tutref','tutref_b','extref','extref_b','manual','corref','toolref','toolref_b','stdlib','api_b','refman-pdf','refman-txt','refman-html','refman-info'];
+    let arr = ['tutref_b','extref_b','toolref_b','api_b'];
     let selectedVersion = document.getElementById('version-selector');
 
     for(let i = 0; i < arr.length; i++){
           const newSpan = document.querySelector(`#${arr[i]} .varPrefix`);
         if (newSpan) {
-          newSpan.innerText = selectedVersion.value;
+          newSpan.innerText = `(${selectedVersion.value})`;
         } else {
           let newText = document.getElementById(arr[i]);
-          newText.innerHTML = "<span class='varPrefix'> " + selectedVersion.value + "</span> "+ newText.innerText;
+          newText.innerHTML = newText.innerText + ` <span class='varPrefix'>(${selectedVersion.value})</span>`;
         }
     }
 }

--- a/site/docs/version_selector.js
+++ b/site/docs/version_selector.js
@@ -106,6 +106,22 @@ function fill_selector(){
     document.getElementById("version-selector").innerHTML = html;
 }
 
+//This function adds the selected version from the version selector to all
+//the links that change when a particular version is selected.
+function getSelectedVersion() {
+    let arr = ['tutref','tutref_b','extref','extref_b','manual','corref','toolref','toolref_b','stdlib','api_b','refman-pdf','refman-txt','refman-html','refman-info'];
+    let selectedVersion = document.getElementById('version-selector');
+
+    for(let i = 0; i < arr.length; i++){
+          const newSpan = document.querySelector(`#${arr[i]} .varPrefix`);
+        if (newSpan) {
+          newSpan.innerText = selectedVersion.value;
+        } else {
+          let newText = document.getElementById(arr[i]);
+          newText.innerHTML = "<span class='varPrefix'> " + selectedVersion.value + "</span> "+ newText.innerText;
+        }
+    }
+}
 
 function refresh(){
     let i = document.Versions.selector.selectedIndex;
@@ -113,6 +129,8 @@ function refresh(){
     localStorage.setItem("CURRENT_VERSION_INDEX", i);
     let version = document.Versions.selector.options[i].value;
     setVersion(version);
+    getSelectedVersion();
+
 }
 
 function init(){


### PR DESCRIPTION
# Issue Description
When users select a version from the version selector on the documentation page, the changes that are made to the page such as the links to the resources changing are not visible so the users might be confused about what the version selector is really doing
Please include a summary of the issue.
Changes made by the version selector not visible
Fixes # (issue)
Fixes #1310 
## Changes Made
Added the selected version to all the link texts whose links change when a version is selected.
Please describe the changes that you made.
Created a function to get the selected option's value and add it in front of the affected link texts.

Before

![ver-before](https://user-images.githubusercontent.com/15726413/114109305-eb198280-98cc-11eb-87ba-bd9ac5e245c2.png)

After

![ver1](https://user-images.githubusercontent.com/15726413/114109323-f7054480-98cc-11eb-8432-b02f3fae1aa4.PNG)
![ver](https://user-images.githubusercontent.com/15726413/114109324-f8367180-98cc-11eb-8c49-756414f33aa2.PNG)

For Firefox
![fire2](https://user-images.githubusercontent.com/15726413/114174842-2057bc00-9931-11eb-8141-dd7a676b5ffc.PNG)
![fire1](https://user-images.githubusercontent.com/15726413/114174848-2188e900-9931-11eb-95e2-c73092082615.PNG)

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
