### PR TITLE
removed uncaught type error on index page

### DIFF
--- a/template/main.mpp
+++ b/template/main.mpp
@@ -96,8 +96,10 @@
     </footer>
     {{!j ifdef extra-js {{!i input ((! get extra-js !)) i!}} j!}}
     <!-- Load javascript from CDN -->
-    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.1/js/bootstrap.min.js"></script>
-
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.0/jquery.min.js" integrity="sha256-xNzN2a4ltkB44Mc/Jz3pT4iU1cmeR0FkXs4pru/JxaQ=" crossorigin="anonymous"></script>
+    
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.2/js/bootstrap.min.js"></script> 
+    
     {{!S ifndef staging
     <script>
 


### PR DESCRIPTION
# Uncaught TypeError in console

Please include a summary of the issue.
- Most of the pages of ocaml.org have Uncaught TypeError: e is not a function error.
- This PR is to point to the source of the error.
- Browser: Chrome and Firefox

Fixes #1255  

## Changes Made

Please describe the changes that you made.
- added two src links in main.mpp file. But the changes are only reflected on index page.
* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
![Screenshot from 2021-04-20 13-12-40](https://user-images.githubusercontent.com/69427216/115361588-596c1800-a1de-11eb-9bc0-bab30f2d86a6.png)
![Screenshot from 2021-04-20 13-46-03](https://user-images.githubusercontent.com/69427216/115362106-d7c8ba00-a1de-11eb-8036-8296bdfc9c1e.png)


- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
