### PR TITLE
Responsive learn page fixes #1374

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -249,6 +249,47 @@ h4.news img.rss {
   border-bottom: 1px #ACACAC solid;
 }
 
+/*Learn section styling*/
+.learn-section{
+  padding: 3em 0;
+}
+
+@media (min-width: 1200px){
+  .learn-section{
+    width: 370px;
+    margin-left: 30px;
+    float: left;
+  }
+}
+
+@media (min-width: 992px) and (max-width: 1199px){
+  #success-story p:nth-child(3), #success-story p:nth-child(4){
+    margin-top: 70px;
+  }
+  .learn-section{
+    width: 300px;
+    margin-left: 20px;
+    float: left;
+  }
+}
+
+@media (max-width: 991px){
+  .learn-section{
+    width: 100%;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 991px){
+  #success-story p:nth-child(3), #success-story p:nth-child(4){
+    margin-top: 40px;
+  }
+  .learn-section{
+    margin-left: 10px;
+    float: left;
+  }
+}
+
+
 /* Edit buttom, right of the navbar. */
 a.edit-this-page {
   margin-top: 22.5px;

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -33,7 +33,7 @@
 		   >Rosetta</a>.</p>
             </footer>
         </section>
-        <section class="span4 condensed">
+        <section class="learn-section condensed">
             <h1 class="ruled"><a href="tutorials/">Tutorials</a> &amp; <a href="faq.html">FAQ</a></h1>
             <ul>
                 <li><a href="tutorials/up_and_running.html">Up and Running</a></li>
@@ -49,7 +49,7 @@
                 <p><a href="tutorials/">See full list</a></p>
             </footer>
         </section>
-        <section class="span4 condensed">
+        <section class="learn-section condensed">
             <h1 class="ruled"><a href="books.html">Books</a></h1>
                 <a href="https://realworldocaml.org"><img style="float:
                 left; margin-right: 2px; margin-bottom: 10px"
@@ -68,7 +68,7 @@
         </section>
     </div>
     <div class="row">
-        <section class="span4 condensed">
+        <section class="learn-section condensed">
           <h1 class="ruled"><a href="/community/media.html">Online Courses, Slides &amp; Videos</a></h1>
 
 <iframe title="A massive open online course on OCaml" frameborder="0" width="380" height="220" src="//www.dailymotion.com/embed/video/x2ymo3x" style="max-width: 100%;" allowfullscreen></iframe><br /><a href="//www.dailymotion.com/video/x2ymo3x_fun-mooc-introduction-to-functional-programming-in-ocaml_school" target="_blank" rel="noopener"> A massive open online course (MOOC) entirely centered around OCaml</a> <i>is now available, and runs once a year!</i>
@@ -99,7 +99,7 @@
               <a href="/community/media.html">See more slides and videos</a></p>
           </footer>
         </section>
-        <section class="span4 condensed">
+        <section class="learn-section condensed" id="success-story">
           <h1 class="ruled"><a href="companies.html">Industrial
           Users</a></h1> <p><a href="http://janestreet.com"><img style="float:
           left; margin-right: 10px; margin-bottom: 10px"


### PR DESCRIPTION
# Issue Description

The spacing of the learn landing page sections on tablet and mobile is quite tight. This affects the legibility of different sections and blocks of text.

Fixes #1374 

## Changes Made

A class was created to handle the sizing of the sections of the learn page on different screen sizes using media queries. The class handling this before was used on too many elements to be edited without breaking things.

The initial intention was  to create a two-column layout but due to the structure of the html and in order to improve the layout with minimal changes, a single column layout on tablets was what was feasible

Here is the page on an iPad before the change was made:

![](https://user-images.githubusercontent.com/38317939/113411944-fc373080-93ae-11eb-9a8e-3f245d39a34e.JPG)


And the page after the change:

![changed](https://user-images.githubusercontent.com/38317939/114282602-bfb5a580-9a3c-11eb-8074-4f64811aa335.JPG)


I tested the changes using a browser's device emulator on different screen sizes

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
