### PR TITLE
Improved accessibility on the Books page

### DIFF
--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -611,10 +611,14 @@ ul.translations:after { content: "]"; }
   .books-span{
     margin: 5px;
   }
+  .books-row{
+    display: flex;
+  }
+  .books-row div.span2{
+    padding: 5px;
+  }
 }
-.books-row{
-  display: flex;
-}
+
 @media (max-width: 480px) {
   #footer .column {
     width: 98%;

--- a/site/learn/books.md
+++ b/site/learn/books.md
@@ -5,14 +5,14 @@
 # Books
 ## Books in English
 ###  The OCaml System: Documentation and User's Manual
-<img src="/img/colour-icon-170x148.png" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/colour-icon-170x148.png" alt="" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Damien Doligez, Alain Frisch, Jacques Garrigue, Didier Rémy, and Jérôme
 Vouillon*
 
 This the official User's Manual. It serves as a complete reference guide
 to OCaml. Updated for each version of OCaml, it contains the description
-of the language, of its extensions, and the documentation of the tools
+of the language, its extensions, and the documentation of the tools
 and libraries included in the official distribution.
 
 [Online](/releases/latest/manual.html) |
@@ -24,7 +24,7 @@ Tarball](http://caml.inria.fr/distrib/ocaml-{{! get LATEST_OCAML_VERSION_MAIN !}
 ****
 
 ###  Real World OCaml
-<img src="/img/real-world-ocaml.jpg" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/real-world-ocaml.jpg" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Jason Hickey, Anil Madhavapeddy, and Yaron Minsky. Published 25th November 2013*
 
@@ -41,13 +41,13 @@ system, foreign-function interface, macro language, and the ocamlbuild
 system. Quickly learn how to put OCaml to work for writing succinct and
 readable code.
 
-[Book Website](https://realworldocaml.org/) | [O'Reilly](http://shop.oreilly.com/product/0636920024743.do) | [Amazon](http://www.amazon.com/Real-World-OCaml-Functional-programming/dp/144932391X/ref=tmm_pap_title_0?ie=UTF8&qid=1385006524&sr=8-1)
+[Book Website](https://realworldocaml.org/) | [Amazon](http://www.amazon.com/Real-World-OCaml-Functional-programming/dp/144932391X/ref=tmm_pap_title_0?ie=UTF8&qid=1385006524&sr=8-1)
 
 
 ****
 
 ###  OCaml from the Very Beginning
-<img src="/img/OCaml_from_beginning.png" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/OCaml_from_beginning.png" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *John Whitington. Published June 7th, 2013*
 
@@ -58,7 +58,7 @@ new topic, building until the reader can write quite substantial
 programs. There are plenty of questions and, crucially, worked answers
 and hints.
 
-"OCaml from the Very Beginning" will appeal both to new programmers, and experienced programmers eager to explore functional languages such as OCaml. It is suitable both for formal use within an undergraduate or graduate curriculum, and for the interested amateur.
+"OCaml from the Very Beginning" will appeal both to new programmers, and experienced programmers eager to explore functional languages such as OCaml. It is suitable both for formal use within an undergraduate or graduate curriculum and for the interested amateur.
 
 [Book Website](http://ocaml-book.com/) |
 [Amazon](http://www.amazon.com/gp/product/0957671105)
@@ -66,7 +66,7 @@ and hints.
 ****
 
 ###  More OCaml: Algorithms, Methods & Diversions
-<img src="/img/more-ocaml-300-376.png" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/more-ocaml-300-376.png" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *John Whitington. Published 26th August 2014*
 
@@ -79,7 +79,7 @@ worked answers and hints.
 "More OCaml" will appeal both to existing OCaml programmers who wish to brush up
 their skills, and to experienced programmers eager to explore functional
 languages such as OCaml. It is hoped that each reader will find something new,
-or see an old thing in a new light. For the more casual reader, or those who are
+or see an old thing in a new light. For the more casual reader or those who are
 used to a different functional language, a summary of basic OCaml is provided at
 the front of the book.
 
@@ -89,7 +89,7 @@ the front of the book.
 ****
 
 ###  Unix System Programming in OCaml
-<img src="/img/default.png" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/default.png" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Xavier Leroy and Didier Rémy. Published May 2010*
 
@@ -105,7 +105,7 @@ Unix shell commands.
 ****
 
 ###  OCaml for Scientists
-<img src="/img/harrop-book.gif" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/harrop-book.gif" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Jon D. Harrop<br />
  Flying Frog Consultancy Ltd, 2005.*
@@ -115,18 +115,16 @@ applications. Many examples are given, covering everything from simple
 numerical analysis to sophisticated real-time 3D visualisation using
 OpenGL. This book contains over 800 color syntax-highlighted source code
 examples and dozens of diagrams that elucidate the power of functional
-programming to explain how lightning-fast and yet remarkably-simple
+programming to explain how lightning-fast and yet remarkably simple
 programs can be constructed in the OCaml programming language.
 
 [Book
 Website](http://www.ffconsultancy.com/products/ocaml_for_scientists/index.html)
-| [Ordering
-Information](http://www.ffconsultancy.com/products/ocaml_for_scientists/index.html)
 
 ****
 
 ###  Using, Understanding, and Unraveling OCaml
-<img src="/img/default.png" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/default.png" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Didier Rémy. Published 20th September 2002*
 
@@ -140,7 +138,7 @@ OCaml it is addressed to a wide audience of people interested in modern programm
 ****
 
 ###  Developing Applications With OCaml
-<img src="/img/logocaml-oreilly.gif" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/logocaml-oreilly.gif" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Emmanuel Chailloux, Pascal Manoury, Bruno Pagano. Published 2002*
 
@@ -156,32 +154,32 @@ translation of a French book published by OReilly.
 ****
 
 ###  Introduction to OCaml
-<img src="/img/default.png" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/default.png" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Jason Hickey. Published in 2008*
 
 This book is notoriously much more than just an introduction to OCaml,
 it describes most of the language, and is accessible.
 
-Abstract: *This book is an introduction to ML programming, specifically for the OCaml programming language from INRIA. OCaml is a dialect of the ML family of languages, which derive from the Classic ML language designed by Robin Milner in 1975 for the LCF (Logic of Computable Functions) theorem prover.*
+Abstract: *This book is an introduction to ML programming, specifically for the OCaml programming language from INRIA. OCaml is a dialect of the ML family of languages, which derives from the Classic ML language designed by Robin Milner in 1975 for the LCF (Logic of Computable Functions) theorem prover.*
 
 [PDF](http://courses.cms.caltech.edu/cs134/cs134b/book.pdf)
 
 ****
 
 ###  The Functional Approach to Programming
-<img src="/img/cousineau-mauny-en.gif" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/cousineau-mauny-en.gif" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Guy Cousineau, Michel Mauny<br />
  Cambridge University Press, Cambridge, 1998, <br />
  ISBN 0-521-57183-9 (hardcover) or 0-521-57681-4 (paperback)*
 
 This book uses OCaml as a tool to introduce several important
-programming concepts. It is divided in three parts. The first part is an
-introduction to OCaml, which presents the language itself, but also
-introduces evaluation by rewriting, evaluation strategies and proofs of
+programming concepts. It is divided into three parts. The first part is an
+introduction to OCaml, which presents the language itself but also
+introduces evaluation by rewriting, evaluation strategies, and proofs of
 programs by induction. The second part is dedicated to the description
-of application programs which belong to various fields and might
+of application programs that belong to various fields and might
 interest various types of readers or students. Finally, the third part
 is dedicated to implementation. It describes interpretation and
 compilation, with brief descriptions of memory management and type
@@ -194,7 +192,7 @@ Amazon.com](http://www.amazon.com/exec/obidos/ASIN/0521571839/qid%3D911812711/sr
 ****
 
 ###  OCaml Book
-<img src="/img/default.png" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/default.png" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Hongbo Zhang. Published 2011*
 
@@ -207,7 +205,7 @@ runtime, interoperating with C, and pearls.
 ****
 
 ###  Think OCaml: How to Think Like a (Functional) Programmer
-<img src="http://greenteapress.com/thinkocaml/thinkocaml_cover_web.png" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="http://greenteapress.com/thinkocaml/thinkocaml_cover_web.png" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Nicholas Monje and Allen Downey. Published 2008*
 
@@ -215,7 +213,7 @@ This book is a work in progress. It is an introductory programming
 textbook based on the OCaml language. It is a modified version of
 Think Python by Allen Downey. It is intended for newcomers to
 programming and also those who know some programming but want to learn
-programming in the function-oriented paradigm, or those who simply
+programming in the function-oriented paradigm or those who simply
 want to learn OCaml.
 
 [Book Website](http://greenteapress.com/thinkocaml/index.html) |
@@ -226,7 +224,7 @@ want to learn OCaml.
 ## Books in French
 
 ### Initiation à la programmation fonctionnelle en OCaml
-<img src="/img/Initiation_a_la_programmation_fonctionnelle_en_OCaml.jpg" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/Initiation_a_la_programmation_fonctionnelle_en_OCaml.jpg" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Mohammed-Said Habet<br />
 édition: Edilivre, 2015. ISBN: 9782332978400*
@@ -252,7 +250,7 @@ l’initiative du lecteur.
 ****
 
 ###  Apprendre à programmer avec OCaml
-<img src="/img/apprendre_ocaml_cover.png" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/apprendre_ocaml_cover.png" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Jean-Christophe Filliâtre and Sylvain Conchon<br />
  Éditions Eyrolles, Paris, 2014, ISBN 2-21213-678-1.*
@@ -267,12 +265,12 @@ The programming style is essential. Given a programming language, the
 same algorithm can be written in multiple ways, and some of them can
 be both elegant and efficient. This is what the programmer must seek
 at all costs and the reason why we choose a programming language for
-this book rather than pseudo-code. Our choice is OCaml.
+this book rather than a pseudo-code. Our choice is OCaml.
 
 This book is organized into three parts. The first one introduces
 OCaml and targets beginners, being they programming beginners or
 simply new to OCaml. Through small programs, the reader is introduced
-to fundamental concepts of programming and of OCaml. The second and
+to fundamental concepts of programming and OCaml. The second and
 third parts are dedicated to fundamental concepts of algorithmics and
 should allow the reader to write programs in a structured and
 efficient way. Algorithmic concepts are directly presented in the
@@ -285,7 +283,7 @@ online.
 ****
 
 ###  Développement d'applications avec Objective Caml
-<img src="/img/chailloux-manoury-pagano.jpg" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/chailloux-manoury-pagano.jpg" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Emmanuel Chailloux, Pascal Manoury, and Bruno Pagano<br />
  Éditions O'Reilly, Paris, 2000, ISBN 2-84177-121-0.*
@@ -302,7 +300,7 @@ programming, and interoperability with C. <br />
 
 
 ###  Manuel de référence du langage Caml
-<img src="/img/leroy-weis.jpg" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/leroy-weis.jpg" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Xavier Leroy and Pierre Weis<br />
  InterEditions, Paris, 1993, ISBN 2-7296-0492-8 (out of print).*
@@ -318,7 +316,7 @@ Intro: "Cet ouvrage contient le manuel de référence du langage Caml et la docu
 
 
 ###  Le langage Caml
-<img src="/img/weis-leroy.jpg" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/weis-leroy.jpg" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Pierre Weis, Xavier Leroy<br />
  Second edition: Dunod, Paris, 1999, ISBN 2-10-004383-8.<br />
@@ -337,17 +335,17 @@ automata, etc.
 ****
 
 ###  Approche fonctionnelle de la programmation
-<img src="/img/cousineau-mauny-fr.gif" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/cousineau-mauny-fr.gif" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Guy Cousineau, Michel Mauny<br />
  Ediscience (Collection Informatique), Paris, 1995, ISBN 2-84074-114-8.*
 
 This book uses OCaml as a tool to introduce several important
-programming concepts. It is divided in three parts. The first part is an
-introduction to OCaml, which presents the language itself, but also
-introduces evaluation by rewriting, evaluation strategies and proofs of
+programming concepts. It is divided into three parts. The first part is an
+introduction to OCaml, which presents the language itself but also
+introduces evaluation by rewriting, evaluation strategies, and proofs of
 programs by induction. The second part is dedicated to the description
-of application programs which belong to various fields and might
+of application programs that belong to various fields and might
 interest various types of readers or students. Finally, the third part
 is dedicated to implementation. It describes interpretation then
 compilation, with brief descriptions of memory management and type
@@ -358,7 +356,7 @@ synthesis.
 ****
 
 ###  Seize problèmes d'informatique
-<img src="/img/petazzoni.jpg" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/petazzoni.jpg" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Bruno Petazzoni<br />
  Éditions Springer, Paris, 2001 <br />
@@ -371,33 +369,33 @@ infinite words, formal language theory, and some classical algorithms
 such as bin-packing. It is intended for students who attend the optional
 computer science curriculum of the “classes préparatoires MPSI/MP”. It
 should also be useful to all teachers and computer science students up
-to a masters degree.
+to a master's degree.
 
 [Springer&#39;s Catalog
-Page](http://www.springeronline.com/sgw/cda/frontpage/0,10735,5-102-22-2042496-0,00.html)
+Page](http://www.springeronline.com/sgw/cda/frontpage/0,10735,5-102-22-2042496-0,00.html) | [Order at Amazon.fr](http://www.amazon.fr/exec/obidos/ASIN/3540673873)
 
 ****
 
 ###  Nouveaux exercices d'algorithmique
-<img src="/img/quercia.gif" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/quercia.gif" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Michel Quercia<br />
  Éditions Vuibert, Paris, 2000 <br />
  ISBN 2-7117-8990 X.*
 
 This book presents 103 exercises and 5 problems about algorithms, for
-masters students. It attempts to address both practical and theoretical
+master's students. It attempts to address both practical and theoretical
 questions. Programs are written in OCaml and expressed in a purely
 functional style. Problem areas include programming methodology, lists,
 formula evaluation, Boolean logic, algorithmic complexity, trees,
 languages, and automata.
 
-[Order at Amazon.fr](http://www.amazon.fr/exec/obidos/ASIN/3540673873)
+[Order at Amazon.fr](https://www.amazon.fr/Nouveaux-exercices-dalgorithmique-Michel-Quercia/dp/271178990X)
 
 ****
 
 ###  Option informatique MPSI
-<img src="/img/monasse-1.gif" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/monasse-1.gif" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Denis Monasse<br />
  Éditions Vuibert (Enseignement supérieur &amp; Informatique), Paris, 1996 <br />
@@ -416,14 +414,13 @@ science.
 ****
 
 ###  Option informatique MP/MP*
-<img src="/img/monasse-2.jpg" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/monasse-2.jpg" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Denis Monasse<br />
  Éditions Vuibert (Enseignement supérieur &amp; Informatique), Paris 1997 <br />
 ISBN 2-7117-8839-3.*
 
-This books is a follow-up to the previous one and is intended for second
-year students in “classes préparatoires”. It deals with trees, algebraic
+This book is a follow-up to the previous one and is intended for second-year students in “classes préparatoires”. It deals with trees, algebraic
 expressions, automata and languages, and OCaml streams. The book
 contains more than 200 OCaml programs.
 
@@ -432,7 +429,7 @@ contains more than 200 OCaml programs.
 ****
 
 ###  Cours et exercices d'informatique
-<img src="/img/albert.gif" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/albert.gif" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Luc Albert<br />
  Thomson Publishing International, Paris, 1997 <br />
@@ -441,14 +438,14 @@ contains more than 200 OCaml programs.
 This book was written by teachers at university and in “classes
 préparatoires”. It is intended for “classes préparatoires” students who
 study computer science and for students engaged in a computer science
-cursus up to the masters level. It includes a tutorial of the OCaml
+course up to the masters level. It includes a tutorial of the OCaml
 language, a course on algorithms, data structures, automata theory, and
 formal logic, as well as 135 exercises with solutions.
 
 ****
 
 ###  Concepts et outils de programmation
-<img src="/img/hardin-donzeau-gouge.gif" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/hardin-donzeau-gouge.gif" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Thérèse Accart Hardin, Véronique Donzeau-Gouge Viguié<br />
  InterEditions, ISBN 2 7296 0419 7.*
@@ -457,7 +454,7 @@ This book presents a new approach to teaching programming concepts to
 beginners, based on language semantics. A simplified semantic model is
 used to describe in a precise manner the features found in most
 programming languages. This model is powerful enough to explain
-typechecking, polymorphism, evaluation, side-effects, modularity,
+type checking, polymorphism, evaluation, side-effects, modularity,
 exceptions. Yet, it is simple enough to be manipulated by hand, so that
 students can actually use it to compute. The book begins with a
 functional approach, based on OCaml, and continues with a presentation
@@ -469,7 +466,7 @@ exercises with solutions.
 ****
 
 ###  Programmation en Caml
-<img src="/img/rouable.jpg" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/rouable.jpg" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Jacques Rouablé<br />
  Eyrolles, Paris 1997, ISBN 2-212-08944-9.*
@@ -480,14 +477,14 @@ initiates the reader to the OCaml language. Important notions are
 presented from a practical point of view, and the implementation of some
 of these is analyzed and sketched. The second part, the “OCaml
 workshop”, is a practical application of these notions to other domains
-connected to computer science, logic, automata and grammars.
+connected to computer science, logic, automata, and grammars.
 
 [Order at Amazon.fr](http://www.amazon.fr/exec/obidos/ASIN/2212089449)
 
 ****
 
 ###  Apprentissage de la programmation avec OCaml
-<img src="/img/dubois-menissier.gif" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/dubois-menissier.gif" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Catherine Dubois and Valérie Ménissier Morain<br />
  Hermès Sciences, Paris 2004, ISBN 2-7462-0819-9.*
@@ -501,13 +498,13 @@ language. This book is targeted towards beginner programmers and
 provides teaching material for all programmers wishing to learn the
 functional programming style. The programming features introduced in
 this book are available in all dialects of the ML language, notably
-Caml-Light, OCaml and Standard ML. The concepts presented therein and
+Caml-Light, OCaml, and Standard ML. The concepts presented therein and
 illustrated in OCaml easily transpose to other programming languages.
 
 ****
 
 ###  Programmation fonctionnelle, générique et objet: une introduction avec le langage OCaml
-<img src="/img/narbel.jpg" width="180"></img>
+<img src="/img/narbel.jpg" alt="" width="180"></img>
 
 *Philippe Narbel<br />
  Vuibert, Paris 2005, ISBN 2-7117-4843-X.*
@@ -515,7 +512,7 @@ illustrated in OCaml easily transpose to other programming languages.
 ****
 
 ###  Programmation de droite à gauche et vice-versa
-<img src="/img/manoury.png" width="180"></img>
+<img src="/img/manoury.png" alt="" width="180"></img>
 
 *Pascal Manoury<br />
  Éditions Paracamplus, Paris, 2011, ISBN 978-2-916466-05-7.*
@@ -528,13 +525,13 @@ illustrated in OCaml easily transpose to other programming languages.
 ## Books in German
 
 ###  Algorithmen, Datenstrukturen, Funktionale Programmierung: Eine praktische Einführung mit Caml Light
-<img src="/img/wolff.gif" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/wolff.gif" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Juergen Wolff von Gudenberg<br />
  Addison-Wesley, Bonn, 1996.*
 
-This book gives an introduction to programming where algorithms as well
-as data structures are considered functionally. It is intended as an
+This book gives an introduction to programming where algorithms, as well
+as data structures, are considered functionally. It is intended as an
 accompanying book for basic courses in computer science, but it is also
 suitable for self-studies. In the first part, algorithms are described
 in a concise and precise manner using Caml Light. The second part
@@ -546,7 +543,7 @@ last chapter a comprehensive description of the language kernel.
 ## Books in Italian
 
 ### Programmazione funzionale, una semplice introduzione
-<img src="/img/default.png" width="180"></img>
+<img src="/img/default.png" alt="" width="180"></img>
 
 *Massimo Maria Ghisalberti*
 
@@ -555,7 +552,7 @@ last chapter a comprehensive description of the language kernel.
 ****
 
 ###  Introduzione alla programmazione funzionale
-<img src="/img/limongelli-cialdea.gif" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/limongelli-cialdea.gif" alt="" width="180" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Carla Limongelli and Marta Cialdea<br />
  Societa' Editrice Esculapio, 2002, ISBN 88-7488-031-6.*
@@ -566,17 +563,17 @@ last chapter a comprehensive description of the language kernel.
 ## Books in Portuguese
 
 ### OCaml: Programação Funcional na Prática
-<img src="/img/opfp.png" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
+<img src="/img/opfp.png" alt="" style="float: left; margin-right: 15px; margin-bottom: 15px;"></img>
 
 *Andrei de Araújo Formiga<br />
  Casa do Código, 2015*
 
 This book is an introduction to functional programming through OCaml, with a pragmatic
 focus. The goal is to enable the reader to write real programs in OCaml and understand
-most of the open source code written in the language. It includes many code examples
+most of the open-source code written in the language. It includes many code examples
 illustrating the topics and a few larger projects written in OCaml that showcase the
 integration of many language features. These larger
-programs include a set of interpreter, compiler and stack machine for a simple
+programs include a set of interpreters, compiler, and stack machines for a simple
 language, and a decision tree learning program for data analysis.
 
 [Book site](http://andreiformiga.com/livro/ocaml/)

--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -49,21 +49,20 @@
                 <p><a href="tutorials/">See full list</a></p>
             </footer>
         </section>
-        <section class="span4 condensed">
+        <section class="span4 condensed books-span">
             <h1 class="ruled"><a href="books.html">Books</a></h1>
-                <a href="https://realworldocaml.org"><img style="float:
-                left; margin-right: 2px; margin-bottom: 10px"
-                src="/img/real-world-ocaml.jpg" width="48%"
-				alt="Real World OCaml book"></a><a
-				href="http://ocaml-book.com"><img style="float:
-                right; margin-left: 2px; margin-bottom: 10px"
-                src="/img/OCaml_from_beginning.png" width="48%"
-				alt="OCaml from the very beginning"></a>
-				<p style="clear:both">There are a number of excellent
-				books, with two new titles published in recent years.
-		</p>
+                <div class="row books-row">
+                    <div class="span2">
+                        <a href="https://realworldocaml.org"><img src="/img/real-world-ocaml.jpg" alt="Real World OCaml book"></a>
+                    </div>
+                    <div class="span2">
+                        <a href="http://ocaml-book.com"><img src="/img/OCaml_from_beginning.png" alt="OCaml from the very beginning"></a>
+                    </div>
+                </div>
+                <p style="clear:both">There are a number of excellent
+                books, with two new titles published in recent years.</p>
 		<footer>
-                  <p><a href="books.html">See full list</a></p>
+            <p><a href="books.html">See full list</a></p>
 		</footer>
         </section>
     </div>


### PR DESCRIPTION
# Issue Description
Noticed that some images on the OCaml website didn't have the alt attribute so I measured its accessibility using Lighthouse and I saw that images not having the alt attribute affected the accessibility score. Having an alt text provides screen readers and search engines with a textual description of what is on your page.
Please include a summary of the issue.

Fixes # (issue)
Fixes #1439 
## Changes Made
Added alt attribute with appropriate descriptions for the images, added alt attributes with an empty value for decorative images or images that have texts that already describe them or are just on the page for visual purposes, for example on the books page, with the name of the book above the image and an adjacent description of the book, there is no need to add an additional description in the alt attribute to avoid confusing the readers. With an empty alt, screen readers will ignore it, putting the empty alt is better than no alt attribute at all because some screen readers will announce the file name of the image when the alt attribute is not provided. One more thing that happens with adding alt attributes is that they are displayed in case images fail to load for one reason or the other which is better than having the broken image icon on the page. For images with empty alt, nothing gets displayed as shown in the after image.

Please describe the changes that you made.
In addition to adding the alt attribute to images, I am also correcting typos and links on the affected pages.

Before
![alt-1](https://user-images.githubusercontent.com/15726413/114878008-ba1edd80-9df7-11eb-983a-cb4b61a103e0.png)

After
![alt-2](https://user-images.githubusercontent.com/15726413/114878017-bbe8a100-9df7-11eb-9e60-d9d6b1f40534.PNG)

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
