### PR TITLE
Improved user experience in the OCaml Documentation Tutorials

### DIFF
--- a/site/releases/4.12/htmlman/advexamples.html
+++ b/site/releases/4.12/htmlman/advexamples.html
@@ -7,12 +7,26 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Advanced examples with classes and modules</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a></li><li class="active"><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec64"><span class="number">Chapter 6</span>Advanced examples with classes and modules</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  An introduction to OCaml
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a>
+  </li>
+  <li  class="active"><a href="advexamples.html">Advanced examples with classes and modules</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+  <h1 class="chapter" id="sec64"><span class="number">Chapter 6</span>Advanced examples with classes and modules</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Advanced examples with classes and modules</a></li>
 <li><a href="advexamples.html#s%3Aextended-bank-accounts"><span class="number">1</span>Extended example: bank accounts</a>
 </li><li><a href="advexamples.html#s%3Amodules-as-classes"><span class="number">2</span>Simple modules as classes</a>

--- a/site/releases/4.12/htmlman/afl-fuzz.html
+++ b/site/releases/4.12/htmlman/afl-fuzz.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Fuzzing with afl-fuzz</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li class="active"><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec546"><span class="number">Chapter 20</span>Fuzzing with afl-fuzz</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li  class="active"><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec546"><span class="number">Chapter 20</span>Fuzzing with afl-fuzz</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Fuzzing with afl-fuzz</a></li>
 <li><a href="afl-fuzz.html#s%3Aafl-overview"><span class="number">1</span>Overview</a>
 </li><li><a href="afl-fuzz.html#s%3Aafl-generate"><span class="number">2</span>Generating instrumentation</a>

--- a/site/releases/4.12/htmlman/alerts.html
+++ b/site/releases/4.12/htmlman/alerts.html
@@ -7,12 +7,24 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/attributes.html
+++ b/site/releases/4.12/htmlman/attributes.html
@@ -7,12 +7,24 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+  <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/bigarray.html
+++ b/site/releases/4.12/htmlman/bigarray.html
@@ -7,12 +7,24 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+  <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/bindingops.html
+++ b/site/releases/4.12/htmlman/bindingops.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
+  <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/classes.html
+++ b/site/releases/4.12/htmlman/classes.html
@@ -7,12 +7,24 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
 </li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>

--- a/site/releases/4.12/htmlman/comp.html
+++ b/site/releases/4.12/htmlman/comp.html
@@ -7,12 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Batch compilation (ocamlc)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li class="active"><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec287"><span class="number">Chapter 9</span>Batch compilation (ocamlc)</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" ><h1 class="chapter" id="sec287"><span class="number">Chapter 9</span>Batch compilation (ocamlc)</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Batch compilation (ocamlc)</a></li>
 <li><a href="comp.html#s%3Acomp-overview"><span class="number">1</span>Overview of the compiler</a>
 </li><li><a href="comp.html#s%3Acomp-options"><span class="number">2</span>Options</a>
@@ -103,7 +113,7 @@ with the object files ( <span class="c004">.cmo</span> files)
 given on the command line, instead of linking them into an executable file.
 The name of the library must be set with the <span class="c004">-o</span> option.<p>If <span class="c004">-custom</span>, <span class="c004">-cclib</span> or <span class="c004">-ccopt</span> options are passed on the command
 line, these options are stored in the resulting <span class="c004">.cma</span>library. Then,
-linking with this library automatically adds back the <span class="c004">-custom</span>, 
+linking with this library automatically adds back the <span class="c004">-custom</span>,
 <span class="c004">-cclib</span> and <span class="c004">-ccopt</span> options as if they had been provided on the
 command line, unless the <span class="c004">-noautolink</span> option is given.
 </p></dd><dt class="dt-description"><span class="c007">-absname</span></dt><dd class="dd-description">
@@ -129,7 +139,7 @@ compilation. Source code files are turned into compiled files, but no
 executable file is produced. This option is useful to
 compile modules separately.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">-cc</span> <span class="c010">ccomp</span></span></dt><dd class="dd-description">
-Use <span class="c010">ccomp</span> as the C linker 
+Use <span class="c010">ccomp</span> as the C linker
 when linking in “custom runtime” mode (see the <span class="c004">-custom</span> option)
 and as the C compiler for compiling <span class="c004">.c</span> source files.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">-cclib</span> <span class="c004">-l</span><span class="c010">libname</span></span></dt><dd class="dd-description">

--- a/site/releases/4.12/htmlman/compunit.html
+++ b/site/releases/4.12/htmlman/compunit.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
+  <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
 </li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>

--- a/site/releases/4.12/htmlman/const.html
+++ b/site/releases/4.12/htmlman/const.html
@@ -7,12 +7,24 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
 </li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>

--- a/site/releases/4.12/htmlman/core.html
+++ b/site/releases/4.12/htmlman/core.html
@@ -7,12 +7,24 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The core library</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li class="active"><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec563"><span class="number">Chapter 22</span>The core library</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml library
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div-1" style="position:fixed;">
+  <ul id="part-menu">
+    <li class="active"><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li>
+  </br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+  <h1 class="chapter" id="sec563"><span class="number">Chapter 22</span>The core library</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The core library</a></li>
 <li><a href="core.html#s%3Acore-builtins"><span class="number">1</span>Built-in types and predefined exceptions</a>
 </li><li><a href="core.html#s%3Astdlib-module"><span class="number">2</span>Module <span class="c004">Stdlib</span>: the initially opened module</a>

--- a/site/releases/4.12/htmlman/coreexamples.html
+++ b/site/releases/4.12/htmlman/coreexamples.html
@@ -2,16 +2,30 @@
 
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="generator" content="hevea 2.35">
-
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The core language</title>
-<script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li class="active"><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a></li><li><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
-
-
-
-
+<script src="scroll.js"></script><script src="navigation.js"></script>
+<link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
+<body>
+<div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+An introduction to OCaml
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li class="active"><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a>
+</li>
+<li><a href="advexamples.html">Advanced examples with classes and modules</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
 <h1 class="chapter" id="sec7"><span class="number">Chapter 1</span>The core language</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The core language</a></li>
 <li><a href="coreexamples.html#s%3Abasics"><span class="number">1</span>Basics</a>
@@ -1394,7 +1408,7 @@ the function <span class="c004">f</span> cannot raise a <span class="c004">Done<
 entire class of misbehaving functions.</p>
 <h2 class="section" id="s:lazy-expr"><a class="section-anchor" href="#s:lazy-expr" aria-hidden="true">﻿</a><span class="number">7</span>Lazy expressions</h2>
 <p>OCaml allows us to defer some computation until later when we need the result of
-that computation. </p><p>We use <span class="c004">lazy (expr)</span> to delay the evaluation of some expression <span class="c004">expr</span>. For 
+that computation. </p><p>We use <span class="c004">lazy (expr)</span> to delay the evaluation of some expression <span class="c004">expr</span>. For
 example, we can defer the computation of <span class="c004">1+1</span> until we need the result of that
 expression, <span class="c004">2</span>. Let us see how we initialize a lazy expression. </p><div class="caml-example toplevel">
 
@@ -1409,10 +1423,10 @@ expression, <span class="c004">2</span>. Let us see how we initialize a lazy exp
 <div class="pre caml-output ok"><span class="ocamlkeyword">val</span> lazy_two : int lazy_t = &lt;<span class="ocamlkeyword">lazy</span>&gt;</div></div>
 
 </div><p>We added <span class="c004">print_endline "lazy_two evaluation"</span> to see when the lazy
-expression is being evaluated.</p><p>The value of <span class="c004">lazy_two</span> is displayed as <span class="c004">&lt;lazy&gt;</span>, which means the expression 
-has not been evaluated yet, and its final value is unknown.</p><p>Note that <span class="c004">lazy_two</span> has type <span class="c004">int lazy_t</span>. However, the type <span class="c004">'a lazy_t</span> is an 
-internal type name, so the type <span class="c004">'a Lazy.t</span> should be preferred when possible.</p><p>When we finally need the result of a lazy expression, we can call <span class="c004">Lazy.force</span> 
-on that expression to force its evaluation. The function <span class="c004">force</span> comes from 
+expression is being evaluated.</p><p>The value of <span class="c004">lazy_two</span> is displayed as <span class="c004">&lt;lazy&gt;</span>, which means the expression
+has not been evaluated yet, and its final value is unknown.</p><p>Note that <span class="c004">lazy_two</span> has type <span class="c004">int lazy_t</span>. However, the type <span class="c004">'a lazy_t</span> is an
+internal type name, so the type <span class="c004">'a Lazy.t</span> should be preferred when possible.</p><p>When we finally need the result of a lazy expression, we can call <span class="c004">Lazy.force</span>
+on that expression to force its evaluation. The function <span class="c004">force</span> comes from
 standard-library module <a href="../api/Lazy.html"><span class="c004">Lazy</span></a>.</p><div class="caml-example toplevel">
 
 <div class="ocaml">
@@ -1426,8 +1440,8 @@ standard-library module <a href="../api/Lazy.html"><span class="c004">Lazy</span
 <div class="pre caml-output ok">lazy_two evaluation
 - : int = 2</div></div>
 
-</div><p>Notice that our function call above prints “lazy_two evaluation” and then 
-returns the plain value of the computation. </p><p>Now if we look at the value of <span class="c004">lazy_two</span>, we see that it is not displayed as 
+</div><p>Notice that our function call above prints “lazy_two evaluation” and then
+returns the plain value of the computation. </p><p>Now if we look at the value of <span class="c004">lazy_two</span>, we see that it is not displayed as
 <span class="c004">&lt;lazy&gt;</span> anymore but as <span class="c004">lazy 2</span>.</p><div class="caml-example toplevel">
 
 <div class="ocaml">
@@ -1440,9 +1454,9 @@ returns the plain value of the computation. </p><p>Now if we look at the value o
 
 <div class="pre caml-output ok">- : int lazy_t = <span class="ocamlkeyword">lazy</span> 2</div></div>
 
-</div><p>This is because <span class="c004">Lazy.force</span> memoizes the result of the forced expression. In other 
-words, every subsequent call of <span class="c004">Lazy.force</span> on that expression returns the 
-result of the first computation without recomputing the lazy expression. Let us 
+</div><p>This is because <span class="c004">Lazy.force</span> memoizes the result of the forced expression. In other
+words, every subsequent call of <span class="c004">Lazy.force</span> on that expression returns the
+result of the first computation without recomputing the lazy expression. Let us
 force <span class="c004">lazy_two</span> once again. </p><div class="caml-example toplevel">
 
 <div class="ocaml">
@@ -1492,9 +1506,9 @@ not printed. The result of the initial computation is simply returned. </p><p>La
 
 <div class="pre caml-output ok"><span class="ocamlkeyword">val</span> maybe_eval : bool lazy_t -&gt; 'a lazy_t -&gt; string = &lt;<span class="ocamlkeyword">fun</span>&gt;</div></div>
 
-</div><p>The lazy expression <span class="c004">lazy_expr</span> is forced only if the <span class="c004">lazy_guard</span> value yields 
-<span class="c004">true</span> once computed. Indeed, a simple wildcard pattern (not lazy) never forces 
-the lazy expression’s evaluation. However, a pattern with keyword <span class="c004">lazy</span>, even 
+</div><p>The lazy expression <span class="c004">lazy_expr</span> is forced only if the <span class="c004">lazy_guard</span> value yields
+<span class="c004">true</span> once computed. Indeed, a simple wildcard pattern (not lazy) never forces
+the lazy expression’s evaluation. However, a pattern with keyword <span class="c004">lazy</span>, even
 if it is wildcard, always forces the evaluation of the deferred computation.</p>
 <h2 class="section" id="s:symb-expr"><a class="section-anchor" href="#s:symb-expr" aria-hidden="true">﻿</a><span class="number">8</span>Symbolic processing of expressions</h2>
 <p>We finish this introduction with a more complete example

--- a/site/releases/4.12/htmlman/debugger.html
+++ b/site/releases/4.12/htmlman/debugger.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The debugger (ocamldebug)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li class="active"><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec381"><span class="number">Chapter 16</span>The debugger (ocamldebug)</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li class="active"><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec381"><span class="number">Chapter 16</span>The debugger (ocamldebug)</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The debugger (ocamldebug)</a></li>
 <li><a href="debugger.html#s%3Adebugger-compilation"><span class="number">1</span>Compiling for debugging</a>
 </li><li><a href="debugger.html#s%3Adebugger-invocation"><span class="number">2</span>Invocation</a>
@@ -364,7 +375,7 @@ information it may have cached about the files.</p><dl class="description"><dt c
 Add the given directories to the search path. These directories are
 added at the front, and will therefore be searched first.</dd><dt class="dt-description"><span class="c014"><span class="c004">directory</span> <span class="c010">directorynames</span> <span class="c004">for</span> <span class="c010">modulename</span></span></dt><dd class="dd-description">
 Same as <span class="c004">directory</span> <span class="c010">directorynames</span>, but the given directories will be
-searched only when looking for the source file of a module that has 
+searched only when looking for the source file of a module that has
 been packed into <span class="c010">modulename</span>.</dd><dt class="dt-description"><span class="c007">directory</span></dt><dd class="dd-description">
 Reset the search path. This requires confirmation.
 </dd></dl>

--- a/site/releases/4.12/htmlman/depend.html
+++ b/site/releases/4.12/htmlman/depend.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Dependency generator (ocamldep)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li class="active"><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec341"><span class="number">Chapter 14</span>Dependency generator (ocamldep)</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li class="active"><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec341"><span class="number">Chapter 14</span>Dependency generator (ocamldep)</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Dependency generator (ocamldep)</a></li>
 <li><a href="depend.html#s%3Aocamldep-options"><span class="number">1</span>Options</a>
 </li><li><a href="depend.html#s%3Aocamldep-makefile"><span class="number">2</span>A typical Makefile</a>

--- a/site/releases/4.12/htmlman/doccomments.html
+++ b/site/releases/4.12/htmlman/doccomments.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
+  <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/emptyvariants.html
+++ b/site/releases/4.12/htmlman/emptyvariants.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
+  <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/expr.html
+++ b/site/releases/4.12/htmlman/expr.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
+  <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
 </li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>
@@ -360,11 +371,11 @@ is equivalent to
 Beware of the small syntactic difference between a type constraint on
 the last parameter
 </p><div class="center">
-<span class="c005">fun</span> <a class="syntax" href="#parameter"><span class="c011">parameter</span></a><sub>1</sub> …  (<a class="syntax" href="#parameter"><span class="c011">parameter</span></a><sub><span class="c010">n</span></sub><span class="c005">:</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a>)<span class="c005">-&gt;</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a> 
+<span class="c005">fun</span> <a class="syntax" href="#parameter"><span class="c011">parameter</span></a><sub>1</sub> …  (<a class="syntax" href="#parameter"><span class="c011">parameter</span></a><sub><span class="c010">n</span></sub><span class="c005">:</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a>)<span class="c005">-&gt;</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a>
 </div><p>
 and one on the result
 </p><div class="center">
-<span class="c005">fun</span> <a class="syntax" href="#parameter"><span class="c011">parameter</span></a><sub>1</sub> …  <a class="syntax" href="#parameter"><span class="c011">parameter</span></a><sub><span class="c010">n</span></sub><span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a> <span class="c005">-&gt;</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a> 
+<span class="c005">fun</span> <a class="syntax" href="#parameter"><span class="c011">parameter</span></a><sub>1</sub> …  <a class="syntax" href="#parameter"><span class="c011">parameter</span></a><sub><span class="c010">n</span></sub><span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typexpr</span></a> <span class="c005">-&gt;</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a>
 </div><p>The parameter patterns <span class="c005">~</span><a class="syntax" href="lex.html#label-name"><span class="c011">lab</span></a> and <span class="c005">~(</span><a class="syntax" href="lex.html#label-name"><span class="c011">lab</span></a>  [<span class="c005">:</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>]<span class="c005">)</span>
 are shorthands for respectively <span class="c005">~</span><a class="syntax" href="lex.html#label-name"><span class="c011">lab</span></a><span class="c005">:</span> <a class="syntax" href="lex.html#label-name"><span class="c011">lab</span></a> and
 <span class="c005">~</span><a class="syntax" href="lex.html#label-name"><span class="c011">lab</span></a><span class="c005">:(</span> <a class="syntax" href="lex.html#label-name"><span class="c011">lab</span></a>  [<span class="c005">:</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>]<span class="c005">)</span>, and similarly for their optional
@@ -461,7 +472,7 @@ as explained in section&nbsp;<a href="letrecvalues.html#s%3Aletrecvalues">8.1</a
 <p>
 (Introduced in OCaml 3.12)</p><p>Polymorphic type annotations in <span class="c005">let</span>-definitions behave in a way
 similar to polymorphic methods:</p><div class="center">
-<span class="c005">let</span> <a class="syntax" href="patterns.html#pattern"><span class="c011">pattern</span></a><sub>1</sub> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>1</sub> …  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub><span class="c010">n</span></sub> <span class="c005">.</span>  <span class="c011">typeexpr</span> <span class="c005">=</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a> 
+<span class="c005">let</span> <a class="syntax" href="patterns.html#pattern"><span class="c011">pattern</span></a><sub>1</sub> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>1</sub> …  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub><span class="c010">n</span></sub> <span class="c005">.</span>  <span class="c011">typeexpr</span> <span class="c005">=</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a>
 </div><p>These annotations explicitly require the defined value to be polymorphic,
 and allow one to use this polymorphism in recursive occurrences
 (when using <span class="c003"><span class="c004">let</span> <span class="c004">rec</span></span>). Note however that this is a normal polymorphic
@@ -575,7 +586,7 @@ whose constructor is <a class="syntax" href="names.html#constr"><span class="c01
  <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub><span class="c010">n</span></sub>.</p><p>The expression <a class="syntax" href="names.html#constr"><span class="c011">constr</span></a> <span class="c005">(</span> <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub>, …,  <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub><span class="c010">n</span></sub><span class="c005">)</span> evaluates to the
 variant value whose constructor is <a class="syntax" href="names.html#constr"><span class="c011">constr</span></a>, and whose arguments are
 the values of <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub> …  <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub><span class="c010">n</span></sub>.</p><p>For lists, some syntactic sugar is provided. The expression
-<a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub> <span class="c005">::</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>2</sub> stands for the constructor <span class="c003"><span class="c004">(</span> <span class="c004">::</span> <span class="c004">)</span></span> 
+<a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub> <span class="c005">::</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>2</sub> stands for the constructor <span class="c003"><span class="c004">(</span> <span class="c004">::</span> <span class="c004">)</span></span>
 applied to the arguments <span class="c005">(</span> <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub> <span class="c005">,</span>  <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>2</sub> <span class="c005">)</span>, and therefore
 evaluates to the list whose head is the value of <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub> and whose tail
 is the value of <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>2</sub>. The expression <span class="c005">[</span> <a class="syntax" href="#expr"><span class="c011">expr</span></a><sub>1</sub> <span class="c005">;</span> … <span class="c005">;</span>
@@ -774,13 +785,13 @@ In the following paragraphs we describe the subtyping relation used.</p><h4 clas
 its methods. The types of the methods shall be subtypes of those in
 the supertype. Namely,
 </p><div class="center">
- <span class="c005">&lt;</span> <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub>1</sub> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>1</sub> <span class="c005">;</span> … <span class="c005">;</span>  <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub><span class="c010">n</span></sub> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub><span class="c010">n</span></sub> <span class="c005">&gt;</span> 
+ <span class="c005">&lt;</span> <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub>1</sub> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>1</sub> <span class="c005">;</span> … <span class="c005">;</span>  <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub><span class="c010">n</span></sub> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub><span class="c010">n</span></sub> <span class="c005">&gt;</span>
 </div><p>
 is a supertype of
 </p><div class="center">
  <span class="c005">&lt;</span> <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub>1</sub> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>1</sub> <span class="c005">;</span> … <span class="c005">;</span> <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub><span class="c010">n</span></sub> <span class="c005">:</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">n</span></sub> <span class="c005">;</span>
 <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub><span class="c010">n</span>+1</sub> <span class="c005">:</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">n</span>+1</sub> <span class="c005">;</span> … <span class="c005">;</span> <a class="syntax" href="names.html#method-name"><span class="c011">met</span></a><sub><span class="c010">n</span>+<span class="c010">m</span></sub> <span class="c005">:</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">n</span>+<span class="c010">m</span></sub>
-&nbsp;[<span class="c003"><span class="c004">;</span> <span class="c004">..</span></span>] <span class="c005">&gt;</span> 
+&nbsp;[<span class="c003"><span class="c004">;</span> <span class="c004">..</span></span>] <span class="c005">&gt;</span>
 </div><p>
 which may contain an ellipsis <span class="c004">..</span> if every <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub><span class="c010">i</span></sub> is a supertype of
 the corresponding <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">i</span></sub>.</p><p>A monomorphic method type can be a supertype of a polymorphic method
@@ -798,13 +809,13 @@ is included in the lower bound of <a class="syntax" href="types.html#typexpr"><s
 for the constructors of <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a> are subtypes of those in
 <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′. Namely,
 </p><div class="center">
- <span class="c005">[</span>[<span class="c005">&lt;</span>] <span class="c005">`</span><a class="syntax" href="names.html#constr-name"><span class="c011">C</span></a><sub>1</sub> <span class="c005">of</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>1</sub> <span class="c005">|</span> … <span class="c003"><span class="c004">|</span> <span class="c004">`</span></span> <a class="syntax" href="names.html#constr-name"><span class="c011">C</span></a><sub><span class="c010">n</span></sub> <span class="c005">of</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub><span class="c010">n</span></sub> <span class="c005">]</span> 
+ <span class="c005">[</span>[<span class="c005">&lt;</span>] <span class="c005">`</span><a class="syntax" href="names.html#constr-name"><span class="c011">C</span></a><sub>1</sub> <span class="c005">of</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub>1</sub> <span class="c005">|</span> … <span class="c003"><span class="c004">|</span> <span class="c004">`</span></span> <a class="syntax" href="names.html#constr-name"><span class="c011">C</span></a><sub><span class="c010">n</span></sub> <span class="c005">of</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub><span class="c010">n</span></sub> <span class="c005">]</span>
 </div><p>
 which may be a shrinkable type, is a subtype of
 </p><div class="center">
  <span class="c005">[</span>[<span class="c005">&gt;</span>] <span class="c005">`</span><a class="syntax" href="names.html#constr-name"><span class="c011">C</span></a><sub>1</sub> <span class="c005">of</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub>1</sub> <span class="c005">|</span> … <span class="c003"><span class="c004">|</span> <span class="c004">`</span></span><a class="syntax" href="names.html#constr-name"><span class="c011">C</span></a><sub><span class="c010">n</span></sub> <span class="c005">of</span>  <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">n</span></sub>
 <span class="c003"><span class="c004">|</span> <span class="c004">`</span></span><a class="syntax" href="names.html#constr-name"><span class="c011">C</span></a><sub><span class="c010">n</span>+1</sub> <span class="c005">of</span> <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">n</span>+1</sub> <span class="c005">|</span> … <span class="c003"><span class="c004">|</span> <span class="c004">`</span></span><a class="syntax" href="names.html#constr-name"><span class="c011">C</span></a><sub><span class="c010">n</span>+<span class="c010">m</span></sub> <span class="c005">of</span>
-<a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">n</span>+<span class="c010">m</span></sub> <span class="c005">]</span> 
+<a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">n</span>+<span class="c010">m</span></sub> <span class="c005">]</span>
 </div><p>
 which may be an extensible type, if every <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a><sub><span class="c010">i</span></sub> is a subtype of <a class="syntax" href="types.html#typexpr"><span class="c011">typ</span></a>′<sub><span class="c010">i</span></sub>.</p><h4 class="subsubsection" id="sss:expr-variance"><a class="section-anchor" href="#sss:expr-variance" aria-hidden="true">﻿</a>Variance</h4>
 <p>Other types do not introduce new subtyping, but they may propagate the

--- a/site/releases/4.12/htmlman/extensiblevariants.html
+++ b/site/releases/4.12/htmlman/extensiblevariants.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
+  <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/extensionnodes.html
+++ b/site/releases/4.12/htmlman/extensionnodes.html
@@ -7,12 +7,24 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/extensionsyntax.html
+++ b/site/releases/4.12/htmlman/extensionsyntax.html
@@ -7,11 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
+  
 <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>

--- a/site/releases/4.12/htmlman/extn.html
+++ b/site/releases/4.12/htmlman/extn.html
@@ -7,12 +7,24 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1>
 <p> <a id="c:extensions"></a>
 </p><p>This chapter describes language extensions and convenience features
 that are implemented in OCaml, but not described in chapter <a href="language.html#c%3Arefman">7</a>.</p><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>

--- a/site/releases/4.12/htmlman/firstclassmodules.html
+++ b/site/releases/4.12/htmlman/firstclassmodules.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
 <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>

--- a/site/releases/4.12/htmlman/flambda.html
+++ b/site/releases/4.12/htmlman/flambda.html
@@ -7,12 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Optimisation with Flambda</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li class="active"><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec495"><span class="number">Chapter 19</span>Optimisation with Flambda</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li class="active"><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" ><h1 class="chapter" id="sec495"><span class="number">Chapter 19</span>Optimisation with Flambda</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Optimisation with Flambda</a></li>
 <li><a href="flambda.html#s%3Aflambda-overview"><span class="number">1</span>Overview</a>
 </li><li><a href="flambda.html#s%3Aflambda-cli"><span class="number">2</span>Command-line flags</a>
@@ -642,7 +652,7 @@ the attribute it behaves as follows:
 <ul class="itemize"><li class="li-itemize">
 If <span class="c010">n</span> is zero or less, nothing happens.
 </li><li class="li-itemize">Otherwise the function being called is substituted at the call site
-with its body having been rewritten such that 
+with its body having been rewritten such that
 any recursive calls to that function <em>or
 any others in the same mutually-recursive group</em> are annotated with the
 attribute <span class="c004">unrolled(</span><span class="c010">n</span> − 1<span class="c004">)</span>. Inlining may continue on that body.

--- a/site/releases/4.12/htmlman/gadts.html
+++ b/site/releases/4.12/htmlman/gadts.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
+  <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/generalizedopens.html
+++ b/site/releases/4.12/htmlman/generalizedopens.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
+  <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/generativefunctors.html
+++ b/site/releases/4.12/htmlman/generativefunctors.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
 <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>

--- a/site/releases/4.12/htmlman/indexops.html
+++ b/site/releases/4.12/htmlman/indexops.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
+  <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/inlinerecords.html
+++ b/site/releases/4.12/htmlman/inlinerecords.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
 <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>

--- a/site/releases/4.12/htmlman/instrumented-runtime.html
+++ b/site/releases/4.12/htmlman/instrumented-runtime.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Runtime tracing with the instrumented runtime</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li class="active"><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec551"><span class="number">Chapter 21</span>Runtime tracing with the instrumented runtime</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li class="active"><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec551"><span class="number">Chapter 21</span>Runtime tracing with the instrumented runtime</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Runtime tracing with the instrumented runtime</a></li>
 <li><a href="instrumented-runtime.html#s%3Ainstr-runtime-overview"><span class="number">1</span>Overview</a>
 </li><li><a href="instrumented-runtime.html#s%3Ainstr-runtime-enabling"><span class="number">2</span>Enabling runtime instrumentation</a>

--- a/site/releases/4.12/htmlman/intfc.html
+++ b/site/releases/4.12/htmlman/intfc.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Interfacing C with OCaml</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li class="active"><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="c:intf-c"><span class="number">Chapter 18</span>Interfacing C with OCaml</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li class="active"><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="c:intf-c"><span class="number">Chapter 18</span>Interfacing C with OCaml</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Interfacing C with OCaml</a></li>
 <li><a href="intfc.html#s%3Ac-overview"><span class="number">1</span>Overview and compilation information</a>
 </li><li><a href="intfc.html#s%3Ac-value"><span class="number">2</span>The <span class="c004">value</span> type</a>
@@ -1857,7 +1868,7 @@ code around C calls. Technically it wraps every C call with the C function
 <span class="c004">caml_c_call</span> which is part of the OCaml runtime.</p><p>For small functions that are called repeatedly, this indirection can have
 a big impact on performances. However this is not needed if we know that
 the C function doesn’t allocate, doesn’t raise exceptions, and doesn’t release
-the master lock (see section&nbsp;<a href="#ss%3Aparallel-execution-long-running-c-code">18.12.2</a>). 
+the master lock (see section&nbsp;<a href="#ss%3Aparallel-execution-long-running-c-code">18.12.2</a>).
 We can instruct the OCaml native-code compiler of this fact by annotating the
 external declaration with the attribute <span class="c004">[@@noalloc]</span>:</p><pre>external bar : int -&gt; int -&gt; int = "foo" [@@noalloc]
 </pre><p>

--- a/site/releases/4.12/htmlman/lablexamples.html
+++ b/site/releases/4.12/htmlman/lablexamples.html
@@ -7,11 +7,26 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Labels and variants</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li class="active"><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a></li><li><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
-
-
-
-
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  An introduction to OCaml
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li ><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li class="active"><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a>
+  </li>
+  <li><a href="advexamples.html">Advanced examples with classes and modules</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+</body>
 <h1 class="chapter" id="sec44"><span class="number">Chapter 4</span>Labels and variants</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Labels and variants</a></li>
 <li><a href="lablexamples.html#s%3Alabels"><span class="number">1</span>Labels</a>

--- a/site/releases/4.12/htmlman/language.html
+++ b/site/releases/4.12/htmlman/language.html
@@ -7,11 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1>
 <p> <a id="c:refman"></a>
 </p><h3 class="subsection" id="ss:foreword"><a class="section-anchor" href="#ss:foreword" aria-hidden="true"></a>Foreword</h3>

--- a/site/releases/4.12/htmlman/letrecvalues.html
+++ b/site/releases/4.12/htmlman/letrecvalues.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="language.html">The OCaml language</a></li><li  class="active"><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
 <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>

--- a/site/releases/4.12/htmlman/lex.html
+++ b/site/releases/4.12/htmlman/lex.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml language
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
 <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>

--- a/site/releases/4.12/htmlman/lexyacc.html
+++ b/site/releases/4.12/htmlman/lexyacc.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Lexer and parser generators (ocamllex, ocamlyacc)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li class="active"><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec320"><span class="number">Chapter 13</span>Lexer and parser generators (ocamllex, ocamlyacc)</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li class="active"><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+  <h1 class="chapter" id="sec320"><span class="number">Chapter 13</span>Lexer and parser generators (ocamllex, ocamlyacc)</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Lexer and parser generators (ocamllex, ocamlyacc)</a></li>
 <li><a href="lexyacc.html#s%3Aocamllex-overview"><span class="number">1</span>Overview of <span class="c004">ocamllex</span></a>
 </li><li><a href="lexyacc.html#s%3Aocamllex-syntax"><span class="number">2</span>Syntax of lexer definitions</a>

--- a/site/releases/4.12/htmlman/libdynlink.html
+++ b/site/releases/4.12/htmlman/libdynlink.html
@@ -7,11 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The dynlink library: dynamic loading and linking of object files</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li class="active"><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml library
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div-1" style="position:fixed;">
+<ul id="part-menu">
+  <li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li class="active"><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li>
+</br></ul>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+</div>
+<br/><br/>
+<div class="content manual" >
 <h1 class="chapter" id="sec573"><span class="number">Chapter 28</span>The dynlink library: dynamic loading and linking of object files</h1>
 <p>The <span class="c004">dynlink</span> library supports type-safe dynamic loading and linking
 of bytecode object files (<span class="c004">.cmo</span> and <span class="c004">.cma</span> files) in a running

--- a/site/releases/4.12/htmlman/libstr.html
+++ b/site/releases/4.12/htmlman/libstr.html
@@ -7,10 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The str library: regular expressions and string processing</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li class="active"><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml library
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div-1" style="position:fixed;">
+<ul id="part-menu">
+  <li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li  class="active"><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li>
+</br></ul>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+</div>
+<br/><br/>
+<div class="content manual" >
 
 <h1 class="chapter" id="sec571"><span class="number">Chapter 26</span>The str library: regular expressions and string processing</h1>
 <p>The <span class="c004">str</span> library provides high-level string processing functions,

--- a/site/releases/4.12/htmlman/libthreads.html
+++ b/site/releases/4.12/htmlman/libthreads.html
@@ -7,10 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The threads library</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li class="active"><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml library
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div-1" style="position:fixed;">
+<ul id="part-menu">
+  <li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li class="active"><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li>
+</br></ul>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+</div>
+<br/><br/>
+<div class="content manual" >
 
 <h1 class="chapter" id="sec572"><span class="number">Chapter 27</span>The threads library</h1>
 <p>

--- a/site/releases/4.12/htmlman/libunix.html
+++ b/site/releases/4.12/htmlman/libunix.html
@@ -7,12 +7,24 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The unix library: Unix system calls</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li class="active"><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
-
-
-
-
-<h1 class="chapter" id="sec570"><span class="number">Chapter 25</span>The unix library: Unix system calls</h1>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml library
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div-1" style="position:fixed;">
+<ul id="part-menu">
+  <li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li class="active"><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li>
+</br></ul>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+</div>
+<br/><br/>
+<div class="content manual" >
+  <h1 class="chapter" id="sec570"><span class="number">Chapter 25</span>The unix library: Unix system calls</h1>
 <p>
 <a id="c:unix"></a></p><p>The <span class="c004">unix</span> library makes many Unix
 system calls and system-related library functions available to

--- a/site/releases/4.12/htmlman/locallyabstract.html
+++ b/site/releases/4.12/htmlman/locallyabstract.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body>  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>

--- a/site/releases/4.12/htmlman/manual.css
+++ b/site/releases/4.12/htmlman/manual.css
@@ -26,7 +26,24 @@
 
 html.smooth-scroll {
   scroll-behavior: smooth; }
-
+  @media all and (max-width: 14400px) and (min-width: 900px) {
+      .right-div{
+       margin-left:73%;
+        display:content;
+      }
+      .right-div-1{
+        width: 25%;
+        margin-left: 72%;
+      }
+    }
+    @media all and (max-width: 800px) and (min-width: 300px){
+      .right-div{
+        width: 96%;
+      }
+      .right-div-1{
+        width: 96%;
+      }
+    }
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto; } }
@@ -46,9 +63,13 @@ html {
 #sidebar-button {
   float: right;
   cursor: context-menu;
+   background-color: white;
   display: none; }
   #sidebar-button span {
-    font-size: 28px; }
+    font-size: 22px;
+    display: block;
+      width: 100%;
+      background-color: white;}
 
 .content > header, .api > header {
   margin-bottom: 30px; }
@@ -396,6 +417,7 @@ blockquote.quote {
   text-align: right;
   list-style: none;
   overflow-y: hidden;
+   background-color: white;
   transition: height 0.3s; }
 
 #part-menu li.active a {

--- a/site/releases/4.12/htmlman/manual024.html
+++ b/site/releases/4.12/htmlman/manual024.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body> <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>

--- a/site/releases/4.12/htmlman/modtypes.html
+++ b/site/releases/4.12/htmlman/modtypes.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body> <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>

--- a/site/releases/4.12/htmlman/modulealias.html
+++ b/site/releases/4.12/htmlman/modulealias.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body> <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>

--- a/site/releases/4.12/htmlman/moduleexamples.html
+++ b/site/releases/4.12/htmlman/moduleexamples.html
@@ -6,12 +6,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The module system</title>
-<script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">The core language</a></li><li class="active"><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a></li><li><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
-
-
-
-
+<script src="scroll.js"></script><script src="navigation.js"></script>
+<link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
+<body>
+<div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+An introduction to OCaml
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li ><a href="coreexamples.html">The core language</a></li><li class="active"><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a>
+</li>
+<li><a href="advexamples.html">Advanced examples with classes and modules</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
 <h1 class="chapter" id="sec20"><span class="number">Chapter 2</span>The module system</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The module system</a></li>
 <li><a href="moduleexamples.html#s%3Amodule%3Astructures"><span class="number">1</span>Structures</a>

--- a/site/releases/4.12/htmlman/modules.html
+++ b/site/releases/4.12/htmlman/modules.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>

--- a/site/releases/4.12/htmlman/moduletypeof.html
+++ b/site/releases/4.12/htmlman/moduletypeof.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li ><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>

--- a/site/releases/4.12/htmlman/names.html
+++ b/site/releases/4.12/htmlman/names.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>

--- a/site/releases/4.12/htmlman/native.html
+++ b/site/releases/4.12/htmlman/native.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Native-code compilation (ocamlopt)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li class="active"><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec310"><span class="number">Chapter 12</span>Native-code compilation (ocamlopt)</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li class="active"><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+  <h1 class="chapter" id="sec310"><span class="number">Chapter 12</span>Native-code compilation (ocamlopt)</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Native-code compilation (ocamlopt)</a></li>
 <li><a href="native.html#s%3Anative-overview"><span class="number">1</span>Overview of the compiler</a>
 </li><li><a href="native.html#s%3Anative-options"><span class="number">2</span>Options</a>
@@ -99,7 +110,7 @@ with the object files (<span class="c004">.cmx</span> and <span class="c004">.o<
 given on the command line, instead of linking them into an executable file.
 The name of the library must be set with the <span class="c004">-o</span> option.<p>If <span class="c004">-cclib</span> or <span class="c004">-ccopt</span> options are passed on the command
 line, these options are stored in the resulting <span class="c004">.cmxa</span>library. Then,
-linking with this library automatically adds back the 
+linking with this library automatically adds back the
 <span class="c004">-cclib</span> and <span class="c004">-ccopt</span> options as if they had been provided on the
 command line, unless the <span class="c004">-noautolink</span> option is given.
 </p></dd><dt class="dt-description"><span class="c007">-absname</span></dt><dd class="dd-description">
@@ -125,7 +136,7 @@ compilation. Source code files are turned into compiled files, but no
 executable file is produced. This option is useful to
 compile modules separately.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">-cc</span> <span class="c010">ccomp</span></span></dt><dd class="dd-description">
-Use <span class="c010">ccomp</span> as the C linker called to build the final executable 
+Use <span class="c010">ccomp</span> as the C linker called to build the final executable
 
 and as the C compiler for compiling <span class="c004">.c</span> source files.
 </dd><dt class="dt-description"><span class="c014"><span class="c004">-cclib</span> <span class="c004">-l</span><span class="c010">libname</span></span></dt><dd class="dd-description">

--- a/site/releases/4.12/htmlman/objectexamples.html
+++ b/site/releases/4.12/htmlman/objectexamples.html
@@ -5,13 +5,27 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 <link rel="stylesheet" type="text/css" href="manual.css">
-<title>OCaml - Objects in OCaml</title>
-<script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li class="active"><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a></li><li><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
-
-
-
-
+<script src="scroll.js"></script><script src="navigation.js"></script>
+<link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
+<body>
+<div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+An introduction to OCaml
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div" style="position:fixed;">
+<ul id="part-menu">
+<li><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li  class="active"><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li><a href="polymorphism.html">Polymorphism and its limitations</a>
+</li>
+<li><a href="advexamples.html">Advanced examples with classes and modules</a></li>
+</br/></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
 <h1 class="chapter" id="sec26"><span class="number">Chapter 3</span>Objects in OCaml</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Objects in OCaml</a></li>
 <li><a href="objectexamples.html#s%3Aclasses-and-objects"><span class="number">1</span>Classes and objects</a>

--- a/site/releases/4.12/htmlman/ocamldoc.html
+++ b/site/releases/4.12/htmlman/ocamldoc.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The documentation generator (ocamldoc)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li class="active"><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec344"><span class="number">Chapter 15</span>The documentation generator (ocamldoc)</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li class="active"><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec344"><span class="number">Chapter 15</span>The documentation generator (ocamldoc)</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The documentation generator (ocamldoc)</a></li>
 <li><a href="ocamldoc.html#s%3Aocamldoc-usage"><span class="number">1</span>Usage</a>
 </li><li><a href="ocamldoc.html#s%3Aocamldoc-comments"><span class="number">2</span>Syntax of documentation comments</a>

--- a/site/releases/4.12/htmlman/old.html
+++ b/site/releases/4.12/htmlman/old.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li class="active"><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml library
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div-1" style="position:fixed;">
+<ul id="part-menu">
+  <li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li class="active"><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li>
+</br></ul>
+</div>
+<br/><br/>
+<div class="content manual" >
 <h1 class="chapter" id="sec574"><span class="number">Chapter 29</span>Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li>
 <li><a href="old.html#s%3Agraphics-removed"><span class="number">1</span>The Graphics Library</a>

--- a/site/releases/4.12/htmlman/overridingopen.html
+++ b/site/releases/4.12/htmlman/overridingopen.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li ><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>

--- a/site/releases/4.12/htmlman/parsing.html
+++ b/site/releases/4.12/htmlman/parsing.html
@@ -7,11 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The compiler front-end</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li class="active"><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+<nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+<span>☰</span>
+The OCaml library
+</div>
+<div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+</nav>
+</div>
+<br/><br/>
+<div class="right-div-1" style="position:fixed;">
+<ul id="part-menu">
+  <li><a href="core.html">The core library</a></li><li><a href="stdlib.html">The standard library</a></li><li class="active"><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li>
+</br></ul>
+<header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+</div>
+<br/><br/>
+<div class="content manual" >
 <h1 class="chapter" id="sec569"><span class="number">Chapter 24</span>The compiler front-end</h1>
 <p> <a id="c:parsinglib"></a></p><p>
 <a id="Compiler-underscorelibs"></a> </p><p>This chapter describes the OCaml front-end, which declares the abstract

--- a/site/releases/4.12/htmlman/patterns.html
+++ b/site/releases/4.12/htmlman/patterns.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>

--- a/site/releases/4.12/htmlman/polymorphism.html
+++ b/site/releases/4.12/htmlman/polymorphism.html
@@ -7,12 +7,26 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Polymorphism and its limitations</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>An introduction to OCaml</nav><ul id="part-menu"><li><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li class="active"><a href="polymorphism.html">Polymorphism and its limitations</a></li><li><a href="advexamples.html">Advanced examples with classes and modules</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec53"><span class="number">Chapter 5</span>Polymorphism and its limitations</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  An introduction to OCaml
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="coreexamples.html">The core language</a></li><li><a href="moduleexamples.html">The module system</a></li><li><a href="objectexamples.html">Objects in OCaml</a></li><li><a href="lablexamples.html">Labels and variants</a></li><li  class="active"><a href="polymorphism.html">Polymorphism and its limitations</a>
+  </li>
+  <li><a href="advexamples.html">Advanced examples with classes and modules</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+  <h1 class="chapter" id="sec53"><span class="number">Chapter 5</span>Polymorphism and its limitations</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Polymorphism and its limitations</a></li>
 <li><a href="polymorphism.html#s%3Aweak-polymorphism"><span class="number">1</span>Weak polymorphism and mutation</a>
 </li><li><a href="polymorphism.html#s%3Apolymorphic-recursion"><span class="number">2</span>Polymorphic recursion</a>

--- a/site/releases/4.12/htmlman/privatetypes.html
+++ b/site/releases/4.12/htmlman/privatetypes.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>

--- a/site/releases/4.12/htmlman/profil.html
+++ b/site/releases/4.12/htmlman/profil.html
@@ -7,12 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Profiling (ocamlprof)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li class="active"><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec412"><span class="number">Chapter 17</span>Profiling (ocamlprof)</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li class="active"><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" ><h1 class="chapter" id="sec412"><span class="number">Chapter 17</span>Profiling (ocamlprof)</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Profiling (ocamlprof)</a></li>
 <li><a href="profil.html#s%3Aocamlprof-compiling"><span class="number">1</span>Compiling for profiling</a>
 </li><li><a href="profil.html#s%3Aocamlprof-profiling"><span class="number">2</span>Profiling an execution</a>

--- a/site/releases/4.12/htmlman/runtime.html
+++ b/site/releases/4.12/htmlman/runtime.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The runtime system (ocamlrun)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li class="active"><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec305"><span class="number">Chapter 11</span>The runtime system (ocamlrun)</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li   class="active"><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec305"><span class="number">Chapter 11</span>The runtime system (ocamlrun)</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The runtime system (ocamlrun)</a></li>
 <li><a href="runtime.html#s%3Aocamlrun-overview"><span class="number">1</span>Overview</a>
 </li><li><a href="runtime.html#s%3Aocamlrun-options"><span class="number">2</span>Options</a>

--- a/site/releases/4.12/htmlman/signaturesubstitution.html
+++ b/site/releases/4.12/htmlman/signaturesubstitution.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - Language extensions</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li><a href="language.html">The OCaml language</a></li><li class="active"><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec238"><span class="number">Chapter 8</span>Language extensions</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">Language extensions</a></li>
 <li><a href="letrecvalues.html#start-section"><span class="number">1</span>Recursive definitions of values</a>
 </li><li><a href="manual024.html#start-section"><span class="number">2</span>Recursive modules</a>
 </li><li><a href="privatetypes.html#start-section"><span class="number">3</span>Private types</a>

--- a/site/releases/4.12/htmlman/stdlib.html
+++ b/site/releases/4.12/htmlman/stdlib.html
@@ -7,12 +7,25 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The standard library</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml library</nav><ul id="part-menu"><li><a href="core.html">The core library</a></li><li class="active"><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li></ul><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
-
-
-
-
-<h1 class="chapter" id="sec568"><span class="number">Chapter 23</span>The standard library</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml library
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div-1" style="position:fixed;">
+  <ul id="part-menu">
+    <li><a href="core.html">The core library</a></li><li class="active"><a href="stdlib.html">The standard library</a></li><li><a href="parsing.html">The compiler front-end</a></li><li><a href="libunix.html">The unix library: Unix system calls</a></li><li><a href="libstr.html">The str library: regular expressions and string processing</a></li><li><a href="libthreads.html">The threads library</a></li><li><a href="libdynlink.html">The dynlink library: dynamic loading and linking of object files</a></li><li><a href="old.html">Recently removed or moved libraries (Graphics, Bigarray, Num, LablTk)</a></li>
+  </br></ul>
+  <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div></nav></header>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+  <h1 class="chapter" id="sec568"><span class="number">Chapter 23</span>The standard library</h1>
 <p> <a id="c:stdlib"></a></p><p>This chapter describes the functions provided by the OCaml
 standard library. The modules from the standard library are
 automatically linked with the user’s object code files by the <span class="c004">ocamlc</span>

--- a/site/releases/4.12/htmlman/toplevel.html
+++ b/site/releases/4.12/htmlman/toplevel.html
@@ -7,12 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The toplevel system or REPL (ocaml)</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml tools</nav><ul id="part-menu"><li><a href="comp.html">Batch compilation (ocamlc)</a></li><li class="active"><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec297"><span class="number">Chapter 10</span>The toplevel system or REPL (ocaml)</h1>
+<body>
+  <div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml tools
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li><a href="comp.html">Batch compilation (ocamlc)</a></li><li  class="active"><a href="toplevel.html">The toplevel system or REPL (ocaml)</a></li><li><a href="runtime.html">The runtime system (ocamlrun)</a></li><li><a href="native.html">Native-code compilation (ocamlopt)</a></li><li><a href="lexyacc.html">Lexer and parser generators (ocamllex, ocamlyacc)</a></li><li><a href="depend.html">Dependency generator (ocamldep)</a></li><li><a href="ocamldoc.html">The documentation generator (ocamldoc)</a></li><li><a href="debugger.html">The debugger (ocamldebug)</a></li><li><a href="profil.html">Profiling (ocamlprof)</a></li><li><a href="intfc.html">Interfacing C with OCaml</a></li><li><a href="flambda.html">Optimisation with Flambda</a></li><li><a href="afl-fuzz.html">Fuzzing with afl-fuzz</a></li><li><a href="instrumented-runtime.html">Runtime tracing with the instrumented runtime</a></li></br></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" ><h1 class="chapter" id="sec297"><span class="number">Chapter 10</span>The toplevel system or REPL (ocaml)</h1>
 <header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The toplevel system or REPL (ocaml)</a></li>
 <li><a href="toplevel.html#s%3Atoplevel-options"><span class="number">1</span>Options</a>
 </li><li><a href="toplevel.html#s%3Atoplevel-directives"><span class="number">2</span>Toplevel directives</a>

--- a/site/releases/4.12/htmlman/typedecl.html
+++ b/site/releases/4.12/htmlman/typedecl.html
@@ -7,12 +7,23 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
-<h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
+<body><div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
+    <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>
 </li><li><a href="names.html#start-section"><span class="number">3</span>Names</a>

--- a/site/releases/4.12/htmlman/types.html
+++ b/site/releases/4.12/htmlman/types.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>

--- a/site/releases/4.12/htmlman/values.html
+++ b/site/releases/4.12/htmlman/values.html
@@ -7,11 +7,22 @@
 <link rel="stylesheet" type="text/css" href="manual.css">
 <title>OCaml - The OCaml language</title>
 <script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
-<body><div class="content manual"><div id="sidebar-button"><span>☰</span></div><nav id="part-title"><span>☰</span>The OCaml language</nav><ul id="part-menu"><li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li></ul>
-
-
-
-
+<body><div style="width:100%;position:fixed;" class="content manual" >
+  <nav><div id="part-title" style="width:95%; background-color: white; position: fixed; top: 0; padding-bottom: 20px;">
+  <span>☰</span>
+  The OCaml language
+  </div>
+  <div id="sidebar-button" style="width:5%; background-color: white; position: fixed; top: 0; padding-bottom: 100px;"><span>☰</span></div>
+  </nav>
+  </div>
+  <br/><br/>
+  <div class="right-div" style="position:fixed;">
+  <ul id="part-menu">
+  <li class="active"><a href="language.html">The OCaml language</a></li><li><a href="extn.html">Language extensions</a></li>
+  </br/></ul>
+  </div>
+  <br/><br/>
+  <div class="content manual" >
 <h1 class="chapter" id="sec73"><span class="number">Chapter 7</span>The OCaml language</h1><header id="sidebar"><nav class="toc brand"><a class="brand" href="https://ocaml.org/"><img src="colour-logo.svg" class="svg" alt="OCaml"></a></nav><nav class="toc"><div class="toc_version"><a id="version-select" href="https://ocaml.org/releases/">Version 4.12</a></div><div class="toc_title"><a href="index.html">&lt; The OCaml Manual</a></div><ul><li class="top"><a href="#">The OCaml language</a></li>
 <li><a href="lex.html#start-section"><span class="number">1</span>Lexical conventions</a>
 </li><li><a href="values.html#start-section"><span class="number">2</span>Values</a>


### PR DESCRIPTION
# Issue Description
I have changed the layout for OCaml Manual.
these changes include fixing the right-div at the time of scrolling.


Fixes # (issue)
I have fixed the layout of all the pages relating to OCaml manual.
This PR fixes the issue https://github.com/ocaml/ocaml.org/issues/1402

I have also described the changes  I have made in the form of a video here

https://user-images.githubusercontent.com/69522036/115788621-77ee3100-a3e1-11eb-98c2-d1e6f2dd8328.mp4



* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
