### PR TITLE
Rewrite of "Compiling OCaml Programs"

### DIFF
--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -5,7 +5,7 @@
 # Compiling OCaml projects
 
 This tutorial explains how to compile your OCaml programs into executable form.
-It addresses:
+It addresses, in turn:
 
 1. The compilation commands `ocamlc` and `ocamlopt` provided with OCaml. It is
    useful to learn these commands to understand OCaml's compilation model.
@@ -14,9 +14,10 @@ It addresses:
    about where libraries have been installed on your particular system. 
 
 1. Automatic build systems for OCaml, such as `dune`, which release us from
-   details of compiler command invocation.
+   details of compiler command invocation, so we never touch `ocamlc`,
+   `ocamlopt`, or even `ocamlfind`.
 
-In our [up and running tutorial](up_and_running.html) we jumped straight using
+In our [up and running tutorial](up_and_running.html) we jumped straight to using
 the automated build system `dune`. Now we shall look under the hood.
 
 ## Compilation basics
@@ -43,15 +44,14 @@ can compile the program in one single step:
 ocamlopt -o program module1.ml module2.ml
 ```
 
-That's it. The compiler produces an executable named `program` or
-`program.exe`. The order of the source files matters, and that `module1.ml`
-cannot depend on things that are defined in `module2.ml`.
+The compiler produces an executable named `program` or `program.exe`. The order
+of the source files matters, and so `module1.ml` cannot depend upon things that
+are defined in `module2.ml`.
 
-Let's use a library other than the standard library. The OCaml
-distribution is shipped with the standard library, plus several other
-libraries that you can use as well. There is also a large number of
-third-party libraries, for a wide range of applications, from networking
-to graphics. You must understand the following:
+The OCaml distribution is shipped with the standard library, plus several other
+libraries. There are also a large number of third-party libraries, for a wide
+range of applications, from networking to graphics. You should understand the
+following:
 
 1. The OCaml compilers know where the standard library is and use it
    systematically (try: `ocamlc -where`). You don't have to worry much about
@@ -75,25 +75,23 @@ the extension of bytecode libraries. The file `unix.cmxa` is found because it
 is always installed at the same place as the standard library, and this
 directory is in the library search path.
 
-
-
 If your program depends upon third-party libraries, you must pass them on the
 command line. You must also indicate the libraries on which these libraries
 depend. You must also pass the -I option to `ocamlopt` for each directory where
 they may be found. This becomes complicated, and this information is
-installation-dependent. So we will use `ocamlfind` instead, which does these
+installation dependent. So we will use `ocamlfind` instead, which does these
 jobs for us.
 
 ###  Using the ocamlfind front-end
 
-Using `ocamlfind` is highly recommended for compiling any program or library
-that uses third-party OCaml libraries. Library authors themselves should make
-their library installable with `ocamlfind` as well. Let's assume that all the
-libraries you want to use have been installed properly with ocamlfind (you can
-install `ocamlfind` using the opam package manager, by typing `opam install
-ocamlfind`).
+Using `ocamlfind` is often used for compiling any program or library that uses
+third-party OCaml libraries. Library authors themselves make their library
+installable with `ocamlfind` as well. You can install `ocamlfind` using the
+opam package manager, by typing `opam install ocamlfind`.
 
-You can see which libraries are available in your system by typing:
+Let's assume that all the libraries you want to use have been installed
+properly with ocamlfind. You can see which libraries are available in your
+system by typing:
 
 ```shell
 ocamlfind list
@@ -113,7 +111,6 @@ ocamlfind ocamlopt -o program -linkpkg -package package module1.ml module2.ml
 Multiple packages can be specified using commas e.g `package1,package2`. This
 command will work regardless of the location of the libraries, as long as they
 are known by `ocamlfind`.
-
 
 Note that you can compile the files separately. This is useful if
 you want to recompile only some parts of the programs. Here are the
@@ -154,8 +151,9 @@ ocamlfind ocamlmktop -o toplevel unix.cma -package package module1.ml module2.ml
 
 The most popular modern system for building OCaml projects is
 [dune](https://dune.readthedocs.io/en/stable/) which may be installed with
-`opam install dune`. It includes support for packages. For example, the dune
-file for our project might look like this:
+`opam install dune`. It allows one to build OCaml projects from a simple
+description of their elements. For example, the dune file for our project might
+look like this:
 
 ```shell
 ;; our example project

--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -4,14 +4,13 @@
 
 # Compiling OCaml projects
 
-This tutorial describes the base compilation commands provided with
+This tutorial describes the compilation commands provided with
 OCaml. It is useful to learn these commands to understand OCaml's
 compilation model. However, eventually you will want to use a build tool
 that automatically calls these commands internally. See [Compilation
 Tools](dev_tools.html#compilation-tools) for more information on the
 available options.
 
-## Compilation basics
 The core OCaml distribution provides the `ocamlc` and `ocamlopt`
 compilers. Using them directly is fine, but if you are using third party
 libraries, you should use the `ocamlfind` front-end, since it saves you
@@ -20,102 +19,109 @@ particular system. You can even skip to the next section "Automated
 build systems", where you will find how to do things even more
 automatically.
 
+## Compilation basics
+
 In this section, we will first see how to compile a simple program using
-only ocamlc or ocamlopt. Then we will see how to use libraries and how
+only `ocamlc` or `ocamlopt`. Then we will see how to use libraries and how
 to take advantage of the
 [findlib](http://projects.camlcity.org/projects/findlib.html)
 system, which provides the `ocamlfind` command.
 
-###  `ocamlc` and `ocamlopt`
-`ocamlc` is the bytecode compiler, and `ocamlopt` is the native code
-compiler. If you don't know which one to use, use `ocamlopt` since it
-provides standalone executables that are normally faster than bytecode.
+### The ocamlc and ocamlopt compilers
 
-Let's assume that your program `progprog` has two source files,
+OCaml comes with two compilers: `ocamlc` is the bytecode compiler, and
+`ocamlopt` is the native code compiler. If you don't know which one to use, use
+`ocamlopt` since it provides executables that are faster than bytecode.
+
+Let's assume that your program `program` has two source files,
 `module1.ml` and `module2.ml`. We will compile them to native code,
 using `ocamlopt`. For now, we also assume that they do not use any other
 library than the standard library, which is automatically loaded. You
 can compile the program in one single step:
 
 ```shell
-ocamlopt -o progprog module1.ml module2.ml
+ocamlopt -o program module1.ml module2.ml
 ```
-That's it. The compiler produced an executable named `progprog` or
-`progprog.exe`. If you are wondering how to write a program in multiple
+
+That's it. The compiler produced an executable named `program` or
+`program.exe`. If you are wondering how to write a program in multiple
 files, see our [Modules](modules.html "Modules") tutorial. Don't forget
 that the order of the source files matters, and that `module1.ml` cannot
-depend on things that are defined in `module2.ml`, unless `module2.ml`
-comes earlier on the command line.
+depend on things that are defined in `module2.ml`.
 
-Let's use libraries other than the standard library. The OCaml
+Let's use a library other than the standard library. The OCaml
 distribution is shipped with the standard library, plus several other
 libraries that you can use as well. There is also a large number of
 third-party libraries, for a wide range of applications, from networking
-to 3D graphics. You must understand the following:
+to graphics. You must understand the following:
 
 1. The OCaml compilers know where the standard library is and uses it
  systematically (try: `ocamlc -where`). You don't have to worry much
  about it.
-1. The other libraries that ship with the OCaml distribution from Inria
- (str, unix, bigarray, etc.) are installed in the same directory as
- the standard library.
+
+1. The other libraries that ship with the OCaml distribution (Str, Unix, etc.)
+ are installed in the same directory as the standard library.
+
 1. Third-party libraries may be installed in various places, and even a
  given library can be installed in different places from one system
  to another.
 
-If your program uses only the unix library (provides system calls not
+If your program uses only the Unix library (provides system calls not
 only for Unix systems), the command line would be:
 
 ```shell
-ocamlopt -o progprog unix.cmxa module1.ml module2.ml
+ocamlopt -o program unix.cmxa module1.ml module2.ml
 ```
+
 `.cmxa` is the extension of native code libraries, while `.cma` is the
 extension of bytecode libraries. The file `unix.cmxa` is found because
 it is always installed at the same place as the standard library, and
 this directory is in the library search path.
 
-If your program is a video game that uses openGL with SDL, you will need
-to tell the compiler which library files must be used, and where to find
-them. It means you will be using lablGL and OCamlSDL, the OCaml
-interfaces to your local implementation of openGL and SDL. LablGL
-provides one OCaml library file `lablgl.cmxa`, while OCamlSDL provides
-one core library file `sdl.cmxa`, and 3 optional files `sdlloader.cmxa`,
-`sdlmixer.cmxa` and `sdlttf.cmxa`. If you want to use those files, you
-must pass them on the command line. You must also indicate the libraries
-on which these libraries depend. Here, the bigarray library is needed by
-OCamlSDL. You must also pass the -I option to `ocamlopt` for each
-directory where they should be looked for. Since this information
-installation-dependent, we will use ocamlfind instead.
+If, for example, your program is a video game that uses openGL with SDL, you
+will need to tell the compiler which library files must be used, and where to
+find them. It means you will be using lablGL and OCamlSDL, the OCaml interfaces
+to your local implementation of openGL and SDL. LablGL provides one OCaml
+library file `lablgl.cmxa`, while OCamlSDL provides one core library file
+`sdl.cmxa`, and 3 optional files `sdlloader.cmxa`, `sdlmixer.cmxa` and
+`sdlttf.cmxa`. If you want to use those files, you must pass them on the
+command line. You must also indicate the libraries on which these libraries
+depend. You must also pass the -I option to `ocamlopt` for each directory where
+they may be found. Since this information is installation-dependent, we will
+use `ocamlfind` instead.
 
-###  Using the `ocamlfind` front-end
+###  Using the ocamlfind front-end
+
 Using `ocamlfind` is highly recommended for compiling any program or
 library that uses third-party OCaml libraries. Library authors
 themselves should make their library installable with `ocamlfind` as
-well. If they don't, you may have to do it yourself, which is not very
-difficult, but hopefully you won't have to. OK, let's assume that all
+well. Let's assume that all
 the libraries you want to use have been installed properly with
 ocamlfind.
 
-You can see which packages and subpackages are available in your system
+You can see which libraries are available in your system
 by typing:
 
 ```shell
 ocamlfind list
 ```
-This shows the list of package names, with their version ID.
+
+This shows the list of package names, with their version ID. Note that most
+opam packages install software using ocamlfind, so your list of ocamlfind
+libraries will be somewhat similar to your list of installed opam packages
+listed by `opam list`.
 
 For our example using LablGL and OCamlSDL, we are going to use the
 following packages: lablGL, sdl, sdl.sdlimage, sdl.sdlmixer, sdl.sdlttf.
-The bigarray package is needed by the sdl package, but we don't need to
-worry about that since `ocamlfind` knows it.
 
 The command for compiling our program will be:
 
 ```shell
-ocamlfind ocamlopt -o progprog -linkpkg \
+ocamlfind ocamlopt -o program -linkpkg \
   -package lablGL,sdl,sdl.sdlimage,sdl.sdlmixer,sdl.sdlttf \
   module1.ml module2.ml
 ```
+
 And it will work regardless of the location of the libraries, as long as
 they are known by `ocamlfind`.
 
@@ -131,17 +137,22 @@ ocamlfind ocamlopt -c \
 ocamlfind ocamlopt -c \
   -package lablGL,sdl,sdl.sdlimage,sdl.sdlmixer,sdl.sdlttf \
   module2.ml
-ocamlfind ocamlopt -o progprog -linkpkg \
+ocamlfind ocamlopt -o program -linkpkg \
   -package lablGL,sdl,sdl.sdlimage,sdl.sdlmixer,sdl.sdlttf \
   module1.cmx module2.cmx
 ```
-Separate compilation is usually not performed manually but only when
-using a Makefile that will take care of recompiling only what it
-necessary. See next section.
 
-## Automated build systems
+Separate compilation (one command for `module1.ml`, another for `module2.ml`
+and another to link the final output) is usually not performed manually but
+only when using an automated build system that will take care of recompiling
+only what it necessary.
+
+## Dune: an automated build system
 
 - [dune](https://dune.readthedocs.io/en/latest/quick-start.html) Popular for new projects.
+
+## Other build systems
+
 - [OMake](https://github.com/ocaml-omake/omake) Another OCaml build system.
 - [GNU make](https://www.gnu.org/software/make/) GNU make can build anything, including OCaml. May be used in conjunction with [OCamlmakefile](https://github.com/mmottl/ocaml-makefile)
 - [Oasis](https://github.com/ocaml/oasis) Generates configure, build, and install system using another build system.

--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -59,36 +59,41 @@ to graphics. You must understand the following:
  systematically (try: `ocamlc -where`). You don't have to worry much
  about it.
 
-1. The other libraries that ship with the OCaml distribution (Str, Unix, etc.)
+1. The other libraries that ship with the OCaml distribution (str, unix, etc.)
  are installed in the same directory as the standard library.
 
 1. Third-party libraries may be installed in various places, and even a
  given library can be installed in different places from one system
  to another.
 
-If your program uses only the Unix library (provides system calls not
-only for Unix systems), the command line would be:
+If your program uses the unix library, for example, the command line would be:
 
 ```shell
 ocamlopt -o program unix.cmxa module1.ml module2.ml
 ```
 
-`.cmxa` is the extension of native code libraries, while `.cma` is the
-extension of bytecode libraries. The file `unix.cmxa` is found because
-it is always installed at the same place as the standard library, and
-this directory is in the library search path.
+Note that `.cmxa` is the extension of native code libraries, while `.cma` is
+the extension of bytecode libraries. The file `unix.cmxa` is found because it
+is always installed at the same place as the standard library, and this
+directory is in the library search path.
 
-If, for example, your program is a video game that uses openGL with SDL, you
-will need to tell the compiler which library files must be used, and where to
-find them. It means you will be using lablGL and OCamlSDL, the OCaml interfaces
-to your local implementation of openGL and SDL. LablGL provides one OCaml
-library file `lablgl.cmxa`, while OCamlSDL provides one core library file
-`sdl.cmxa`, and 3 optional files `sdlloader.cmxa`, `sdlmixer.cmxa` and
-`sdlttf.cmxa`. If you want to use those files, you must pass them on the
+We can use another tool `ocamlmktop` to make an interactive toplevel with
+libraries accessible:
+
+```shell
+ocamlmktop -o toplevel unix.cma module1.ml module2.ml
+```
+
+We run `toplevel` and get an OCaml toplevel with modules `Unix`, `Module1`, and
+`Module2` all available, allowing us to experiment interactively with our
+program.
+
+If your program depends upon third-party libraries, you must pass them on the
 command line. You must also indicate the libraries on which these libraries
 depend. You must also pass the -I option to `ocamlopt` for each directory where
-they may be found. Since this information is installation-dependent, we will
-use `ocamlfind` instead.
+they may be found. This becomes complicated, and this information is
+installation-dependent. So we will use `ocamlfind` instead, which does these
+jobs for us.
 
 ###  Using the ocamlfind front-end
 
@@ -109,37 +114,33 @@ ocamlfind list
 This shows the list of package names, with their version ID. Note that most
 opam packages install software using ocamlfind, so your list of ocamlfind
 libraries will be somewhat similar to your list of installed opam packages
-listed by `opam list`.
+obtained by `opam list`.
 
-For our example using LablGL and OCamlSDL, we are going to use the
-following packages: lablGL, sdl, sdl.sdlimage, sdl.sdlmixer, sdl.sdlttf.
-
-The command for compiling our program will be:
+The command for compiling our program using package `package` will be:
 
 ```shell
-ocamlfind ocamlopt -o program -linkpkg \
-  -package lablGL,sdl,sdl.sdlimage,sdl.sdlmixer,sdl.sdlttf \
-  module1.ml module2.ml
+ocamlfind ocamlopt -o program -linkpkg -package package module1.ml module2.ml
 ```
 
-And it will work regardless of the location of the libraries, as long as
-they are known by `ocamlfind`.
+Multiple packages can be specified using commas e.g `package1,package2`. This
+command will work regardless of the location of the libraries, as long as they
+are known by `ocamlfind`.
 
-Note that you can compile the files separately. This is mostly useful if
+Let's use `ocamlfind` with `ocamlmktop` to make our custom toplevel:
+
+```shell
+ocamlfind ocamlmktop -o toplevel unix.cma -package package module1.ml module2.ml
+```
+
+Note that you can compile the files separately. This is useful if
 you want to recompile only some parts of the programs. Here are the
 equivalent commands that perform a separate compilation of the source
 files and link them together in a final step:
 
 ```shell
-ocamlfind ocamlopt -c \
-  -package lablGL,sdl,sdl.sdlimage,sdl.sdlmixer,sdl.sdlttf \
-  module1.ml
-ocamlfind ocamlopt -c \
-  -package lablGL,sdl,sdl.sdlimage,sdl.sdlmixer,sdl.sdlttf \
-  module2.ml
-ocamlfind ocamlopt -o program -linkpkg \
-  -package lablGL,sdl,sdl.sdlimage,sdl.sdlmixer,sdl.sdlttf \
-  module1.cmx module2.cmx
+ocamlfind ocamlopt -c -package package module1.ml
+ocamlfind ocamlopt -c -package package module2.ml
+ocamlfind ocamlopt -o program -linkpkg -package package module1.cmx module2.cmx
 ```
 
 Separate compilation (one command for `module1.ml`, another for `module2.ml`
@@ -155,4 +156,4 @@ only what it necessary.
 
 - [OMake](https://github.com/ocaml-omake/omake) Another OCaml build system.
 - [GNU make](https://www.gnu.org/software/make/) GNU make can build anything, including OCaml. May be used in conjunction with [OCamlmakefile](https://github.com/mmottl/ocaml-makefile)
-- [Oasis](https://github.com/ocaml/oasis) Generates configure, build, and install system using another build system.
+- [Oasis](https://github.com/ocaml/oasis) Generates a configure, build, and install system from a specification.

--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -153,7 +153,15 @@ only what it necessary.
 The most popular modern system for building OCaml projects is
 [dune](https://dune.readthedocs.io/en/latest/quick-start.html). The quick-start
 guide shows you how to control the building of OCaml projects from a simple
-description file. This includes support for packages.
+description file. This includes support for packages. For example, the dune
+file for our project might look like this:
+
+```shell
+;; our example project
+(executable
+  (name program)
+  (libraries unix package))
+```
 
 ## Other build systems
 

--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -150,7 +150,10 @@ only what it necessary.
 
 ## Dune: an automated build system
 
-- [dune](https://dune.readthedocs.io/en/latest/quick-start.html) Popular for new projects.
+The most popular modern system for building OCaml projects is
+[dune](https://dune.readthedocs.io/en/latest/quick-start.html). The quick-start
+guide shows you how to control the building of OCaml projects from a simple
+description file. This includes support for packages.
 
 ## Other build systems
 

--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -4,14 +4,20 @@
 
 # Compiling OCaml projects
 
-This tutorial describes the compilation commands provided with OCaml. It is
-useful to learn these commands to understand OCaml's compilation model. The
-core OCaml distribution provides the `ocamlc` and `ocamlopt` compilers. Using
-them directly is fine, but if you are using third party libraries, you should
-use the `ocamlfind` front-end, since it saves you from worrying about where
-libraries have been installed on your particular system.  However, eventually
-you will want to use a build tool that automatically calls these commands
-internally. Such tools are listed at the bottom of this page.
+This tutorial explains how to compile your OCaml programs into executable form.
+It addresses:
+
+1. The compilation commands `ocamlc` and `ocamlopt` provided with OCaml. It is
+   useful to learn these commands to understand OCaml's compilation model.
+
+1. The `ocamlfind` front-end to the compiler, which saves you from worrying
+   about where libraries have been installed on your particular system. 
+
+1. Automatic build systems for OCaml, such as `dune`, which release us from
+   details of compiler command invocation.
+
+In our [up and running tutorial](up_and_running.html) we jumped straight using
+the automated build system `dune`. Now we shall look under the hood.
 
 ## Compilation basics
 
@@ -37,10 +43,9 @@ can compile the program in one single step:
 ocamlopt -o program module1.ml module2.ml
 ```
 
-That's it. The compiler produced an executable named `program` or
-`program.exe`. Don't forget
-that the order of the source files matters, and that `module1.ml` cannot
-depend on things that are defined in `module2.ml`.
+That's it. The compiler produces an executable named `program` or
+`program.exe`. The order of the source files matters, and that `module1.ml`
+cannot depend on things that are defined in `module2.ml`.
 
 Let's use a library other than the standard library. The OCaml
 distribution is shipped with the standard library, plus several other
@@ -48,18 +53,18 @@ libraries that you can use as well. There is also a large number of
 third-party libraries, for a wide range of applications, from networking
 to graphics. You must understand the following:
 
-1. The OCaml compilers know where the standard library is and uses it
- systematically (try: `ocamlc -where`). You don't have to worry much
- about it.
+1. The OCaml compilers know where the standard library is and use it
+   systematically (try: `ocamlc -where`). You don't have to worry much about
+   it.
 
 1. The other libraries that ship with the OCaml distribution (str, unix, etc.)
- are installed in the same directory as the standard library.
+   are installed in the same directory as the standard library.
 
-1. Third-party libraries may be installed in various places, and even a
- given library can be installed in different places from one system
- to another.
+1. Third-party libraries may be installed in various places, and even a given
+   library can be installed in different places from one system to another.
 
-If your program uses the unix library, for example, the command line would be:
+If your program uses the unix library in addition to the standard library, for
+example, the command line would be:
 
 ```shell
 ocamlopt -o program unix.cmxa module1.ml module2.ml
@@ -70,16 +75,7 @@ the extension of bytecode libraries. The file `unix.cmxa` is found because it
 is always installed at the same place as the standard library, and this
 directory is in the library search path.
 
-We can use another tool `ocamlmktop` to make an interactive toplevel with
-libraries accessible:
 
-```shell
-ocamlmktop -o toplevel unix.cma module1.ml module2.ml
-```
-
-We run `toplevel` and get an OCaml toplevel with modules `Unix`, `Module1`, and
-`Module2` all available, allowing us to experiment interactively with our
-program.
 
 If your program depends upon third-party libraries, you must pass them on the
 command line. You must also indicate the libraries on which these libraries
@@ -118,11 +114,6 @@ Multiple packages can be specified using commas e.g `package1,package2`. This
 command will work regardless of the location of the libraries, as long as they
 are known by `ocamlfind`.
 
-Let's use `ocamlfind` with `ocamlmktop` to make our custom toplevel:
-
-```shell
-ocamlfind ocamlmktop -o toplevel unix.cma -package package module1.ml module2.ml
-```
 
 Note that you can compile the files separately. This is useful if
 you want to recompile only some parts of the programs. Here are the
@@ -140,12 +131,30 @@ and another to link the final output) is usually not performed manually but
 only when using an automated build system that will take care of recompiling
 only what it necessary.
 
+## Interlude: making a custom toplevel
+
+OCaml provides another tool `ocamlmktop` to make an interactive toplevel with
+libraries accessible. For example:
+
+```shell
+ocamlmktop -o toplevel unix.cma module1.ml module2.ml
+```
+
+We run `toplevel` and get an OCaml toplevel with modules `Unix`, `Module1`, and
+`Module2` all available, allowing us to experiment interactively with our
+program.
+
+OCamlfind also supports `ocamlmktop`:
+
+```shell
+ocamlfind ocamlmktop -o toplevel unix.cma -package package module1.ml module2.ml
+```
+
 ## Dune: an automated build system
 
 The most popular modern system for building OCaml projects is
-[dune](https://dune.readthedocs.io/en/latest/quick-start.html). The quick-start
-guide shows you how to control the building of OCaml projects from a simple
-description file. This includes support for packages. For example, the dune
+[dune](https://dune.readthedocs.io/en/stable/) which may be installed with
+`opam install dune`. It includes support for packages. For example, the dune
 file for our project might look like this:
 
 ```shell
@@ -154,6 +163,11 @@ file for our project might look like this:
   (name program)
   (libraries unix package))
 ```
+
+The dune [quick-start
+guide](https://dune.readthedocs.io/en/latest/quick-start.html) shows you how to
+write such description files for more complicated situations, and how to
+structure, build, and run dune projects. 
 
 ## Other build systems
 

--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -84,7 +84,7 @@ jobs for us.
 
 ###  Using the ocamlfind front-end
 
-Using `ocamlfind` is often used for compiling any program or library that uses
+The `ocamlfind` front-end is often used for compiling programs that use
 third-party OCaml libraries. Library authors themselves make their library
 installable with `ocamlfind` as well. You can install `ocamlfind` using the
 opam package manager, by typing `opam install ocamlfind`.
@@ -102,15 +102,17 @@ opam packages install software using ocamlfind, so your list of ocamlfind
 libraries will be somewhat similar to your list of installed opam packages
 obtained by `opam list`.
 
-The command for compiling our program using package `package` will be:
+The command for compiling our program using package `pkg` will be:
 
 ```shell
-ocamlfind ocamlopt -o program -linkpkg -package package module1.ml module2.ml
+ocamlfind ocamlopt -o program -linkpkg -package pkg module1.ml module2.ml
 ```
 
-Multiple packages can be specified using commas e.g `package1,package2`. This
-command will work regardless of the location of the libraries, as long as they
-are known by `ocamlfind`.
+Multiple packages may be specified using commas e.g `pkg1,pkg2`. Ocamlfind
+knows how to find any files `ocamlopt` may need from the package, for example
+`.cmxa` implementation files or `.cmi` interface files, because they have been
+packaged together and installed at a known location by ocamlfind. We need only
+the name `pkg` to refer to them all - ocamlfind does the rest.
 
 Note that you can compile the files separately. This is useful if
 you want to recompile only some parts of the programs. Here are the
@@ -118,9 +120,9 @@ equivalent commands that perform a separate compilation of the source
 files and link them together in a final step:
 
 ```shell
-ocamlfind ocamlopt -c -package package module1.ml
-ocamlfind ocamlopt -c -package package module2.ml
-ocamlfind ocamlopt -o program -linkpkg -package package module1.cmx module2.cmx
+ocamlfind ocamlopt -c -package pkg module1.ml
+ocamlfind ocamlopt -c -package pkg module2.ml
+ocamlfind ocamlopt -o program -linkpkg -package pkg module1.cmx module2.cmx
 ```
 
 Separate compilation (one command for `module1.ml`, another for `module2.ml`
@@ -144,7 +146,7 @@ program.
 OCamlfind also supports `ocamlmktop`:
 
 ```shell
-ocamlfind ocamlmktop -o toplevel unix.cma -package package module1.ml module2.ml
+ocamlfind ocamlmktop -o toplevel unix.cma -package pkg module1.ml module2.ml
 ```
 
 ## Dune: an automated build system
@@ -155,11 +157,11 @@ The most popular modern system for building OCaml projects is
 description of their elements. For example, the dune file for our project might
 look like this:
 
-```shell
+```scheme
 ;; our example project
 (executable
   (name program)
-  (libraries unix package))
+  (libraries unix pkg))
 ```
 
 The dune [quick-start

--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -4,20 +4,14 @@
 
 # Compiling OCaml projects
 
-This tutorial describes the compilation commands provided with
-OCaml. It is useful to learn these commands to understand OCaml's
-compilation model. However, eventually you will want to use a build tool
-that automatically calls these commands internally. See [Compilation
-Tools](dev_tools.html#compilation-tools) for more information on the
-available options.
-
-The core OCaml distribution provides the `ocamlc` and `ocamlopt`
-compilers. Using them directly is fine, but if you are using third party
-libraries, you should use the `ocamlfind` front-end, since it saves you
-from worrying about where libraries have been installed on your
-particular system. You can even skip to the next section "Automated
-build systems", where you will find how to do things even more
-automatically.
+This tutorial describes the compilation commands provided with OCaml. It is
+useful to learn these commands to understand OCaml's compilation model. The
+core OCaml distribution provides the `ocamlc` and `ocamlopt` compilers. Using
+them directly is fine, but if you are using third party libraries, you should
+use the `ocamlfind` front-end, since it saves you from worrying about where
+libraries have been installed on your particular system.  However, eventually
+you will want to use a build tool that automatically calls these commands
+internally. Such tools are listed at the bottom of this page.
 
 ## Compilation basics
 
@@ -33,7 +27,7 @@ OCaml comes with two compilers: `ocamlc` is the bytecode compiler, and
 `ocamlopt` is the native code compiler. If you don't know which one to use, use
 `ocamlopt` since it provides executables that are faster than bytecode.
 
-Let's assume that your program `program` has two source files,
+Let's assume that our program `program` has two source files,
 `module1.ml` and `module2.ml`. We will compile them to native code,
 using `ocamlopt`. For now, we also assume that they do not use any other
 library than the standard library, which is automatically loaded. You
@@ -44,8 +38,7 @@ ocamlopt -o program module1.ml module2.ml
 ```
 
 That's it. The compiler produced an executable named `program` or
-`program.exe`. If you are wondering how to write a program in multiple
-files, see our [Modules](modules.html "Modules") tutorial. Don't forget
+`program.exe`. Don't forget
 that the order of the source files matters, and that `module1.ml` cannot
 depend on things that are defined in `module2.ml`.
 
@@ -97,21 +90,20 @@ jobs for us.
 
 ###  Using the ocamlfind front-end
 
-Using `ocamlfind` is highly recommended for compiling any program or
-library that uses third-party OCaml libraries. Library authors
-themselves should make their library installable with `ocamlfind` as
-well. Let's assume that all
-the libraries you want to use have been installed properly with
-ocamlfind.
+Using `ocamlfind` is highly recommended for compiling any program or library
+that uses third-party OCaml libraries. Library authors themselves should make
+their library installable with `ocamlfind` as well. Let's assume that all the
+libraries you want to use have been installed properly with ocamlfind (you can
+install `ocamlfind` using the opam package manager, by typing `opam install
+ocamlfind`).
 
-You can see which libraries are available in your system
-by typing:
+You can see which libraries are available in your system by typing:
 
 ```shell
 ocamlfind list
 ```
 
-This shows the list of package names, with their version ID. Note that most
+This shows the list of package names, with their versions. Note that most
 opam packages install software using ocamlfind, so your list of ocamlfind
 libraries will be somewhat similar to your list of installed opam packages
 obtained by `opam list`.

--- a/site/learn/tutorials/modules.md
+++ b/site/learn/tutorials/modules.md
@@ -38,7 +38,6 @@ ocamlopt -c amodule.ml
 ocamlopt -c bmodule.ml
 ocamlopt -o hello amodule.cmx bmodule.cmx
 ```
-
 Now we have a wonderful executable that prints "Hello". As you can see,
 if you want to access anything from a given module, use the name of the
 module (always starting with a capital) followed by a dot and the thing
@@ -126,7 +125,6 @@ using `ocamlopt`:
 ocamlc -c amodule.mli
 ocamlopt -c amodule.ml
 ...
-
 ```
 ## Abstract types
 What about type definitions? We saw that values such as functions can be

--- a/site/learn/tutorials/modules.md
+++ b/site/learn/tutorials/modules.md
@@ -24,13 +24,21 @@ And here is what we have in `bmodule.ml`:
 ```ocaml
 Amodule.hello ()
 ```
-Usually files are compiled one by one, let's do it:
+
+We can compile the files in one command:
+
+```shell
+ocamlopt -o hello amodule.ml bmodule.ml
+```
+
+Or, as a build system might do, one by one:
 
 ```shell
 ocamlopt -c amodule.ml
 ocamlopt -c bmodule.ml
 ocamlopt -o hello amodule.cmx bmodule.cmx
 ```
+
 Now we have a wonderful executable that prints "Hello". As you can see,
 if you want to access anything from a given module, use the name of the
 module (always starting with a capital) followed by a dot and the thing
@@ -118,6 +126,7 @@ using `ocamlopt`:
 ocamlc -c amodule.mli
 ocamlopt -c amodule.ml
 ...
+
 ```
 ## Abstract types
 What about type definitions? We saw that values such as functions can be


### PR DESCRIPTION
This PR is a rewrite of the "Compiling OCaml Programs" tutorial. It is the last piece of the important "Getting Started" section of the manual to be modernized.

One particular difficulty is the explanation of the connection between ocaml, ocamlfind, opam, and dune. I hope this needle has been threaded, but I welcome fixes.

After this is merged, there will need to be one more pass over the whole of the "Getting Started" section to ensure consistency.

(A small change is made to modules.md too, to avoid contradictory statements in two parts of the tutorials).