### PR TITLE
Improves Tutorial Bottom Navigation

### DIFF
--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -271,6 +271,12 @@ a:focus {
 .navbar-fixed-bottom .container {
   width: 940px;
 }
+.bottom-navigation .previous {
+  float: left;
+}
+.bottom-navigation .next {
+  float: right;
+}
 .span12 {
   width: 940px;
 }

--- a/site/learn/tutorials/99problems.md
+++ b/site/learn/tutorials/99problems.md
@@ -3170,3 +3170,7 @@ way of placing words onto sites.
 ```ocaml
 (* example pending *);;
 ```
+
+<div class="bottom-navigation">
+<a href = "format.html" class="previous">« Formatting and Wrapping Text</a><a href="introduction_to_gtk.html" class="next">Introduction to Gtk »</a>
+</div>

--- a/site/learn/tutorials/a_first_hour_with_ocaml.md
+++ b/site/learn/tutorials/a_first_hour_with_ocaml.md
@@ -891,3 +891,7 @@ This quick tour should have given you a little taste of OCaml and why you might
 like to explore it further. Elsewhere on [ocaml.org](/index.html) there are
 pointers to [books on OCaml](/learn/books.html) and
 [other tutorials](/learn/tutorials/index.html).
+
+<div class="bottom-navigation">
+<a href = "up_and_running.html" class="previous">« Up and Running</a><a href="guidelines.html" class="next">OCaml Programming Guidelines »</a>
+</div>

--- a/site/learn/tutorials/calling_c_libraries.md
+++ b/site/learn/tutorials/calling_c_libraries.md
@@ -395,3 +395,7 @@ In order for it to get passed to OCaml code at all, we must somehow
 convert it to a `value`. Luckily we can quite easily use the C API to
 create `value` blocks which the OCaml garbage collector *won't* examine
 too closely ......
+
+<div class="bottom-navigation">
+<a href = "file_manipulation.html" class="previous">« File Manipulation</a><a href="calling_fortran_libraries.html" class="next">Calling Fortran Libraries »</a>
+</div>

--- a/site/learn/tutorials/calling_fortran_libraries.md
+++ b/site/learn/tutorials/calling_fortran_libraries.md
@@ -143,3 +143,7 @@ let some else help out (or wait until I learn how to do it).
 prompt> ocamlc -c gtd6.ml prompt> ocamlc -o test gtd6.cmo wrapper.so
 ```
 And voila, we've called the fortran function from OCaml.
+
+<div class="bottom-navigation">
+<a href = "calling_c_libraries.html" class="previous">« Calling C Libraries</a><a href="garbage_collection.html" class="next">Garbage Collection »</a>
+</div>

--- a/site/learn/tutorials/command-line_arguments.md
+++ b/site/learn/tutorials/command-line_arguments.md
@@ -50,3 +50,7 @@ without having to scan the `Sys.argv` array yourself:
 * [Getopt](https://opam.ocaml.org/packages/getopt/)
   for OCaml is similar to [GNU
   getopt](http://www.gnu.org/software/libc/manual/html_node/Getopt.html).
+
+<div class="bottom-navigation">
+<a href = "introduction_to_gtk.html" class="previous">« Introduction to Gtk</a><a href="file_manipulation.html" class="next">File Manipulation »</a>
+</div>

--- a/site/learn/tutorials/common_error_messages.md
+++ b/site/learn/tutorials/common_error_messages.md
@@ -188,3 +188,7 @@ option.
 "\e\n" (* bad practice *);;
 "\\e\n" (* good practice *);;
 ```
+
+<div class="bottom-navigation">
+<a href = "error_handling.html" class="previous">« Error Handling</a><a href="debug.html" class="next">Debugging »</a>
+</div>

--- a/site/learn/tutorials/comparison_of_standard_containers.md
+++ b/site/learn/tutorials/comparison_of_standard_containers.md
@@ -96,3 +96,7 @@ element doesn't create a new stack but simply adds it to the stack.
 * adding an element: O(1)
 * taking an element: O(1)
 * length: O(1)
+
+<div class="bottom-navigation">
+<a href = "hashtbl.html" class="previous">« Hash Tables</a><a href="format.html" class="next">Formatting and Wrapping Text »</a>
+</div>

--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -145,3 +145,7 @@ necessary. See next section.
 - [OMake](https://github.com/ocaml-omake/omake) Another OCaml build system.
 - [GNU make](https://www.gnu.org/software/make/) GNU make can build anything, including OCaml. May be used in conjunction with [OCamlmakefile](https://github.com/mmottl/ocaml-makefile)
 - [Oasis](https://github.com/ocaml/oasis) Generates configure, build, and install system using another build system.
+
+<div class="bottom-navigation">
+<a href = "guidelines.html" class="previous">« OCaml Programming Guidelines</a><a href="data_types_and_matching.html" class="next">Data Types and Matching »</a>
+</div>

--- a/site/learn/tutorials/data_types_and_matching.md
+++ b/site/learn/tutorials/data_types_and_matching.md
@@ -431,3 +431,7 @@ was not handled.
 
 Exercise: Extend the pattern matching with a `Product` case so
 `to_string` compiles without warning.
+
+<div class="bottom-navigation">
+<a href = "compiling_ocaml_projects.html" class="previous">« Compiling OCaml Projects</a><a href="functional_programming.html" class="next">Functional Programming »</a>
+</div>

--- a/site/learn/tutorials/debug.md
+++ b/site/learn/tutorials/debug.md
@@ -276,3 +276,7 @@ Under Emacs you call the debugger using `ESC-x` `ocamldebug a.out`. Then Emacs
 will send you directly to the file and character reported by the debugger, and
 you can step back and forth using `ESC-b` and `ESC-s`, you can set up break
 points using `CTRL-X space`, and so on...
+
+<div class="bottom-navigation">
+<a href = "common_error_messages.html" class="previous">« Common Error Messages</a><a href="map.html" class="next">Maps »</a>
+</div>

--- a/site/learn/tutorials/error_handling.md
+++ b/site/learn/tutorials/error_handling.md
@@ -154,3 +154,7 @@ are:
 
 For easy combination of functions that can fail, many alternative standard
 libraries provide useful combinators on the `result` type: `map`, `>>=`, etc.
+
+<div class="bottom-navigation">
+<a href = "objects.html" class="previous">« Objects</a><a href="common_error_messages.html" class="next">Common Error Messages »</a>
+</div>

--- a/site/learn/tutorials/file_manipulation.md
+++ b/site/learn/tutorials/file_manipulation.md
@@ -103,3 +103,7 @@ let () =
   
   (* normal exit: all channels are flushed and closed *)
 ```
+
+<div class="bottom-navigation">
+<a href = "command-line_arguments.html" class="previous">« Command-Line Arguments</a><a href="calling_c_libraries.html" class="next">Calling C Libraries »</a>
+</div>

--- a/site/learn/tutorials/format.md
+++ b/site/learn/tutorials/format.md
@@ -416,3 +416,7 @@ or `stderr` is just a matter of partial application:
 let print_lambda = pr_lambda std_formatter
 let eprint_lambda = pr_lambda err_formatter
 ```
+
+<div class="bottom-navigation">
+<a href = "comparison_of_standard_containers.html" class="previous">« Comparison of Standard Containers</a><a href="99problems.html" class="next">99 Problems(solved) in OCaml »</a>
+</div>

--- a/site/learn/tutorials/functional_programming.md
+++ b/site/learn/tutorials/functional_programming.md
@@ -431,3 +431,7 @@ let print_string = output_string stdout
 `output_string` takes two arguments (a channel and a string), but since
 we have only supplied one, it is partially applied. So `print_string` is
 a function, expecting one string argument.
+
+<div class="bottom-navigation">
+<a href = "data_types_and_matching.html" class="previous">« Data Types and Matching</a><a href="if_statements_loops_and_recursion.html" class="next">If Statements, Loops, and Recursion »</a>
+</div>

--- a/site/learn/tutorials/functors.md
+++ b/site/learn/tutorials/functors.md
@@ -87,3 +87,7 @@ the source files
 [`set.ml`](https://github.com/ocaml/ocaml/blob/trunk/stdlib/set.ml) or
 [`map.ml`](https://github.com/ocaml/ocaml/blob/trunk/stdlib/map.ml) of the
 standard library.
+
+<div class="bottom-navigation">
+<a href = "null_pointers_asserts_and_warnings.html" class="previous">« Null Pointers, Asserts, and Warnings</a><a href="objects.html" class="next">Objects »</a>
+</div>

--- a/site/learn/tutorials/garbage_collection.md
+++ b/site/learn/tutorials/garbage_collection.md
@@ -349,3 +349,7 @@ increasing order of difficulty:
 1. Make the underlying file representation a **DBM-style hash**.
 1. Provide a general-purpose cache fronting a "users" table in your
  choice of **relational database** (with locking).
+
+<div class="bottom-navigation">
+<a href = "calling_fortran_libraries.html" class="previous">« Calling Fortran Libraries</a><a href="performance_and_profiling.html" class="next">Performance and Profiling »</a>
+</div>

--- a/site/learn/tutorials/guidelines.md
+++ b/site/learn/tutorials/guidelines.md
@@ -1721,4 +1721,7 @@ as the imperative program with the additional clarity and natural
 look of an algorithm that performs pattern matching and recursive
 calls to handle an argument that belongs to a recursive sum data type.
 
+<div class="bottom-navigation">
+<a href = "a_first_hour_with_ocaml.html" class="previous">« A First Hour with OCaml</a><a href="compiling_ocaml_projects.html" class="next">Compiling OCaml Projects »</a>
+</div>
 

--- a/site/learn/tutorials/hashtbl.md
+++ b/site/learn/tutorials/hashtbl.md
@@ -89,3 +89,7 @@ entry in `my_hash` for a letter we would do:
 ```ocamltop
 Hashtbl.mem my_hash "h"
 ```
+
+<div class="bottom-navigation">
+<a href = "set.html" class="previous">« Sets</a><a href="comparison_of_standard_containers.html" class="next">Comparison of Standard Containers »</a>
+</div>

--- a/site/learn/tutorials/if_statements_loops_and_recursion.md
+++ b/site/learn/tutorials/if_statements_loops_and_recursion.md
@@ -1109,3 +1109,7 @@ and odd n =
 You can also
 use similar syntax for writing mutually recursive class definitions and
 modules.
+
+<div class="bottom-navigation">
+<a href = "functional_programming.html" class="previous">« Functional Programming</a><a href="modules.html" class="next">Modules »</a>
+</div>

--- a/site/learn/tutorials/introduction_to_gtk.md
+++ b/site/learn/tutorials/introduction_to_gtk.md
@@ -663,3 +663,7 @@ List.map (fun w -> m#find w) c#children;;
 * Lablgtk provides two ways to perform downcasting, but this doesn't
  change the fact that downcasting is unsafe and can throw exceptions
  at runtime.
+
+<div class="bottom-navigation">
+<a href = "99problems.html" class="previous">« 99 Problems(solved) in OCaml</a><a href="command-line_arguments.html" class="next">Command-Line Arguments »</a>
+</div>

--- a/site/learn/tutorials/labels.md
+++ b/site/learn/tutorials/labels.md
@@ -532,3 +532,7 @@ reduction in type safety, it is recommended that you don't use these in
 your code. You will, however, see them in advanced OCaml code quite a
 lot precisely because advanced programmers will sometimes want to weaken
 the type system to write advanced idioms.
+
+<div class="bottom-navigation">
+<a href = "modules.html" class="previous">« Modules</a><a href="pointers.html" class="next">Pointers in OCaml »</a>
+</div>

--- a/site/learn/tutorials/map.md
+++ b/site/learn/tutorials/map.md
@@ -70,4 +70,8 @@ MyUsers.find "fred" m;;
 ```
 This should quickly and efficiently return Fred's password: "sugarplums".
 
+<div class="bottom-navigation">
+<a href = "debug.html" class="previous">« Debugging</a><a href="set.html" class="next">Sets »</a>
+</div>
+
 

--- a/site/learn/tutorials/modules.md
+++ b/site/learn/tutorials/modules.md
@@ -304,3 +304,7 @@ open Extensions
 
 List.optmap ...
 ```
+
+<div class="bottom-navigation">
+<a href = "if_statements_loops_and_recursion.html" class="previous">« If Statements, Loops, and Recursion</a><a href="labels.html" class="next">Labels »</a>
+</div>

--- a/site/learn/tutorials/null_pointers_asserts_and_warnings.md
+++ b/site/learn/tutorials/null_pointers_asserts_and_warnings.md
@@ -133,3 +133,7 @@ let () =
   done;
   ignore(read_line ())
 ```
+
+<div class="bottom-navigation">
+<a href = "pointers.html" class="previous">« Pointers</a><a href="functors.html" class="next">Functors »</a>
+</div>

--- a/site/learn/tutorials/objects.md
+++ b/site/learn/tutorials/objects.md
@@ -558,3 +558,7 @@ let y = object method get = 80 method special = "hello" end;;
 let l = [x; y];;
 let l = [x; (y :> t)];;
 ```
+
+<div class="bottom-navigation">
+<a href = "functors.html" class="previous">« Functors</a><a href="error_handling.html" class="next">Error Handling »</a>
+</div>

--- a/site/learn/tutorials/performance_and_profiling.md
+++ b/site/learn/tutorials/performance_and_profiling.md
@@ -885,6 +885,10 @@ You can find out more about how OCaml represents different types by
 reading the ("Interfacing C with OCaml") chapter in the OCaml manual and also
 looking at the `mlvalues.h` header file.
 
+<div class="bottom-navigation">
+<a href = "garbage_collection.html" class="previous">« Garbage Collection</a><a href ="index.html" class="next">OCaml Tutorials</a>
+</div>
+
 <!--###  Java dynamic dispatch
 **There are some serious mistakes in the last paragraph:**
 

--- a/site/learn/tutorials/pointers.md
+++ b/site/learn/tutorials/pointers.md
@@ -259,3 +259,7 @@ let append (l1 : 'a lists) (l2 : 'a lists) =
   done;
   !^ !temp.tl <- l2;;
 ```
+
+<div class="bottom-navigation">
+<a href = "labels.html" class="previous">« Labels</a><a href="null_pointers_asserts_and_warnings.html" class="next">Null Pointers, Asserts, and Warnings »</a>
+</div>

--- a/site/learn/tutorials/set.md
+++ b/site/learn/tutorials/set.md
@@ -73,4 +73,6 @@ removing an element from a set does not alter that set but, rather,
 returns a new set that is very similar to (and shares much of its
 internals with) the original set.
 
-
+<div class="bottom-navigation">
+<a href = "map.html" class="previous">« Maps</a><a href="hashtbl.html" class="next">Hash Tables »</a>
+</div>

--- a/site/learn/tutorials/up_and_running.md
+++ b/site/learn/tutorials/up_and_running.md
@@ -226,3 +226,7 @@ Vim:
 ```
 let $PATH .= ";".substitute(system('opam config var bin'),'\n$','','''')
 ```
+
+<div class="bottom-navigation">
+<a href = "index.html" class="previous">« OCaml Tutorials</a><a href="a_first_hour_with_ocaml.html" class="next">A First Hour With OCaml »</a>
+</div>


### PR DESCRIPTION
# Issue Description
This issue adds bottom navigation to each chapter/section in the tutorial pages.

Fixes #1467 

## Changes Made

Made changes in the tutorial files by adding a `div` at the bottom of each `.md` file.
The `div` adds the link to the 'previous' page and to the 'next' page. I also styled the `div` in `bootstrap.css`

Before :
![Screenshot from 2021-04-13 13-51-28](https://user-images.githubusercontent.com/53010252/114521530-223abb80-9c60-11eb-8844-1786b0a4af5e.png)

After :
![Screenshot from 2021-04-13 13-51-41](https://user-images.githubusercontent.com/53010252/114521613-3979a900-9c60-11eb-9411-44bfba4adea0.png)

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
