### PR TITLE
Navbar low contrast ratio lighthouse issue resolved

### DIFF
--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -6993,6 +6993,8 @@ body {
   .nav-collapse.collapse {
     overflow: hidden;
     height: 0;
+    position: relative;
+    right: 1000px;
   }
   .navbar .btn-navbar {
     display: block;

--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -6992,9 +6992,10 @@ body {
   .nav-collapse,
   .nav-collapse.collapse {
     overflow: hidden;
-    height: 0;
+    height: auto;
     position: relative;
     right: 1000px;
+    display: none;
   }
   .navbar .btn-navbar {
     display: block;

--- a/site/js/collapsed-menu.js
+++ b/site/js/collapsed-menu.js
@@ -3,13 +3,12 @@
 
 function toggleVisibilityMenu(id) {
     var e = document.getElementById(id);
-    if (e.style.height == "auto") {
-	e.style.height = "0";
+    if (e.style.display == "block") {
     e.style.right = "1000px";
-
+    e.style.display = "none";
     }
     else {
-	e.style.height = "auto";
+	e.style.display = "block";
     e.style.right = "0";
     }
 }

--- a/site/js/collapsed-menu.js
+++ b/site/js/collapsed-menu.js
@@ -4,9 +4,12 @@
 function toggleVisibilityMenu(id) {
     var e = document.getElementById(id);
     if (e.style.height == "auto") {
-	e.style.height = "0px";
+	e.style.height = "0";
+    e.style.right = "1000px";
+
     }
     else {
 	e.style.height = "auto";
+    e.style.right = "0";
     }
 }


### PR DESCRIPTION
# Issue Description

When we go to the `ocaml.org/learn/` and generating the lighthouse report, it gives an issue for the contrast ratio being too low between background and foreground colors as can be seen in the image below. I am solving the issue by off-screening the navbar menu when not in use and toggle it back when clicked.
In the image below the contact ratio issue can be seen on the right side as a lighthouse report.

Fixes # (issue)

#1489 

## Changes Made

I am solving the issue by off-screening the navbar menu when not in use and toggle it back when clicked.
In the image below the contrast ratio issue can be seen on the right side as a lighthouse report.

![img1](https://user-images.githubusercontent.com/63946672/114135090-5d6a8100-9926-11eb-991b-32188b36cead.png)
 
I have tried to solve the issue by modifying the collapsed menu JS and making some changes in the `bootstrap.css`.

![img 2](https://user-images.githubusercontent.com/63946672/114135138-71ae7e00-9926-11eb-9f41-17105f233f45.png)

