### PR TITLE
Remove references to removed files

### DIFF
--- a/site/learn/index.fr.md
+++ b/site/learn/index.fr.md
@@ -31,8 +31,7 @@ OCaml est un langage générique de programmation, de puissance industrielle, qu
             <h1 class="ruled"><a href="tutorials/">Tutoriaux</a> &amp; <a href="faq.html">FAQ</a></h1>
             <ul>
                 <li><a href="tutorials/up_and_running.html">Opérationnel avec OCaml</a></li>
-                <li><a href="tutorials/basics.fr.html">Les bases syntaxiques</a></li>
-                <li><a href="tutorials/structure_of_ocaml_programs.fr.html">Les constructions de base</a></li>
+                <li><a href="tutorials/a_first_hour_with_ocaml.html">Une première heure avec OCaml</a></li>
                 <li><a href="tutorials/modules.fr.html">Les modules</a></li>
                 <li><a href="tutorials/map.fr.html">Les dictionnaires</a></li>
                 <li><a href="tutorials/set.fr.html">Les ensembles</a></li>

--- a/site/learn/tutorials/common_error_messages.md
+++ b/site/learn/tutorials/common_error_messages.md
@@ -27,7 +27,7 @@ More disturbing is the following message:
 This expression has type my_type but is here used with type my_type
 ```
 This error happens often while testing some type definitions using the
-[interactive toplevel](basics.html).  In OCaml, it is perfectly legal
+interactive toplevel.  In OCaml, it is perfectly legal
 to define a type with a name
 that is already taken by another type. Consider the following session:
 

--- a/site/learn/tutorials/compiling_ocaml_projects.ja.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.ja.md
@@ -150,7 +150,6 @@ ocamlfind ocamlopt -o progprog -linkpkg \
 ビルドの自動化システム
 ---------------------
 
-- OCamlbuild — [en](ocamlbuild/)
-- [GNU make でのコンパイル](compiling_with_gnu_make.ja.html "GNU make でのコンパイル")
-- [OMakeでのコンパイル](compiling_with_omake.ja.html "OMake でのコンパイル")
-- Oasis — [en](setting_up_with_oasis.html)
+- [GNU make でのコンパイル](https://www.gnu.org/software/make/ "GNU make でのコンパイル")
+- [OMakeでのコンパイル](https://github.com/ocaml-omake/omake "OMake でのコンパイル")
+- Oasis — [en](https://github.com/ocaml/oasis)

--- a/site/learn/tutorials/data_types_and_matching.md
+++ b/site/learn/tutorials/data_types_and_matching.md
@@ -88,8 +88,7 @@ this type:
 Note that we use ":" in the type definition and "=" when creating
 objects of this type.
 
-Here are some examples of this typed into the
-[interactive toplevel](basics.html):
+Here are some examples of this typed into the interactive toplevel:
 
 ```ocamltop
 type pair_of_ints = {a : int; b : int};;

--- a/site/learn/tutorials/functional_programming.md
+++ b/site/learn/tutorials/functional_programming.md
@@ -129,8 +129,7 @@ write its value and type like this:
 5 : int
 ```
 But what about question 3? It looks like `plus 2` is a mistake, a bug.
-In fact, however, it isn't. If we type this into the OCaml
-[interactive toplevel](basics.html), it
+In fact, however, it isn't. If we type this into the OCaml toplevel, it
 tells us:
 
 ```ocamltop

--- a/site/learn/tutorials/if_statements_loops_and_recursion.md
+++ b/site/learn/tutorials/if_statements_loops_and_recursion.md
@@ -25,7 +25,7 @@ let max a b =
   if a > b then a else b;;
 ```
 As a short aside, if you type this into the OCaml
-[interactive toplevel](basics.html) (as above), you'll
+interactive toplevel (as above), you'll
 notice that OCaml decides that this function is polymorphic, with the
 following type:
 

--- a/site/learn/tutorials/index.de.md
+++ b/site/learn/tutorials/index.de.md
@@ -8,9 +8,7 @@
 ((! get begin_two_columns !))
 
 * [Mit OCaml in Betrieb](up_and_running.html)
-* [Die Grundlagen](basics.de.html) Sollten Sie ein Anfänger in OCaml oder
-funktionaler Programmierung sein, lesen Sie bitte dieses Kapitel
-zuerst.
+* Eine erste Stunde mit OCaml - [en](a_first_hour_with_ocaml.html)
 * Die Struktur eines OCaml-Programms — [en](structure_of_ocaml_programs.html)
 * Datentypen und Matching — [en](data_types_and_matching.html)
 * Nullpointer, Asserts und Warnungen — [en](null_pointers_asserts_and_warnings.html)

--- a/site/learn/tutorials/index.fr.md
+++ b/site/learn/tutorials/index.fr.md
@@ -6,9 +6,7 @@
 ((! get begin_two_columns !))
 
 * [Opérationnel avec OCaml](up_and_running.html)
-* [Notions de base](basics.fr.html)
-  — Si vous débutez OCaml ou la programmation fonctionnelle, lisez
-  ceci d'abord.
+* [Une première heure avec OCaml](a_first_hour_with_ocaml.html)
 * [Structure des programmes OCaml](structure_of_ocaml_programs.fr.html)
 * [Types de données et matching](data_types_and_matching.fr.html)
 * [Pointeurs nuls, asserts et warnings](null_pointers_asserts_and_warnings.fr.html)

--- a/site/learn/tutorials/index.it.md
+++ b/site/learn/tutorials/index.it.md
@@ -6,8 +6,7 @@
 ((! get begin_two_columns !))
 
 * [Funzionante con OCaml](up_and_running.html)
-* [Le basi](basics.it.html) — Se sei nuovo di OCaml o della
-  programmazione funzionale, leggi questo per primo.
+* [Una prima ora con OCaml](a_first_hour_with_ocaml.html)
 * [La struttura dei programmi OCaml](structure_of_ocaml_programs.it.html)
 * [Tipi di dati e matching](data_types_and_matching.it.html)
 * [Puntatori nulli, assert e warning](null_pointers_asserts_and_warnings.it.html)

--- a/site/learn/tutorials/index.ja.md
+++ b/site/learn/tutorials/index.ja.md
@@ -49,8 +49,6 @@
 ### ビルドシステム
 
 * [OCamlプログラムをコンパイルする](compiling_ocaml_projects.ja.html)
-* OCamlbuild — [en](ocamlbuild/)
-* OASISを使ったOCamlプロジェクトのセットアップ — [en](setting_up_with_oasis.html)
 
 ### 高度なトピックス
 

--- a/site/learn/tutorials/index.ja.md
+++ b/site/learn/tutorials/index.ja.md
@@ -12,8 +12,7 @@
 ### はじめに
 
 * [Up and Running](up_and_running.html)
-* [はじめの一歩](basics.ja.html) — 基本中の基本
-* [OCamlプログラムの構造](structure_of_ocaml_programs.ja.html)
+* [はじめの一歩](a_first_hour_with_ocaml.html) — 基本中の基本
 * [モジュール](modules.ja.html)
 * ファイル名と拡張子 - [en](filenames.html)
 * プログラミングのスタイル — [en](guidelines.html)

--- a/site/learn/tutorials/index.ko.md
+++ b/site/learn/tutorials/index.ko.md
@@ -10,8 +10,7 @@
 ((! get begin_two_columns !))
 
 * [Up and Running](up_and_running.html)
-* [기본사항](basics.ko.html) 
-* [OCaml 프로그램의 구조](structure_of_ocaml_programs.ko.html)
+* [기본사항](a_first_hour_with_ocaml.html) 
 * 모듈(Modules) - [en](modules.html)
 * 맵(Maps) (Dictionaries) - [en](map.html)
 * 셋(Sets) - [en](set.html)

--- a/site/learn/tutorials/index.zh.md
+++ b/site/learn/tutorials/index.zh.md
@@ -10,8 +10,7 @@ OCaml是一种快速、简洁、而强大的应用程序开发语言－－我想
 ((! get begin_two_columns !))
 
 * [Up and Running](up_and_running.html)
-* [基础](basics.zh.html) — 如果你是OCaml或函数式语言的初学者请先阅读本节。
-* [Ocaml程序的结构](structure_of_ocaml_programs.zh.html)
+* [基础](a_first_hour_with_ocaml.html)
 * [模块](modules.zh.html)
 * [Maps (映射，字典)](map.zh.html)
 * [Sets 集合](set.zh.html)

--- a/site/learn/tutorials/introduction_to_gtk.md
+++ b/site/learn/tutorials/introduction_to_gtk.md
@@ -5,7 +5,7 @@
 # Introduction to Gtk
 
 If you intend to try the code in this tutorial in the
-[interactive toplevel](basics.html), you
+interactive toplevel, you
 must first issue (assuming you have installed `lablgtk` using
 [opam](../../docs/install.html)):
 

--- a/site/learn/tutorials/labels.md
+++ b/site/learn/tutorials/labels.md
@@ -91,7 +91,7 @@ The `may` function as a whole returns `unit`. Notice in each case of the
 `match` the result is `()`.
 
 Thus the type of the `may` function is (and you can verify this in the
-OCaml [interactive toplevel](basics.html) if you want):
+OCaml interactive toplevel if you want):
 
 ```ocaml
 may : f:('a -> 'b) -> 'a option -> unit


### PR DESCRIPTION
This PR removes or replaces references to now-deleted (https://github.com/ocaml/ocaml.org/pull/1419) tutorials, mostly in the translations.