### PR TITLE
Removed reduntant links and reduntant title to improve SEO

### DIFF
--- a/site/css/bootstrap.css
+++ b/site/css/bootstrap.css
@@ -5556,7 +5556,7 @@ body {
   margin-bottom: 24px;
   overflow: hidden;
 }
-.home-feature > a {
+.home-feature > a,span {
   float: left;
 }
 .home-feature h1 {
@@ -5579,7 +5579,7 @@ body {
   margin-bottom: 0;
 }
 @media (min-width: 768px) and (max-width: 979px) {
-  .home-feature > a {
+  .home-feature > a,span {
     margin-bottom: 6px;
   }
   .home-feature h1,
@@ -5658,7 +5658,7 @@ body {
   position: relative;
   top: -1px;
 }
-.news-feed li article > a {
+.news-feed li article > a,span{
   position: absolute;
   top: 0;
   left: 0;

--- a/site/docs/index.fr.md
+++ b/site/docs/index.fr.md
@@ -21,8 +21,7 @@
     <section class="span6 condensed">
       <h2 class="ruled">Les Tutoriels OCaml</h2>
       <p>Les
-	<a id="tutref"
-	   href="/manual/index.html#sec6">tutoriels OCaml</a>
+	tutoriels OCaml
 	officiels (chapitres 1 à 6 du manuel), écrits par les
 	inventeurs du langage, sont le meilleur point de
 	départ. Ils constituent une introduction complète à la
@@ -57,8 +56,7 @@
       <h2 class="ruled">Les outils</h2>
       <p>
 	De nombreux
-	<a id="toolref"
-	   href="/manual/index.html#sec286">outils</a>
+	outils
 	sont distribués avec le langage OCaml. Parmi eux,
 	l'interpréteur interactif (REPL ou `toplevel'), le
 	générateur de documentation, le lexer, le débogueur,
@@ -75,8 +73,7 @@
       <h2 class="ruled">Les Extensions du langage</h2>
 
       <p>N'oubliez pas de vérifier régulièrement les
-	<a id="extref"
-	   href="/manual/extn.html">Extensions du langage</a>,
+	Extensions du langage,
 	afin de rester à jour avec les nouvelles constructions
 	qui vont vous simplifier la vie.
 	<br>

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -21,8 +21,7 @@
     <section class="span6 condensed">
       <h2 class="ruled">The OCaml Tutorials</h2>
       <p>The official
-	<a id="tutref"
-	   href="/manual/index.html#sec6">OCaml tutorials</a>
+	OCaml tutorials
 	(chapters 1 to 6 of the manual), written by the creators of
 	the language, are the best place to start. They form a
 	complete introduction to programming in OCaml, including the
@@ -56,8 +55,7 @@
     <section class="span6 condensed">
       <h2 class="ruled">The Tools</h2>
       <p>
-	Many <a id="toolref"
-		    href="/manual/index.html#sec286">tools</a>
+	Many tools
 	are bundled with the OCaml language. Among them, the REPL (or
 	`toplevel'), the documentation generator, lexers, the
 	debugger, profiling tools, etc.
@@ -73,8 +71,7 @@
       <h2 class="ruled">The Language Extensions</h2>
 
       <p>Don't forget to regularly check the
-	<a id="extref"
-	   href="/manual/extn.html">Language Extensions</a>,
+	Language Extensions,
 	they will keep you up-to-date with useful new OCaml idioms
 	and constructions.<br>
       </p>

--- a/site/index.fr.md
+++ b/site/index.fr.md
@@ -21,49 +21,49 @@
         <div class="span8">
             <div class="row">
                 <section class="span4 home-feature">
-                    <a href="/learn/index.fr.html">
+                    <span>
                         <img src="/img/learn-large.svg" alt="Apprendre"
 						 class="svg">
                         <img src="/img/learn-large.png" alt="Apprendre"
 						 class="png">
-                    </a>
+                    </span>
                     <h1><a href="/learn/index.fr.html">Apprendre</a></h1>
-                    <p>Une <a href="/learn/description.html">description d'OCaml</a>, ses <a href="/learn/success.fr.html">utilisateurs</a>, des <a href="learn/taste.fr.html">exemples de code</a>, des <a href="/learn/tutorials/">tutoriaux à lire</a> et <a href="/learn/index.fr.html">bien plus</a>.</p>
+                    <p>Une <a href="/learn/description.html">description d'OCaml</a>, ses <a href="/learn/success.fr.html">utilisateurs</a>, des <a href="learn/taste.fr.html">exemples de code</a>, des <a href="/learn/tutorials/">tutoriaux à lire</a> et bien plus.</p>
                 </section>
                 <section class="span4 home-feature">
-                    <a href="/docs/index.fr.html">
+                    <span>
                         <img src="/img/documentation-large.svg"
 						 alt="Documentation" class="svg">
                         <img src="/img/documentation-large.png"
 						 alt="Documentation" class="png">
-                    </a>
+                    </span>
                     <h1><a href="/docs/index.fr.html">Documentation</a></h1>
                     <p><a href="docs/install.fr.html" >Installer</a> OCaml,
 					trouver des <a href="https://opam.ocaml.org/packages/">docs de paquets</a>, accéder au
 					<a href="/releases/latest/manual.html"
 					target="_blank" rel="noopener"
-					>Manuel</a>, obtenir <a href="/docs/cheat_sheets.html">des mémentos</a> et <a href="/docs/index.fr.html">bien plus</a>.</p>
+					>Manuel</a>, obtenir <a href="/docs/cheat_sheets.html">des mémentos</a> et bien plus.</p>
                 </section>
             </div>
             <div class="row">
                 <section class="span4 home-feature">
-                    <a href="https://opam.ocaml.org">
+                    <span>
                         <img src="/img/platform-large.svg"
 						 alt="Contributions" class="svg">
                         <img src="/img/platform-large.png"
 						 alt="Contributions" class="png">
-					</a>
+					</span>
                     <h1><a href="https://opam.ocaml.org">Contributions</a></h1>
-                    <p>Le gestionnaire de paquets <a href="https://opam.ocaml.org">OPAM</a> vous donne accès aux multiples versions de
+                    <p>Le gestionnaire de paquets OPAM vous donne accès aux multiples versions de
 					<a href="https://opam.ocaml.org/packages/">centaines de paquets</a>.</p>
                 </section>
                 <section class="span4 home-feature">
-                    <a href="/community/index.fr.html">
+                    <span>
                         <img src="/img/community-large.svg"
 						 alt="Communauté" class="svg">
                         <img src="/img/community-large.png"
 						 alt="Communauté" class="png">
-                    </a>
+                    </span>
                     <h1><a href="/community/index.fr.html">Communauté</a></h1>
                     <p>Lire <a href="/community/planet/">les fils de news</a>,  <a href="/community/mailing_lists.fr.html">discuter et échanger</a>, obtenir <a href="/community/support.fr.html">du support</a>,
                     <a href="/meetings/index.fr.html" >rencontrer</a>
@@ -106,31 +106,29 @@
 			  <h1><a title="OCaml Users and Developers Workshop"
 			       href="/meetings/ocaml/2020/">OCaml 2020</a></h1>
 			  <p>28 août, 2020</p>
-			  <a title="OCaml Users and Developers Workshop"
-			     href="/meetings/ocaml/2020/">
+			  <span>
 			    <img alt="" src="/img/announcement.svg" class="svg" />
 			    <img alt="" src="/img/announcement.png" class="png" />
-			  </a>
+			  </span>
 			</article></li>
 			<li class="announcement"><article>
 			  <h1><a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
 			       href="/releases/{{! get LATEST_OCAML_VERSION !}}.html"
 				   >Parution d'OCaml {{! get LATEST_OCAML_VERSION !}}</a></h1>
 			   <p>24 février 2021</p>
-			   <a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
-			      href="/releases/{{! get LATEST_OCAML_VERSION !}}.html">
+			   <span>
 			    <img alt="" src="/img/announcement.svg" class="svg" />
 			    <img alt="" src="/img/announcement.png" class="png" />
-			  </a>
+			  </span>
 			</article></li>
 			<li class="announcement"><article>
 			  <h1><a title="OCaml Weekly News"
 			       href="/community/cwn/" >OCaml Weekly News</a></h1>
 			   <p>{{! cmd script/weekly_news --date !}}</p>
-			   <a title="OCaml Weekly News" href="/community/cwn/">
+			   <span>
 			    <img alt="" src="/img/announcement.svg" class="svg" />
 			    <img alt="" src="/img/announcement.png" class="png" />
-			  </a>
+			  </span>
 			</article></li>
 	        </ul>
             {{! cmd script/rss2html -n 5 --locale fr_FR.utf8 --headlines http://planet.ocaml.org/rss20.xml !}}

--- a/site/index.md
+++ b/site/index.md
@@ -21,49 +21,49 @@
         <div class="span8">
             <div class="row">
                 <section class="span4 home-feature">
-                    <a href="/learn/">
+                    <span>
                         <img src="/img/learn-large.svg" alt="Learn" class="svg" />
                         <img src="/img/learn-large.png" alt="Learn" class="png" />
-                    </a>
+                    </span>
                     <h1><a href="/learn/">Learn</a></h1>
-                    <p>Find out <a href="/learn/description.html">about OCaml</a>, read about <a href="/learn/companies.html">users</a>, see <a href="learn/taste.html">code examples</a>, go through <a href="/learn/tutorials/">tutorials</a> and <a href="/learn/">more</a>.</p>
+                    <p>Find out <a href="/learn/description.html">about OCaml</a>, read about <a href="/learn/companies.html">users</a>, see <a href="learn/taste.html">code examples</a>, go through <a href="/learn/tutorials/">tutorials</a> and more.</p>
                 </section>
                 <section class="span4 home-feature">
-                    <a href="/docs/">
+                    <span>
                         <img src="/img/documentation-large.svg"
 						alt="Documentation" class="svg" />
                         <img src="/img/documentation-large.png"
 						alt="Documentation" class="png" />
-                    </a>
+                    </span>
                     <h1><a href="/docs/">Documentation</a></h1>
                     <p><a href="docs/install.html" >Install</a> OCaml,
 					look up <a href="https://opam.ocaml.org/packages/">package docs</a>, access the
 					<a
     href="/releases/latest/manual.html"
-					>Manual</a>, get the <a href="/docs/cheat_sheets.html">cheat sheets</a> and <a href="/docs/">more</a>.</p>
+					>Manual</a>, get the <a href="/docs/cheat_sheets.html">cheat sheets</a> and more.</p>
                 </section>
             </div>
             <div class="row">
                 <section class="span4 home-feature">
-                    <a href="https://opam.ocaml.org">
+                    <span>
                         <img src="/img/platform-large.svg" alt="Platform"
 						 class="svg" />
                         <img src="/img/platform-large.png" alt="Platform"
 						 class="png" />
-					</a>
+					</span>
                     <h1><a href="https://opam.ocaml.org">Packages</a></h1>
-                    <p>The <a href="https://opam.ocaml.org">OCaml Package
-					Manager</a>, gives you access to multiple versions of
+                    <p>The OCaml Package
+					Manager, gives you access to multiple versions of
 					<a href="https://opam.ocaml.org/packages/">hundreds of
 					packages</a>.</p>
                 </section>
                 <section class="span4 home-feature">
-                    <a href="/community/">
+                    <span>
                         <img src="/img/community-large.svg" alt="Community"
 						 class="svg" />
                         <img src="/img/community-large.png" alt="Community"
 						 class="png" />
-                    </a>
+                    </span>
                     <h1><a href="/community/">Community</a></h1>
                     <p>Read the <a href="/community/planet/">news feed</a>, join the <a href="/community/mailing_lists.html">mailing lists</a>, get <a href="/community/support.html">support</a>,
                     attend <a href="/meetings/">meetings</a>, and find OCaml
@@ -108,31 +108,27 @@
 			  <h1><a title="OCaml Users and Developers Workshop"
 			       href="/meetings/ocaml/2020/">OCaml 2020</a></h1>
 			  <p>August 28, 2020</p>
-			  <a title="OCaml Users and Developers Workshop"
-			     href="/meetings/ocaml/2020/">
+			 <span>
 			    <img alt="" src="/img/announcement.svg" class="svg" />
 			    <img alt="" src="/img/announcement.png" class="png" />
-			  </a>
+			  </span>
 			</article></li>
 			<li class="announcement"><article>
-			  <h1><a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
-			       href="/releases/{{! get LATEST_OCAML_VERSION !}}.html"
+			  <h1><a href="/releases/{{! get LATEST_OCAML_VERSION !}}.html"
 				   >Release of OCaml {{! get LATEST_OCAML_VERSION !}}</a></h1>
 			   <p>February 24, 2021</p>
-			   <a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
-			      href="/releases/{{! get LATEST_OCAML_VERSION !}}.html">
+			   <span>
 			    <img alt="" src="/img/announcement.svg" class="svg" />
 			    <img alt="" src="/img/announcement.png" class="png" />
-			  </a>
+			  </span>
 			</article></li>
 			<li class="announcement"><article>
-			  <h1><a title="OCaml Weekly News"
-			       href="/community/cwn/" >OCaml Weekly News</a></h1>
+			  <h1><a href="/community/cwn/" >OCaml Weekly News</a></h1>
 			   <p>{{! cmd script/weekly_news --date !}}</p>
-			   <a title="OCaml Weekly News" href="/community/cwn/">
+			   <span>
 			    <img alt="" src="/img/announcement.svg" class="svg" />
 			    <img alt="" src="/img/announcement.png" class="png" />
-			  </a>
+			  </span>
 			</article></li>
 
 	        </ul>


### PR DESCRIPTION
# Issue Description

Please include a summary of the issue.
Removed the redundant links and redundant titles from the Home page and Documentation page. Having too many redundant links are bad for a website's SEO. Apart from this, too many redundant links confuse users and also waste their time when they began to click links that render to the same page.
Fixes # (issue)
Fixes #1517 
## Changes Made
**_BEFORE_**
![Screenshot from 2021-04-21 15-06-14](https://user-images.githubusercontent.com/57635473/115535859-c652e100-a2b6-11eb-9d1e-4248768932ab.png)
![Screenshot from 2021-04-21 15-07-17](https://user-images.githubusercontent.com/57635473/115536146-1631a800-a2b7-11eb-80e0-dc0e92de565a.png)

**_AFTER_**(removed some redundant links without interfering UI)
![Screenshot from 2021-04-21 15-05-13](https://user-images.githubusercontent.com/57635473/115535824-bc30e280-a2b6-11eb-81dc-b83518f867d1.png)
![Screenshot from 2021-04-21 15-06-52](https://user-images.githubusercontent.com/57635473/115536293-44af8300-a2b7-11eb-8176-56cad569ce8f.png)


* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
