### PR TITLE
Changed the color of the News page button

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,36 +1,16 @@
 # Issue Description
 
-Different button colors on different pages #1353
-
 Please include a summary of the issue.
- The button color on other pages are green and text color are white while on news page the button color is grey and text color is deep grey
-
-BEFORE
-
-![Imgur](https://i.imgur.com/7W0d4Jy.png)
-
-![Imgur](https://i.imgur.com/ZhbSY7G.png)
-
 
 Fixes # (issue)
- #1353
 
 ## Changes Made
 
 Please describe the changes that you made.
 
-Changed the button color on news page to green & the text-color to white (Read more and Hide) and added a down arrow to the read more button and up arrow to the hide button and tested on a desktop
-
-
-AFTER
-
-![Imgur](https://i.imgur.com/w5OJH40.png)
-
-![Imgur](https://i.imgur.com/XPw76yh.png)
-
 * **Please check if the PR fulfills these requirements**
 
-- [x] PR is descriptively titled and links the original issue above
-- [x] Before/after screenshots (if this is a layout change)
-- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
-- [x] Context for what motivated the change (if this is a change to some content)
+- [ ] PR is descriptively titled and links the original issue above
+- [ ] Before/after screenshots (if this is a layout change)
+- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
+- [ ] Context for what motivated the change (if this is a change to some content)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,16 +1,36 @@
 # Issue Description
 
+Different button colors on different pages #1353
+
 Please include a summary of the issue.
+ The button color on other pages are green and text color are white while on news page the button color is grey and text color is deep grey
+
+BEFORE
+
+![Imgur](https://i.imgur.com/7W0d4Jy.png)
+
+![Imgur](https://i.imgur.com/ZhbSY7G.png)
+
 
 Fixes # (issue)
+ #1353
 
 ## Changes Made
 
 Please describe the changes that you made.
 
+Changed the button color on news page to green & the text-color to white (Read more and Hide) and added a down arrow to the read more button and up arrow to the hide button and tested on a desktop
+
+
+AFTER
+
+![Imgur](https://i.imgur.com/w5OJH40.png)
+
+![Imgur](https://i.imgur.com/XPw76yh.png)
+
 * **Please check if the PR fulfills these requirements**
 
-- [ ] PR is descriptively titled and links the original issue above
-- [ ] Before/after screenshots (if this is a layout change)
-- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
-- [ ] Context for what motivated the change (if this is a change to some content)
+- [x] PR is descriptively titled and links the original issue above
+- [x] Before/after screenshots (if this is a layout change)
+- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
+- [x] Context for what motivated the change (if this is a change to some content)

--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -303,12 +303,13 @@ let toggle ?(anchor="") html1 html2 =
   in
   let id1 = new_id() and id2 = new_id() in
   [Element("div", ["id", id1],
-           html1 @ [button id1 id2  "Read more"]);
-            Element("div", ["class","arrow-down"],[]);
+           html1 @ [button id1 id2  "Read more"] @ [ Element("div", ["class","arrow-down"],[])]);
+           
      
    Element("div", ["id", id2; "style", "display: none"],
-           html2 @ [button id2 id1 "Hide"] );
-            Element("div", ["class","arrow-up"],[])]
+        html2 @ [button id2 id1 "Hide"] @ [Element("div",["class","arrow-up"],[])])
+           
+            ]
 
 let toggle_script =
   let script =

--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -303,9 +303,12 @@ let toggle ?(anchor="") html1 html2 =
   in
   let id1 = new_id() and id2 = new_id() in
   [Element("div", ["id", id1],
-           html1 @ [button id1 id2 "Read more..."]);
+           html1 @ [button id1 id2  "Read more"]);
+            Element("div", ["class","arrow-down"],[]);
+     
    Element("div", ["id", id2; "style", "display: none"],
-           html2 @ [button id2 id1 "Hide"])]
+           html2 @ [button id2 id1 "Hide"] );
+            Element("div", ["class","arrow-up"],[])]
 
 let toggle_script =
   let script =

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -161,10 +161,37 @@ a.planet-toggle {
   float: right;
   font-size: 90%;
   padding: 5px 10px;
+  padding-right: 23px;
   margin-bottom: 2ex;
-  color: #4b4b4b;
-  background: #e6e6e6;
-  border: 1px solid #dedede;
+  color: #ffffff;
+  background: #008000;
+  border: 1px solid #008000;
+}
+.arrow-down {
+  width: 0; 
+  height: 0; 
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid #ffffff;
+  right: 15px;
+  float: right;
+  position: relative;
+  left: 85px;
+  top: 17px;
+ 
+}
+
+.arrow-up {
+  width: 0; 
+  height: 0; 
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 5px solid #ffffff;
+  float: right;
+  position: relative;
+  left: 52px;
+  top: 18px;
+  
 }
 
 a.planet-toggle:hover, a.planet-toggle:focus {


### PR DESCRIPTION
# Issue Description

Different button colors on different pages #1353

Please include a summary of the issue.
 The button color on other pages are green and text color are white while on news page the button color is grey and text color is deep grey

BEFORE

![Imgur](https://i.imgur.com/7W0d4Jy.png)

![Imgur](https://i.imgur.com/ZhbSY7G.png)


Fixes #1353

## Changes Made

Please describe the changes that you made.

Changed the button color on news page to green & the text-color to white (Read more and Hide) and added a down arrow to the read more button and up arrow to the hide button and tested on a desktop


AFTER

![Imgur](https://i.imgur.com/w5OJH40.png)

![Imgur](https://i.imgur.com/XPw76yh.png)

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)