### PR TITLE
Makes entire newsfeed list item lead to its respective article when clicked on fixes #1499

### DIFF
--- a/site/css/bootstrap_mod.css
+++ b/site/css/bootstrap_mod.css
@@ -144,3 +144,13 @@ html.svg .news-feed li {
 html.svg .news-feed li.announcement {
   background-image: url(../img/announcement-go.svg);
 }
+
+/* for improved-news-feed.js - ozmos */
+.news-feed li {
+  cursor: pointer;
+}
+
+.news-feed li:hover, .news-feed li:focus {
+  border-bottom: 1px solid #df533b;
+  color:#df533b;
+}

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -636,3 +636,19 @@ html.svg img.svg { display: inline; }
 html.svg img.png { display: none; }
 
 .brand img.svg { width: 131px;  height: 36px; }
+
+/* improved-news-feed.js */
+
+.news-feed li {
+  cursor: pointer;
+}
+
+.news-feed li:hover {
+  border-bottom: 1px solid #df533b;
+  color:#df533b;
+}
+
+.is-hovered {
+  color:#df533b;
+  text-decoration: underline;
+}

--- a/site/index.md
+++ b/site/index.md
@@ -108,19 +108,18 @@
 			  <h1><a title="OCaml Users and Developers Workshop"
 			       href="/meetings/ocaml/2020/">OCaml 2020</a></h1>
 			  <p>August 28, 2020</p>
-			  <a title="OCaml Users and Developers Workshop"
-			     href="/meetings/ocaml/2020/">
+              <a title="OCaml Users and Developers Workshop"
+		     href="/meetings/ocaml/2020/">
 			    <img alt="" src="/img/announcement.svg" class="svg" />
 			    <img alt="" src="/img/announcement.png" class="png" />
-			  </a>
+                </a>
 			</article></li>
 			<li class="announcement"><article>
 			  <h1><a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
-			       href="/releases/{{! get LATEST_OCAML_VERSION !}}.html"
-				   >Release of OCaml {{! get LATEST_OCAML_VERSION !}}</a></h1>
+			       href="/releases/{{! get LATEST_OCAML_VERSION !}}.html">Release of OCaml {{! get LATEST_OCAML_VERSION !}}</a></h1>
 			   <p>February 24, 2021</p>
-			   <a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
-			      href="/releases/{{! get LATEST_OCAML_VERSION !}}.html">
+               <a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
+		      href="/releases/{{! get LATEST_OCAML_VERSION !}}.html">
 			    <img alt="" src="/img/announcement.svg" class="svg" />
 			    <img alt="" src="/img/announcement.png" class="png" />
 			  </a>
@@ -129,7 +128,7 @@
 			  <h1><a title="OCaml Weekly News"
 			       href="/community/cwn/" >OCaml Weekly News</a></h1>
 			   <p>{{! cmd script/weekly_news --date !}}</p>
-			   <a title="OCaml Weekly News" href="/community/cwn/">
+               <a title="OCaml Weekly News" href="/community/cwn/">
 			    <img alt="" src="/img/announcement.svg" class="svg" />
 			    <img alt="" src="/img/announcement.png" class="png" />
 			  </a>

--- a/site/js/improved-news-feed.js
+++ b/site/js/improved-news-feed.js
@@ -1,0 +1,34 @@
+/* Makes all newsfeed list items lead to their respective articles when clicked on */
+
+(function () {
+    
+    var feeds = Array.from(document.getElementsByClassName('news-feed'))
+    .map(el => Array.from(el.children));
+
+    function getHref(listItem) {
+        return listItem.firstChild.querySelector('a').href;
+    }
+
+    function link(url) {
+        window.location.href = url;
+    }
+
+    function addLinks(arr) {
+        arr.forEach(el => {
+            // add linking behaviour
+            el.addEventListener('click', function() {
+                link(getHref(el));
+            });
+            // trigger hover effects for link
+            el.addEventListener('mouseover', function() {
+                el.firstChild.querySelector('a').classList.add('is-hovered');
+            });
+            // remove hover effects
+            el.addEventListener('mouseout', function() {
+                el.firstChild.querySelector('a').classList.remove('is-hovered');
+            });
+        });
+    }
+
+    feeds.forEach(feed => addLinks(feed));
+})();

--- a/template/main.mpp
+++ b/template/main.mpp
@@ -137,6 +137,6 @@
 		      style="border:0;" alt="" /></p></noscript>
     <!-- End Piwik Code -->
     S!}} <!-- ifndef staging -->
-
+    <script language='javascript' type='text/javascript' src="js/improved-news-feed.js"></script>
   </body>
 </html>


### PR DESCRIPTION
# Issue Description

News feed was slightly confusing as some of the elements within each feed item were not linked to the corresponding article.  

Fixes # 1499

## Changes Made

I used javascript to make the entire list item lead to the corresponding news article when clicked on.  I also added hover effects to make it more apparent that the whole item could be clicked on.

I initially tried to alter the markup in *index.md*, wrapping the whole list item in an `a` tag and removing the nested anchor elements.  Unfortunately when the markdown compiled it closed the anchor tag before the list item started, rendering the link unusable.  Thus I had to resort to using javascript to resolve the issue

### Before changes:
![news-before](https://user-images.githubusercontent.com/39433568/114291406-ac94eb00-9ab9-11eb-9c93-a6ee4e1300ff.png)
Clicking on the arrow or anywhere other than the icon or `h1` link doesn't lead to article

### After changes:
![news-after](https://user-images.githubusercontent.com/39433568/114291429-f2ea4a00-9ab9-11eb-9beb-5501e321421a.png)
Clicking anywhere on the list item leads to the corresponding article.  Hovering over list item triggers color changes to highlight 'clickability'.


