### PR TITLE
2020 workshop videos

### DIFF
--- a/site/community/media.md
+++ b/site/community/media.md
@@ -36,32 +36,6 @@ Wallace](http://vimeo.com/user2191865) on [Vimeo](http://vimeo.com).
 
 ## 2020 OCaml workshop
 
-Videos about 2020 OCaml workshop can be found on [youtube](https://www.youtube.com/playlist?list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f).
-
-Keynote session about [OCaml platform](https://www.youtube.com/watch?v=E8T_4zqWmq8&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=1) plans for 2020-21 with a clear roadmap are well presented by Anil Madhavapeddy.
-
-Thomas Leonard explains [OCaml-Cl: A zero configuration Cl](https://www.youtube.com/watch?v=HjcCUZ9i-ug&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=2) which is a service for OCaml projects. 
-
-[The final pieces of the OCaml documentation puzzle](https://www.youtube.com/watch?v=wVyZ-KveN-w&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=3), Jonathan Ludlam.
-
-Joseph Harrison and Steven Varoumas talk about their experience in using an automatic [API migration](https://www.youtube.com/watch?v=y6RKnOu4i74&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=4).
-
-Sadiq Jaffer talks about [Parallelising your OCaml Code with Multicore OCaml](https://www.youtube.com/watch?v=Z7YZR1q8wzI&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=5) in detail with a QnA session with  Sudha Parimala,  KC Sivaramakrishnan and  Anil Madhavapeddy.
-
-Jan Midtgaard expalins [A Simple State-Machine Framework for Property-Based Testing in OCaml](https://www.youtube.com/watch?v=uuL9RYuaZV4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=6).
-
-Tom Ridge talks about new OCaml filesystem, [The ImpFS filesystem](https://www.youtube.com/watch?v=wwzbSeiXbno&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=7) and realted libraries.
-
-Ioana CristescuI, [Irmin v2](https://www.youtube.com/watch?v=v1lfMUM332w&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=8): an OCaml library for building distributed databases with the same design principles as Git.
-
-Markus Mottl presents [AD-OCaml: Algorithmic Differentiation for OCaml](https://www.youtube.com/watch?v=KUVHbVS-PN4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=9).
-
-Sebastien Mondet presents [OCaml Under The Hood: SmartPy](https://www.youtube.com/watch?v=z8YN2oT2gGY&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=10) project.
-
-Eelco Visser, Eduardo Amorim present [A Declarative Syntax Definition for OCaml](https://www.youtube.com/watch?v=SgP4GlWuUr4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=11).
-
-Patrik Keller, Marc Lasson present about the use of [LexiFi Runtime Types](https://www.youtube.com/watch?v=0BpmxJGaaFo&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=12).
-
-Paul Steckler, Matthew Ryan talk about [Types in amber](https://www.youtube.com/watch?v=jroMKd7MzT4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=13).
+Videos about 2020 OCaml workshop can be found on [OCaml 2020](../meetings/ocaml/2020/index.html).
 
 

--- a/site/community/media.md
+++ b/site/community/media.md
@@ -34,4 +34,34 @@ outperform the competition in the financial world.
 Framework](http://vimeo.com/6652523) from [Malcolm
 Wallace](http://vimeo.com/user2191865) on [Vimeo](http://vimeo.com).
 
+## 2020 OCaml workshop
+
+Videos about 2020 OCaml workshop can be found on [youtube](https://www.youtube.com/playlist?list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f).
+
+Keynote session about [OCaml platform](https://www.youtube.com/watch?v=E8T_4zqWmq8&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=1) plans for 2020-21 with a clear roadmap are well presented by Anil Madhavapeddy.
+
+Thomas Leonard explains [OCaml-Cl: A zero configuration Cl](https://www.youtube.com/watch?v=HjcCUZ9i-ug&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=2) which is a service for OCaml projects. 
+
+[The final pieces of the OCaml documentation puzzle](https://www.youtube.com/watch?v=wVyZ-KveN-w&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=3), Jonathan Ludlam.
+
+Joseph Harrison and Steven Varoumas talk about their experience in using an automatic [API migration](https://www.youtube.com/watch?v=y6RKnOu4i74&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=4).
+
+Sadiq Jaffer talks about [Parallelising your OCaml Code with Multicore OCaml](https://www.youtube.com/watch?v=Z7YZR1q8wzI&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=5) in detail with a QnA session with  Sudha Parimala,  KC Sivaramakrishnan and  Anil Madhavapeddy.
+
+Jan Midtgaard expalins [A Simple State-Machine Framework for Property-Based Testing in OCaml](https://www.youtube.com/watch?v=uuL9RYuaZV4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=6).
+
+Tom Ridge talks about new OCaml filesystem, [The ImpFS filesystem](https://www.youtube.com/watch?v=wwzbSeiXbno&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=7) and realted libraries.
+
+Ioana CristescuI, [Irmin v2](https://www.youtube.com/watch?v=v1lfMUM332w&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=8): an OCaml library for building distributed databases with the same design principles as Git.
+
+Markus Mottl presents [AD-OCaml: Algorithmic Differentiation for OCaml](https://www.youtube.com/watch?v=KUVHbVS-PN4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=9).
+
+Sebastien Mondet presents [OCaml Under The Hood: SmartPy](https://www.youtube.com/watch?v=z8YN2oT2gGY&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=10) project.
+
+Eelco Visser, Eduardo Amorim present [A Declarative Syntax Definition for OCaml](https://www.youtube.com/watch?v=SgP4GlWuUr4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=11).
+
+Patrik Keller, Marc Lasson present about the use of [LexiFi Runtime Types](https://www.youtube.com/watch?v=0BpmxJGaaFo&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=12).
+
+Paul Steckler, Matthew Ryan talk about [Types in amber](https://www.youtube.com/watch?v=jroMKd7MzT4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=13).
+
 

--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -5360,7 +5360,10 @@ body {
 #nav-secondary {
   padding-top: 52px;
   padding-bottom: 52px;
-  overflow: hidden;
+  top: 0;
+  position: fixed;
+  z-index: 1;
+  overflow-x: hidden;
 }
 #content-primary {
   padding-bottom: 28px;

--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -5359,12 +5359,14 @@ body {
 }
 #nav-secondary {
   padding-top: 52px;
-  padding-bottom: 52px;
   top: 0;
   position: fixed;
   z-index: 1;
   overflow-x: hidden;
+  height: 250px;
+  width: 300px;
 }
+
 #content-primary {
   padding-bottom: 28px;
 }

--- a/site/meetings/ocaml/2020/index.md
+++ b/site/meetings/ocaml/2020/index.md
@@ -94,6 +94,24 @@ Organizing Comittee
 - Daniel Tornabene
 - Shiwei Weng
 
+2020 OCaml workshop
+--------------------
+
+- Videos about 2020 OCaml workshop can be found on [_youtube_](https://www.youtube.com/playlist?list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f).
+- Keynote session about [_OCaml platform_](https://www.youtube.com/watch?v=E8T_4zqWmq8&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=1) plans for 2020-21 with a clear roadmap are well presented by Anil Madhavapeddy.
+- Thomas Leonard explains [_OCaml-Cl: A zero configuration Cl_](https://www.youtube.com/watch?v=HjcCUZ9i-ug&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=2) which is a service for OCaml projects. 
+- [_The final pieces of the OCaml documentation puzzle_](https://www.youtube.com/watch?v=wVyZ-KveN-w&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=3), Jonathan Ludlam.
+- Joseph Harrison and Steven Varoumas talk about their experience in using an automatic [_API migration_](https://www.youtube.com/watch?v=y6RKnOu4i74&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=4).
+- Sadiq Jaffer talks about [_Parallelising your OCaml Code with Multicore OCaml_](https://www.youtube.com/watch?v=Z7YZR1q8wzI&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=5) in detail with a QnA session with  Sudha Parimala,  KC Sivaramakrishnan and  Anil Madhavapeddy.
+- Jan Midtgaard expalins [_A Simple State-Machine Framework for Property-Based Testing in OCaml_](https://www.youtube.com/watch?v=uuL9RYuaZV4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=6).
+- Tom Ridge talks about new OCaml filesystem, [_The ImpFS filesystem_](https://www.youtube.com/watch?v=wwzbSeiXbno&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=7) and realted libraries.
+- Ioana CristescuI, [_Irmin v2_](https://www.youtube.com/watch?v=v1lfMUM332w&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=8): an OCaml library for building distributed databases with the same design principles as Git.
+- Markus Mottl presents [_AD-OCaml: Algorithmic Differentiation for OCaml_](https://www.youtube.com/watch?v=KUVHbVS-PN4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=9).
+- Sebastien Mondet presents [_OCaml Under The Hood: SmartPy_](https://www.youtube.com/watch?v=z8YN2oT2gGY&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=10) project.
+- Eelco Visser, Eduardo Amorim present [_A Declarative Syntax Definition for OCaml_](https://www.youtube.com/watch?v=SgP4GlWuUr4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=11).
+- Patrik Keller, Marc Lasson present about the use of [_LexiFi Runtime Types_](https://www.youtube.com/watch?v=0BpmxJGaaFo&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=12).
+- Paul Steckler, Matthew Ryan talk about [_Types in amber](https://www.youtube.com/watch?v=jroMKd7MzT4&list=PLKO_ZowsIOu5fHjRj0ua7_QWE_L789K_f&index=13).
+
 Questions and contact
 ---------------------
 


### PR DESCRIPTION
# Issue Description
On the media page, there are a couple of videos about OCaml, most of them rather old though.

Fixes #1311

## Changes Made
Added a new subsection called "2020 OCaml workshop", which contains a link to each video and a short explanation about it such as the name of the talk, the name of the speaker(s), and the abstract. 

![Screenshot from 2021-04-10 14-59-59](https://user-images.githubusercontent.com/26017359/114265264-76019680-9a0d-11eb-9cb8-986c87b1ec01.png)

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
