### PR TITLE
Fixed issue with focus on the book images

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -48,23 +48,23 @@
     background-color:lightgray;
 }
 
-#opamdoc-contents .expander { 
-  width:1.5em; 
-  height:1.5em; 
-  border-radius:0.3em; 
-  font-weight: bold; 
-  font-family:Sans; 
-  line-height:16px; 
+#opamdoc-contents .expander {
+  width:1.5em;
+  height:1.5em;
+  border-radius:0.3em;
+  font-weight: bold;
+  font-family:Sans;
+  line-height:16px;
 }
 #opamdoc-contents .expanding_sig { border-spacing: 5px 1px }
 #opamdoc-contents .expanding_sig td { vertical-align: text-top }
-#opamdoc-contents .expanding_include_0 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_1 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_2 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_3 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_4 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_5 td { vertical-align: text-top } 
-#opamdoc-contents .expanding_include_6 td { vertical-align: text-top } 
+#opamdoc-contents .expanding_include_0 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_1 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_2 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_3 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_4 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_5 td { vertical-align: text-top }
+#opamdoc-contents .expanding_include_6 td { vertical-align: text-top }
 #opamdoc-contents table.expanding_include_0, table.expanding_include_1, table.expanding_include_2, table.expanding_include_3,
 table.expanding_include_4, table.expanding_include_5, table.expanding_include_6 {
   border-top: thin dashed;
@@ -72,12 +72,12 @@ table.expanding_include_4, table.expanding_include_5, table.expanding_include_6 
   border-collapse: collapse;
 }
 #opamdoc-contents table.expanding_include_0 { background-color: #FFF5F5; }
-#opamdoc-contents table.expanding_include_1 { background-color: #F5F5FF; } 
-#opamdoc-contents table.expanding_include_2 { background-color: #F5FFF5; } 
-#opamdoc-contents table.expanding_include_3 { background-color: #FFF5FF; } 
-#opamdoc-contents table.expanding_include_4 { background-color: #FFFFF5; } 
-#opamdoc-contents table.expanding_include_5 { background-color: #F5FFFF; } 
-#opamdoc-contents table.expanding_include_6 { background-color: #FFF5EB; } 
+#opamdoc-contents table.expanding_include_1 { background-color: #F5F5FF; }
+#opamdoc-contents table.expanding_include_2 { background-color: #F5FFF5; }
+#opamdoc-contents table.expanding_include_3 { background-color: #FFF5FF; }
+#opamdoc-contents table.expanding_include_4 { background-color: #FFFFF5; }
+#opamdoc-contents table.expanding_include_5 { background-color: #F5FFFF; }
+#opamdoc-contents table.expanding_include_6 { background-color: #FFF5EB; }
 #opamdoc-contents td.edge_column { border-right: 3px solid lightgrey }
 
 /* end of section for opam-doc */
@@ -112,7 +112,7 @@ h1 code, h2 code, h3 code, h4 code, h5 code, h5 code { font-size: 80%; }
 .string .governing,
 .ocaml .st {
   color: #a95472;
-  font-weight: normal;  
+  font-weight: normal;
 }
 .warning { color : Red ; font-weight : bold }
 .info { margin-left : 3em; margin-right: 3em }
@@ -281,13 +281,13 @@ html.svg a.edit-this-page:hover {
   justify-content: flex-end;
 }
 
-/* 
+/*
 This styling overrides bootstrap style which removes outline
 when an element is in focus
 */
 a:focus{
   outline: 0.2rem solid #c77a27;
- 
+
  }
  .navbar .edit-this-page:focus{
    background-color: #6e5437;
@@ -576,11 +576,23 @@ ul.translations:after { content: "]"; }
     text-align: left;
     padding-right: 5%;
   }
+  .books-span a img{
+    width: 100%;
+  }
+  .books-span{
+    margin: 5px;
+  }
+}
+.books-row{
+  display: flex;
 }
 @media (max-width: 480px) {
   #footer .column {
     width: 98%;
     margin-right: 0px;
+  }
+  .books-span a img{
+    width: 100%;
   }
 }
 #footer .entry {


### PR DESCRIPTION
# Issue Description
Noticed an issue in the Books column on the learn page. Clicking on the first image applies the style for focus on the second image. Clicking on the second image applies to the second and also the outline from the style displays off the outline of the images. This issue is shown in the images below

Please include a summary of the issue.
The style for focus wasn't displaying properly for the book images.

Fixes # (issue)
Fixes #1357 

## Changes Made
Added a class to the affected images and then used CSS in the CSS file to fix the issue.

Please describe the changes that you made.
Remove the inline styling that was added to both images that were contributing to the issue and added new classes to display the images properly.
Before

![before-focus](https://user-images.githubusercontent.com/15726413/114205663-712bdc80-9952-11eb-8bf1-f63181f2a603.PNG)
![before-focus1](https://user-images.githubusercontent.com/15726413/114205671-725d0980-9952-11eb-9b40-32aaeb58edaa.PNG)

After

![afterfocus-2](https://user-images.githubusercontent.com/15726413/114205786-97517c80-9952-11eb-85c2-90196d122b83.PNG)
![afterfocus-2 1](https://user-images.githubusercontent.com/15726413/114205793-9882a980-9952-11eb-8b21-49b9d34229dd.PNG)

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
