### PR TITLE
Fix the ordering of Blogs

### DIFF
--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -188,9 +188,8 @@ let get_opml () =
                                "OCaml Planet" in
   (* Broken feeds will be marked with [is_comment = true]. *)
   let opml = Opml1.of_atom ~head feeds in
-  (* Sort by name.  (FIXME: one may want to ignore spaces.) *)
-  let trimm str = String.trim str in
-  let by_name o1 o2 = String.compare (trimm o1.Opml1.text) (trimm o2.Opml1.text) in
+  (* Sort by name. *)
+  let by_name o1 o2 = String.compare (String.trim o1.Opml1.text) (String.trim o2.Opml1.text) in
   { opml with Opml1.body = List.sort by_name opml.Opml1.body }
 
 let opml fname =

--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -189,7 +189,8 @@ let get_opml () =
   (* Broken feeds will be marked with [is_comment = true]. *)
   let opml = Opml1.of_atom ~head feeds in
   (* Sort by name.  (FIXME: one may want to ignore spaces.) *)
-  let by_name o1 o2 = String.compare o1.Opml1.text o2.Opml1.text in
+  let trimm str = String.trim str in
+  let by_name o1 o2 = String.compare (trimm o1.Opml1.text) (trimm o2.Opml1.text) in
   { opml with Opml1.body = List.sort by_name opml.Opml1.body }
 
 let opml fname =

--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -189,8 +189,7 @@ let get_opml () =
   (* Broken feeds will be marked with [is_comment = true]. *)
   let opml = Opml1.of_atom ~head feeds in
   (* Sort by name.  (FIXME: one may want to ignore spaces.) *)
-  let trimm str = String.trim str in
-  let by_name o1 o2 = String.compare (trimm o1.Opml1.text) (trimm o2.Opml1.text) in
+  let by_name o1 o2 = String.compare o1.Opml1.text o2.Opml1.text in
   { opml with Opml1.body = List.sort by_name opml.Opml1.body }
 
 let opml fname =


### PR DESCRIPTION
# Issue Description

Please include a summary of the issue.
Fixed the ordering of blogs ([FIXME](https://github.com/ocaml/ocaml.org/blob/master/script/rss2html.ml#L191))by removing the leading whitespace using String.trim function. Now leading whitespace won't impact ordering.

Fixes #1534

## Changes Made

Please describe the changes that you made.

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
