### PR TITLE
http: don't use lwt.ignore_result

### DIFF
--- a/script/http.ml
+++ b/script/http.ml
@@ -28,6 +28,7 @@ let make_uri request_uri uri =
   |> set_scheme
 
 let rec http_get_and_follow ~max_redirects uri =
+  let open Lwt in
   Cohttp_lwt_unix.Client.get uri >>= follow_redirect ~max_redirects uri
 
 and follow_redirect ~max_redirects request_uri (response, body) =


### PR DESCRIPTION
`Lwt.ignore_result` is a broken version of `Lwt.async`. The equivalent of ignore is to bind unit. See https://ocsigen.org/lwt/5.2.0/api/Lwt#VALignore_result
Also removes some unnecessary `open Lwt`