### PR TITLE
I have corrected some grammatical errors in the Ocaml docs

### DIFF
--- a/site/releases/4.04/htmlman/coreexamples.html
+++ b/site/releases/4.04/htmlman/coreexamples.html
@@ -26,14 +26,14 @@
 <p> <a id="c:core-xamples"></a>
 
 </p><p>This part of the manual is a tutorial introduction to the
-OCaml language. A good familiarity with programming in a conventional
+OCaml language. A good familiarity with programming in any of the conventional
 languages (say, Pascal or C) is assumed, but no prior exposure to
 functional languages is required. The present chapter introduces the
 core language. Chapter&#XA0;<a href="moduleexamples.html#c%3Amoduleexamples">2</a> deals with the
-module system, chapter&#XA0;<a href="objectexamples.html#c%3Aobjectexamples">3</a> with the
-object-oriented features, chapter&#XA0;<a href="lablexamples.html#c%3Alabl-examples">4</a> with
+module system, Chapter&#XA0;<a href="objectexamples.html#c%3Aobjectexamples">3</a> with the
+object-oriented features, Chapter&#XA0;<a href="lablexamples.html#c%3Alabl-examples">4</a> with
 extensions to the core language (labeled arguments and polymorphic
-variants), and chapter&#XA0;<a href="advexamples.html#c%3Aadvexamples">5</a> gives some advanced examples.</p>
+variants), and Chapter&#XA0;<a href="advexamples.html#c%3Aadvexamples">5</a> gives some advanced examples.</p>
 <h2 class="section" id="sec8">1.1&#XA0;&#XA0;Basics</h2>
 <p>For this overview of OCaml, we use the interactive system, which
 is started by running <span class="c006">ocaml</span> from the Unix shell, or by launching the


### PR DESCRIPTION
# Issue Description
There was a small grammatical error in the Ocaml docs 

Please include a summary of the issue.
I added some meaningful text and also changed small letter to caps for some words
![Screenshot (69)](https://user-images.githubusercontent.com/61267392/115712387-5580f700-a392-11eb-8e5e-d61b486dc141.png)
![Screenshot (70)](https://user-images.githubusercontent.com/61267392/115712414-5c0f6e80-a392-11eb-86bb-63deaa59d1a1.png)


Fixes # (issue)
original:
A good familiarity with programming in a conventional languages (say, C or Java) is assumed
what I changed:
A good familiarity with programming in any of the conventional languages (say, C or Java) is assumed
## Changes Made

Please describe the changes that you made.

* **Please check if the PR fulfills these requirements**

- [ ] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
