### PR TITLE
add darker color bg to button hover property

### DIFF
--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -2746,6 +2746,7 @@ button.close {
 .btn:hover,
 .btn:focus {
   color: #ffffff;
+  background: #004900;
   text-decoration: none;
   background-position: 0 -15px;
   -webkit-transition: background-position 0.1s linear;


### PR DESCRIPTION
# Issue Description
    Add a darker background color to buttons for hover functionality  

Please include a summary of the issue.
 Suggested an improvement to all buttons (Green) that when a user hovers over the button (web only), the background color of the button will change to indicate that it is clickable.  Tested on Mac OS Big Sur and browsers Chrome & FireFox.
     Even though there is already an 'indicator' (cursor changes to hand), I was inspired to suggest a more noticeable color contrast for hover action as this would be beneficial to low vision people using laptops/desktop (this won't work on mobile from my research).

Fixes  https://github.com/ocaml/ocaml.org/issues/1393

## Changes Made
    Please describe the changes that you made.

Added background color into bootstrap CSS file under the .btn hover/.btn focus properties

Please describe the changes that you made.

* **Please check if the PR fulfills these requirements**

- [ ] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
