### PR TITLE
Added discussion links

### DIFF
--- a/site/learn/tutorials/99problems.md
+++ b/site/learn/tutorials/99problems.md
@@ -3170,3 +3170,5 @@ way of placing words onto sites.
 ```ocaml
 (* example pending *);;
 ```
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/a_first_hour_with_ocaml.md
+++ b/site/learn/tutorials/a_first_hour_with_ocaml.md
@@ -891,3 +891,5 @@ This quick tour should have given you a little taste of OCaml and why you might
 like to explore it further. Elsewhere on [ocaml.org](/index.html) there are
 pointers to [books on OCaml](/learn/books.html) and
 [other tutorials](/learn/tutorials/index.html).
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/calling_c_libraries.md
+++ b/site/learn/tutorials/calling_c_libraries.md
@@ -395,3 +395,5 @@ In order for it to get passed to OCaml code at all, we must somehow
 convert it to a `value`. Luckily we can quite easily use the C API to
 create `value` blocks which the OCaml garbage collector *won't* examine
 too closely ......
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/calling_fortran_libraries.md
+++ b/site/learn/tutorials/calling_fortran_libraries.md
@@ -143,3 +143,5 @@ let some else help out (or wait until I learn how to do it).
 prompt> ocamlc -c gtd6.ml prompt> ocamlc -o test gtd6.cmo wrapper.so
 ```
 And voila, we've called the fortran function from OCaml.
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/command-line_arguments.md
+++ b/site/learn/tutorials/command-line_arguments.md
@@ -50,3 +50,5 @@ without having to scan the `Sys.argv` array yourself:
 * [Getopt](https://opam.ocaml.org/packages/getopt/)
   for OCaml is similar to [GNU
   getopt](http://www.gnu.org/software/libc/manual/html_node/Getopt.html).
+
+  [Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/common_error_messages.md
+++ b/site/learn/tutorials/common_error_messages.md
@@ -188,3 +188,5 @@ option.
 "\e\n" (* bad practice *);;
 "\\e\n" (* good practice *);;
 ```
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/comparison_of_standard_containers.md
+++ b/site/learn/tutorials/comparison_of_standard_containers.md
@@ -96,3 +96,5 @@ element doesn't create a new stack but simply adds it to the stack.
 * adding an element: O(1)
 * taking an element: O(1)
 * length: O(1)
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/compiling_ocaml_projects.md
+++ b/site/learn/tutorials/compiling_ocaml_projects.md
@@ -145,3 +145,5 @@ necessary. See next section.
 - [OMake](https://github.com/ocaml-omake/omake) Another OCaml build system.
 - [GNU make](https://www.gnu.org/software/make/) GNU make can build anything, including OCaml. May be used in conjunction with [OCamlmakefile](https://github.com/mmottl/ocaml-makefile)
 - [Oasis](https://github.com/ocaml/oasis) Generates configure, build, and install system using another build system.
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/data_types_and_matching.md
+++ b/site/learn/tutorials/data_types_and_matching.md
@@ -431,3 +431,5 @@ was not handled.
 
 Exercise: Extend the pattern matching with a `Product` case so
 `to_string` compiles without warning.
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/debug.md
+++ b/site/learn/tutorials/debug.md
@@ -276,3 +276,5 @@ Under Emacs you call the debugger using `ESC-x` `ocamldebug a.out`. Then Emacs
 will send you directly to the file and character reported by the debugger, and
 you can step back and forth using `ESC-b` and `ESC-s`, you can set up break
 points using `CTRL-X space`, and so on...
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/error_handling.md
+++ b/site/learn/tutorials/error_handling.md
@@ -154,3 +154,5 @@ are:
 
 For easy combination of functions that can fail, many alternative standard
 libraries provide useful combinators on the `result` type: `map`, `>>=`, etc.
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/file_manipulation.md
+++ b/site/learn/tutorials/file_manipulation.md
@@ -103,3 +103,5 @@ let () =
   
   (* normal exit: all channels are flushed and closed *)
 ```
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/format.md
+++ b/site/learn/tutorials/format.md
@@ -416,3 +416,5 @@ or `stderr` is just a matter of partial application:
 let print_lambda = pr_lambda std_formatter
 let eprint_lambda = pr_lambda err_formatter
 ```
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/functional_programming.md
+++ b/site/learn/tutorials/functional_programming.md
@@ -431,3 +431,5 @@ let print_string = output_string stdout
 `output_string` takes two arguments (a channel and a string), but since
 we have only supplied one, it is partially applied. So `print_string` is
 a function, expecting one string argument.
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/functors.md
+++ b/site/learn/tutorials/functors.md
@@ -87,3 +87,5 @@ the source files
 [`set.ml`](https://github.com/ocaml/ocaml/blob/trunk/stdlib/set.ml) or
 [`map.ml`](https://github.com/ocaml/ocaml/blob/trunk/stdlib/map.ml) of the
 standard library.
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/garbage_collection.md
+++ b/site/learn/tutorials/garbage_collection.md
@@ -349,3 +349,5 @@ increasing order of difficulty:
 1. Make the underlying file representation a **DBM-style hash**.
 1. Provide a general-purpose cache fronting a "users" table in your
  choice of **relational database** (with locking).
+
+ [Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/guidelines.md
+++ b/site/learn/tutorials/guidelines.md
@@ -1721,4 +1721,6 @@ as the imperative program with the additional clarity and natural
 look of an algorithm that performs pattern matching and recursive
 calls to handle an argument that belongs to a recursive sum data type.
 
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)
+
 

--- a/site/learn/tutorials/hashtbl.md
+++ b/site/learn/tutorials/hashtbl.md
@@ -89,3 +89,5 @@ entry in `my_hash` for a letter we would do:
 ```ocamltop
 Hashtbl.mem my_hash "h"
 ```
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/if_statements_loops_and_recursion.md
+++ b/site/learn/tutorials/if_statements_loops_and_recursion.md
@@ -1109,3 +1109,5 @@ and odd n =
 You can also
 use similar syntax for writing mutually recursive class definitions and
 modules.
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/index.md
+++ b/site/learn/tutorials/index.md
@@ -121,3 +121,8 @@ Both in french:
   for getting an explanation on the behaviour of an operator or syntax element, along with usage examples.
 
 
+### Discussion Forums
+
+* [Discussion threads](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677), help you better understand a tutorial, ask questions and share ideas.
+
+

--- a/site/learn/tutorials/introduction_to_gtk.md
+++ b/site/learn/tutorials/introduction_to_gtk.md
@@ -663,3 +663,5 @@ List.map (fun w -> m#find w) c#children;;
 * Lablgtk provides two ways to perform downcasting, but this doesn't
  change the fact that downcasting is unsafe and can throw exceptions
  at runtime.
+
+ [Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/labels.md
+++ b/site/learn/tutorials/labels.md
@@ -532,3 +532,5 @@ reduction in type safety, it is recommended that you don't use these in
 your code. You will, however, see them in advanced OCaml code quite a
 lot precisely because advanced programmers will sometimes want to weaken
 the type system to write advanced idioms.
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/map.md
+++ b/site/learn/tutorials/map.md
@@ -70,4 +70,4 @@ MyUsers.find "fred" m;;
 ```
 This should quickly and efficiently return Fred's password: "sugarplums".
 
-
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/modules.md
+++ b/site/learn/tutorials/modules.md
@@ -304,3 +304,5 @@ open Extensions
 
 List.optmap ...
 ```
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/null_pointers_asserts_and_warnings.md
+++ b/site/learn/tutorials/null_pointers_asserts_and_warnings.md
@@ -133,3 +133,5 @@ let () =
   done;
   ignore(read_line ())
 ```
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/objects.md
+++ b/site/learn/tutorials/objects.md
@@ -558,3 +558,5 @@ let y = object method get = 80 method special = "hello" end;;
 let l = [x; y];;
 let l = [x; (y :> t)];;
 ```
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/performance_and_profiling_discussion.md
+++ b/site/learn/tutorials/performance_and_profiling_discussion.md
@@ -22,3 +22,5 @@ There are some serious mistakes in the last paragraph:
 
 - In Java is a dynamic type check (aka cast) much more expensive than
   a dynamic method dispatch.
+
+  [Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/pointers.md
+++ b/site/learn/tutorials/pointers.md
@@ -259,3 +259,5 @@ let append (l1 : 'a lists) (l2 : 'a lists) =
   done;
   !^ !temp.tl <- l2;;
 ```
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)

--- a/site/learn/tutorials/set.md
+++ b/site/learn/tutorials/set.md
@@ -73,4 +73,5 @@ removing an element from a set does not alter that set but, rather,
 returns a new set that is very similar to (and shares much of its
 internals with) the original set.
 
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)
 

--- a/site/learn/tutorials/up_and_running.md
+++ b/site/learn/tutorials/up_and_running.md
@@ -226,3 +226,5 @@ Vim:
 ```
 let $PATH .= ";".substitute(system('opam config var bin'),'\n$','','''')
 ```
+
+[Discuss](https://discuss.ocaml.org/t/creating-a-discuss-thread-for-tutorials-on-ocaml-org/7677)


### PR DESCRIPTION
# Issue Description
To display an external link to the discussion forum and add a link to the corresponding discussion at the bottom of each tutorial on the website.

Fixes #1504 

## Changes Made
**After:**

External link:
![Screenshot from 2021-04-17 03-20-52](https://user-images.githubusercontent.com/26017359/115090522-b93e9680-9f32-11eb-910c-ce9636616981.png)

Discuss link at the bottom of each tutorial:
![Screenshot from 2021-04-17 03-52-01](https://user-images.githubusercontent.com/26017359/115090600-e428ea80-9f32-11eb-83a0-24d1548586d7.png)

If this seems fine, I'll add the same link at the bottom of other tutorials also. :)

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
