### PR TITLE
 Improvement Home/release pages by adding ToC on all pages

### DIFF
--- a/site/releases/3.12.1.md
+++ b/site/releases/3.12.1.md
@@ -1,5 +1,5 @@
 <!-- ((! set title OCaml 3.12.1 !)) -->
-
+*Table of contents*
 # OCaml 3.12.1
 **License**<br />
  The OCaml system is open source software: the compiler is distributed

--- a/site/releases/4.00.1.md
+++ b/site/releases/4.00.1.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.00.1 !)) -->
+*Table of contents*
 
 # OCaml 4.00.1
 **License**<br />

--- a/site/releases/4.01.0.md
+++ b/site/releases/4.01.0.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.01.0 !)) -->
+*Table of contents*
 
 # OCaml 4.01.0
 **License**<br />

--- a/site/releases/4.02.md
+++ b/site/releases/4.02.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.02 !)) -->
+*Table of contents*
 
 # OCaml 4.02.3
 This page describes OCaml version **4.02.3**,

--- a/site/releases/4.03.md
+++ b/site/releases/4.03.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.03 !)) -->
+*Table of contents*
 
 # OCaml 4.03.0
 This page describes OCaml version **4.03.0**, released on

--- a/site/releases/4.04.md
+++ b/site/releases/4.04.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.04 !)) -->
+*Table of contents*
 
 # OCaml 4.04.2
 This page describes OCaml version **4.04.2**, released on

--- a/site/releases/4.05.md
+++ b/site/releases/4.05.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.05 !)) -->
+*Table of contents*
 
 # OCaml 4.05.0
 This page describes OCaml version **4.05.0**, released on

--- a/site/releases/4.06.1.md
+++ b/site/releases/4.06.1.md
@@ -1,5 +1,5 @@
 <!-- ((! set title OCaml 4.06.1 !)) -->
-
+*Table of contents*
 # OCaml 4.06.1
 
 This page describe OCaml **4.06.1**, released on Feb 16, 2018.  It is

--- a/site/releases/4.06.md
+++ b/site/releases/4.06.md
@@ -1,5 +1,5 @@
 <!-- ((! set title OCaml 4.06 !)) -->
-
+*Table of contents*
 # OCaml 4.06.0
 This page describes OCaml version **4.06.0**, released on
 2017-11-03.  Go [here](./) for a list of all releases.

--- a/site/releases/4.07.0.md
+++ b/site/releases/4.07.0.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.07.0 !)) -->
+*Table of contents*
 
 # OCaml 4.07.0
 This page describes OCaml version **4.07.0**, released on

--- a/site/releases/4.07.1.md
+++ b/site/releases/4.07.1.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.07.1 !)) -->
+*Table of contents*
 
 # OCaml 4.07.1
 This page describes OCaml version **4.07.1**, released on

--- a/site/releases/4.08.0.md
+++ b/site/releases/4.08.0.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.08.0 !)) -->
+*Table of contents*
 
 # OCaml 4.08.0
 This page describes OCaml version **4.08.0**, released on

--- a/site/releases/4.08.1.md
+++ b/site/releases/4.08.1.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.08.1 !)) -->
+*Table of contents*
 
 # OCaml 4.08.1
 

--- a/site/releases/4.09.0.md
+++ b/site/releases/4.09.0.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.09.0 !)) -->
+*Table of contents*
 
 # OCaml 4.09.0
 This page describes OCaml version **4.09.0**, released on

--- a/site/releases/4.09.1.md
+++ b/site/releases/4.09.1.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.09.1 !)) -->
+*Table of contents*
 
 # OCaml 4.09.1
 

--- a/site/releases/4.10.0.md
+++ b/site/releases/4.10.0.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.10.0 !)) -->
+*Table of contents*
 
 # OCaml 4.10.0
 This page describes OCaml version **4.10.0**, released on

--- a/site/releases/4.10.1.md
+++ b/site/releases/4.10.1.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.10.1 !)) -->
+*Table of contents*
 
 # OCaml 4.10.1
 

--- a/site/releases/4.10.2.md
+++ b/site/releases/4.10.2.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.10.2 !)) -->
+*Table of contents*
 
 # OCaml 4.10.2
 

--- a/site/releases/4.11.0.md
+++ b/site/releases/4.11.0.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.11.0 !)) -->
+*Table of contents*
 
 # OCaml 4.11.0
 This page describes OCaml version **4.11.0**, released on

--- a/site/releases/4.11.1.md
+++ b/site/releases/4.11.1.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.11.1 !)) -->
+*Table of contents*
 
 # OCaml 4.11.1
 

--- a/site/releases/4.11.2.md
+++ b/site/releases/4.11.2.md
@@ -1,4 +1,5 @@
 <!-- ((! set title OCaml 4.11.2 !)) -->
+*Table of contents*
 
 # OCaml 4.11.2
 

--- a/site/releases/4.12.0.md
+++ b/site/releases/4.12.0.md
@@ -1,5 +1,6 @@
 <!-- ((! set title OCaml 4.12.0 !)) -->
-
+ *Table of contents*
+ 
 # OCaml 4.12.0
 This page describes OCaml version **4.12.0**, released on
 2021-02-24.  Go [here](./) for a list of all releases.


### PR DESCRIPTION
# Issue Description
fixes issue #1460
Please include a summary of the issue.

- Added ToC (content table) to all release pages on Home/Release so that users can easily navigate through the sections on the page.

Fixes # (issue)
Fixes #1460
## Changes Made
**Before**
![Screenshot from 2021-04-12 12-55-58](https://user-images.githubusercontent.com/57635473/114361554-e0444380-9b93-11eb-90eb-e5f138fda124.png)
**After**
![Screenshot from 2021-04-12 12-56-47](https://user-images.githubusercontent.com/57635473/114361598-ea664200-9b93-11eb-9fa2-6ec59411253e.png)



* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
