### PR TITLE
removal of repeated words in the success stories page

### DIFF
--- a/site/learn/success.md
+++ b/site/learn/success.md
@@ -13,7 +13,7 @@ generating billions of dollars of transactions every day from our offices
 in Hong Kong, London and New York, with strategies that span many asset classes,
 time-zones and regulatory regimes.
 
-Almost all of of our software is written in OCaml, from statistical
+Almost all of our software is written in OCaml, from statistical
 research code to systems-administration tools to our real-time trading
 infrastructure.  OCaml’s type system acts as a rich and
 well-integrated set of static analysis tools that help improve the
@@ -207,7 +207,7 @@ optimized C code to compute DFTs of size N. FFTW was awarded the 1999
 [Wilkinson prize](https://en.wikipedia.org/wiki/J._H._Wilkinson_Prize_for_Numerical_Software)
 for numerical software.
 
-Benchmarks, performed on on a variety of platforms, show that FFTW's
+Benchmarks, performed on a variety of platforms, show that FFTW's
 performance is typically superior to that of other publicly available
 DFT software, and is even competitive with vendor-tuned codes. In
 contrast to vendor-tuned codes, however, FFTW's performance is portable:


### PR DESCRIPTION
# Issue Description
repetition of words in the success stories page #1540

Please include a summary of the issue.
There are words repeated in the success stories page  ( Jane street and FFTW)

BEFORE

![of](https://user-images.githubusercontent.com/48384861/115568621-622f1d80-a2b4-11eb-8c39-91173448eb4e.png)

![on](https://user-images.githubusercontent.com/48384861/115568906-a28e9b80-a2b4-11eb-9b79-d98bbc33b820.png)


Fixes #1540 

## Changes Made

Please describe the changes that you made.
Removal of repeated words in the success stories page ( Jane street and FFTW). and tested on  a desktop device.

AFTER
![of2](https://user-images.githubusercontent.com/48384861/115569340-0a44e680-a2b5-11eb-8c97-6f906efc622e.png)

![on2](https://user-images.githubusercontent.com/48384861/115569371-12048b00-a2b5-11eb-954c-9641a67d3dbb.png)



* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [x] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
