### PR TITLE
Removal of repeated words in the success stories page 

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,36 +1,16 @@
 # Issue Description
 
-Different button colors on different pages #1353
-
 Please include a summary of the issue.
- The button color on other pages are green and text color are white while on news page the button color is grey and text color is deep grey
-
-BEFORE
-
-![Imgur](https://i.imgur.com/7W0d4Jy.png)
-
-![Imgur](https://i.imgur.com/ZhbSY7G.png)
-
 
 Fixes # (issue)
- #1353
 
 ## Changes Made
 
 Please describe the changes that you made.
 
-Changed the button color on news page to green & the text-color to white (Read more and Hide) and added a down arrow to the read more button and up arrow to the hide button and tested on a desktop
-
-
-AFTER
-
-![Imgur](https://i.imgur.com/w5OJH40.png)
-
-![Imgur](https://i.imgur.com/XPw76yh.png)
-
 * **Please check if the PR fulfills these requirements**
 
-- [x] PR is descriptively titled and links the original issue above
-- [x] Before/after screenshots (if this is a layout change)
-- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
-- [x] Context for what motivated the change (if this is a change to some content)
+- [ ] PR is descriptively titled and links the original issue above
+- [ ] Before/after screenshots (if this is a layout change)
+- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
+- [ ] Context for what motivated the change (if this is a change to some content)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,16 +1,36 @@
 # Issue Description
 
+Different button colors on different pages #1353
+
 Please include a summary of the issue.
+ The button color on other pages are green and text color are white while on news page the button color is grey and text color is deep grey
+
+BEFORE
+
+![Imgur](https://i.imgur.com/7W0d4Jy.png)
+
+![Imgur](https://i.imgur.com/ZhbSY7G.png)
+
 
 Fixes # (issue)
+ #1353
 
 ## Changes Made
 
 Please describe the changes that you made.
 
+Changed the button color on news page to green & the text-color to white (Read more and Hide) and added a down arrow to the read more button and up arrow to the hide button and tested on a desktop
+
+
+AFTER
+
+![Imgur](https://i.imgur.com/w5OJH40.png)
+
+![Imgur](https://i.imgur.com/XPw76yh.png)
+
 * **Please check if the PR fulfills these requirements**
 
-- [ ] PR is descriptively titled and links the original issue above
-- [ ] Before/after screenshots (if this is a layout change)
-- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
-- [ ] Context for what motivated the change (if this is a change to some content)
+- [x] PR is descriptively titled and links the original issue above
+- [x] Before/after screenshots (if this is a layout change)
+- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
+- [x] Context for what motivated the change (if this is a change to some content)

--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -303,12 +303,13 @@ let toggle ?(anchor="") html1 html2 =
   in
   let id1 = new_id() and id2 = new_id() in
   [Element("div", ["id", id1],
-           html1 @ [button id1 id2  "Read more"]);
-            Element("div", ["class","arrow-down"],[]);
+           html1 @ [button id1 id2  "Read more"] @ [ Element("div", ["class","arrow-down"],[])]);
+           
      
    Element("div", ["id", id2; "style", "display: none"],
-           html2 @ [button id2 id1 "Hide"] );
-            Element("div", ["class","arrow-up"],[])]
+        html2 @ [button id2 id1 "Hide"] @ [Element("div",["class","arrow-up"],[])])
+           
+            ]
 
 let toggle_script =
   let script =

--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -303,9 +303,12 @@ let toggle ?(anchor="") html1 html2 =
   in
   let id1 = new_id() and id2 = new_id() in
   [Element("div", ["id", id1],
-           html1 @ [button id1 id2 "Read more..."]);
+           html1 @ [button id1 id2  "Read more"]);
+            Element("div", ["class","arrow-down"],[]);
+     
    Element("div", ["id", id2; "style", "display: none"],
-           html2 @ [button id2 id1 "Hide"])]
+           html2 @ [button id2 id1 "Hide"] );
+            Element("div", ["class","arrow-up"],[])]
 
 let toggle_script =
   let script =

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -161,10 +161,37 @@ a.planet-toggle {
   float: right;
   font-size: 90%;
   padding: 5px 10px;
+  padding-right: 23px;
   margin-bottom: 2ex;
-  color: #4b4b4b;
-  background: #e6e6e6;
-  border: 1px solid #dedede;
+  color: #ffffff;
+  background: #008000;
+  border: 1px solid #008000;
+}
+.arrow-down {
+  width: 0; 
+  height: 0; 
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid #ffffff;
+  right: 15px;
+  float: right;
+  position: relative;
+  left: 85px;
+  top: 17px;
+ 
+}
+
+.arrow-up {
+  width: 0; 
+  height: 0; 
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 5px solid #ffffff;
+  float: right;
+  position: relative;
+  left: 52px;
+  top: 18px;
+  
 }
 
 a.planet-toggle:hover, a.planet-toggle:focus {

--- a/site/learn/success.md
+++ b/site/learn/success.md
@@ -13,7 +13,7 @@ generating billions of dollars of transactions every day from our offices
 in Hong Kong, London and New York, with strategies that span many asset classes,
 time-zones and regulatory regimes.
 
-Almost all of of our software is written in OCaml, from statistical
+Almost all of our software is written in OCaml, from statistical
 research code to systems-administration tools to our real-time trading
 infrastructure.  OCaml’s type system acts as a rich and
 well-integrated set of static analysis tools that help improve the
@@ -207,7 +207,7 @@ optimized C code to compute DFTs of size N. FFTW was awarded the 1999
 [Wilkinson prize](https://en.wikipedia.org/wiki/J._H._Wilkinson_Prize_for_Numerical_Software)
 for numerical software.
 
-Benchmarks, performed on on a variety of platforms, show that FFTW's
+Benchmarks, performed on a variety of platforms, show that FFTW's
 performance is typically superior to that of other publicly available
 DFT software, and is even competitive with vendor-tuned codes. In
 contrast to vendor-tuned codes, however, FFTW's performance is portable:


### PR DESCRIPTION
# Issue Description
repetition of words in the success stories page #1540

Please include a summary of the issue.
There are words repeated in the success stories page  ( Jane street and FFTW)

BEFORE

![of](https://user-images.githubusercontent.com/48384861/115568621-622f1d80-a2b4-11eb-8c39-91173448eb4e.png)

![on](https://user-images.githubusercontent.com/48384861/115568906-a28e9b80-a2b4-11eb-9b79-d98bbc33b820.png)


Fixes #1540 

## Changes Made

Please describe the changes that you made.
Removal of repeated words in the success stories page ( Jane street and FFTW). and tested on  a desktop device.

AFTER
![of2](https://user-images.githubusercontent.com/48384861/115569340-0a44e680-a2b5-11eb-8c97-6f906efc622e.png)

![on2](https://user-images.githubusercontent.com/48384861/115569371-12048b00-a2b5-11eb-954c-9641a67d3dbb.png)



* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
