### PR TITLE
Reduced duplicated names in contributor list

### DIFF
--- a/site/contributors.fr.md
+++ b/site/contributors.fr.md
@@ -42,7 +42,7 @@ Contributeurs
 
 Les contributeurs à ce site :
 <ul id="contributors_list">
-((! cmd git log --format="%aN" | sort | uniq | awk '{print "<li>"$1,$2,$3"</li>"}' !))
+((! cmd git log --format="%aE %aN" | sort | uniq | awk '{print "<li>"$2,"</li>"}' !))
 </ul>
 
 Cette liste est obtenue depuis [le log GIT](https://github.com/ocaml/ocaml.org/commits/master), pensez à vérifier que votre

--- a/site/contributors.fr.md
+++ b/site/contributors.fr.md
@@ -42,7 +42,7 @@ Contributeurs
 
 Les contributeurs à ce site :
 <ul id="contributors_list">
-((! cmd git log --format="%aE %aN" | sort -u -k 1,1 | awk '{print "<li>"$2,$3,$4"</li>"}' !))
+((! cmd git log --format="%aE %aN" | sort -u -k 1,1 | awk '{print "<li>"$2,$3,$4"</li>"}' | sort -u !))
 </ul>
 
 Cette liste est obtenue depuis [le log GIT](https://github.com/ocaml/ocaml.org/commits/master), pensez à vérifier que votre

--- a/site/contributors.fr.md
+++ b/site/contributors.fr.md
@@ -42,7 +42,7 @@ Contributeurs
 
 Les contributeurs à ce site :
 <ul id="contributors_list">
-((! cmd git log --format="%aE %aN" | sort | uniq | awk '{print "<li>"$2,"</li>"}' !))
+((! cmd git log --format="%aE %aN" | sort -u -k 1,1 | awk '{print "<li>"$2,$3,$4"</li>"}' !))
 </ul>
 
 Cette liste est obtenue depuis [le log GIT](https://github.com/ocaml/ocaml.org/commits/master), pensez à vérifier que votre

--- a/site/contributors.md
+++ b/site/contributors.md
@@ -44,7 +44,7 @@ The contributors to this site, extracted from the
 [Git log](https://github.com/ocaml/ocaml.org/commits/master), are:
 
 <ul id="contributors_list">
-((! cmd git log --format="%aE %aN" | sort | uniq | awk '{print "<li>"$2,"</li>"}' !))
+((! cmd git log --format="%aE %aN" | sort -u -k 1,1 | awk '{print "<li>"$2,$3,$4"</li>"}' !))
 </ul>
 
 

--- a/site/contributors.md
+++ b/site/contributors.md
@@ -44,7 +44,7 @@ The contributors to this site, extracted from the
 [Git log](https://github.com/ocaml/ocaml.org/commits/master), are:
 
 <ul id="contributors_list">
-((! cmd git log --format="%aN" | sort | uniq | awk '{print "<li>"$1,$2,$3"</li>"}' !))
+((! cmd git log --format="%aE %aN" | sort | uniq | awk '{print "<li>"$2,"</li>"}' !))
 </ul>
 
 

--- a/site/contributors.md
+++ b/site/contributors.md
@@ -44,7 +44,7 @@ The contributors to this site, extracted from the
 [Git log](https://github.com/ocaml/ocaml.org/commits/master), are:
 
 <ul id="contributors_list">
-((! cmd git log --format="%aE %aN" | sort -u -k 1,1 | awk '{print "<li>"$2,$3,$4"</li>"}' !))
+((! cmd git log --format="%aE %aN" | sort -u -k 1,1 | awk '{print "<li>"$2,$3,$4"</li>"}' | sort -u !))
 </ul>
 
 


### PR DESCRIPTION
# Issue Description

The names in the contributors list are duplicated making the list very long

Fixes #1421 

## Changes Made

I checked the list using email addresses to make the search term more unique than using names

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
