### PR TITLE
fixes the size of logo in OCaml around the web on Community page

### DIFF
--- a/site/community/index.fr.md
+++ b/site/community/index.fr.md
@@ -158,16 +158,17 @@
         <section class="span12 condensed">
             <h1 class="ruled" id="ocaml-around-web">OCaml autour du Web</h1>
                 <ul class="inline">
-                    <li><a href="/community/mailing_lists.fr.html"><img src="/img/mail.png" title="OCaml Mailing Lists"></a></li>
-                    <li><a href="https://github.com/trending?l=ocaml&since=monthly"><img src="/img/github-mark.png" title="OCaml repos on Github"></a></li>
-                    <li><a href="https://bitbucket.org/repo/all?name=ocaml"><img src="/img/bitbucket-logo.png" title="OCaml repos on BitBucket"></a></li>                
-                    <li><a href="http://stackoverflow.com/questions/tagged/ocaml"><img src="/img/stackoverflow-logo.jpg" title="OCaml tag on StackOverflow"></a></li>
-                    <li><a href="https://plus.google.com/u/0/communities/100872177392545601885"><img src="/img/googleplus.jpg" title="OCaml on Google+"></a></li>
-                    <li><a href="http://www.reddit.com/r/ocaml/"><img src="/img/reddit-alien.png" title="OCaml subreddit on Reddit"></a></li>
-                    <li><a href="http://www.slideshare.net/search/slideshow/?q=ocaml&qf=qf2&ud=any&ft=all&lang=**&sort=relevance"><img src="/img/slideshare-icon.png" title="OCaml mentions on SlideShare"></a></li>
-                    <li><a href="http://www.meetup.com/find/?keywords=ocaml&radius=Infinity"><img src="/img/meetup-logo.gif" title="OCaml groups on Meetup"></a></li>
-                    <li><a href="irc://irc.freenode.net/#ocaml"><img src="/img/irc-graphic.png" title="#ocaml on freenode"></a></li>
-                    <li><a href="https://dev.to/t/ocaml"><img src="/img/devto-graphic.png" title="#ocaml on dev.to"></a></li>
+                    <li class="community-web"><a href="/community/mailing_lists.fr.html"><img src="/img/mail.png" title="OCaml Mailing Lists"></a></li>
+                    <li class="community-web"><a href="https://github.com/trending?l=ocaml&since=monthly"><img src="/img/github-mark.png" title="OCaml repos on Github"></a></li>
+                    <li class="community-web"><a href="https://bitbucket.org/repo/all?name=ocaml"><img src="/img/bitbucket-logo.png" title="OCaml repos on BitBucket"></a></li>                
+                    <li class="community-web"><a href="http://stackoverflow.com/questions/tagged/ocaml"><img src="/img/stackoverflow-logo.jpg" title="OCaml tag on StackOverflow"></a></li>
+                    
+                    <li class="community-web"><a href="http://www.reddit.com/r/ocaml/"><img src="/img/reddit-alien.png" title="OCaml subreddit on Reddit"></a></li>
+                    <li class="community-web"><a href="http://www.slideshare.net/search/slideshow/?q=ocaml&qf=qf2&ud=any&ft=all&lang=**&sort=relevance"><img src="/img/slideshare-icon.png" title="OCaml mentions on SlideShare"></a></li>
+                    <li class="community-web"><a href="http://www.meetup.com/find/?keywords=ocaml&radius=Infinity"><img src="/img/meetup-logo.gif" title="OCaml groups on Meetup"></a></li>
+                    <li class="community-web"><a href="irc://irc.freenode.net/#ocaml"><img src="/img/irc-graphic.png" title="#ocaml on freenode"></a></li>
+                    <li class="community-web"><a href="https://dev.to/t/ocaml"><img src="/img/devto-graphic.png" title="#ocaml on dev.to"></a></li>
+                    <li class="community-web"><a href="https://discuss.ocaml.org/"><img src="../img/discourse.png" title="OCaml Discourse"/></a></li>
                 </ul>
         </section>
     </div>

--- a/site/community/index.md
+++ b/site/community/index.md
@@ -156,16 +156,16 @@
         <section class="span12 condensed">
             <h1 class="ruled" id="ocaml-around-web">OCaml Around the Web</h1>
                 <ul class="inline">
-                    <li><a href="/community/mailing_lists.html"><img src="/img/mail.png" title="OCaml Mailing Lists"></a></li>
-                    <li><a href="https://github.com/trending?l=ocaml&since=monthly"><img src="/img/github-mark.png" title="OCaml repos on Github"></a></li>
-                    <li><a href="https://bitbucket.org/repo/all?name=ocaml"><img src="/img/bitbucket-logo.png" title="OCaml repos on BitBucket"></a></li>
-                    <li><a href="http://stackoverflow.com/questions/tagged/ocaml"><img src="/img/stackoverflow-logo.jpg" title="OCaml tag on StackOverflow"></a></li>
-                    <li><a href="http://www.reddit.com/r/ocaml/"><img src="/img/reddit-alien.png" title="OCaml subreddit on Reddit"></a></li>
-                    <li><a href="http://www.slideshare.net/search/slideshow/?q=ocaml&qf=qf2&ud=any&ft=all&lang=**&sort=relevance"><img src="/img/slideshare-icon.png" title="OCaml mentions on SlideShare"></a></li>
-                    <li><a href="http://www.meetup.com/find/?keywords=ocaml&radius=Infinity"><img src="/img/meetup-logo.gif" title="OCaml groups on Meetup"></a></li>
-                    <li><a href="irc://irc.freenode.net/#ocaml"><img src="/img/irc-graphic.png" title="#ocaml on freenode"></a></li>
-                    <li><a href="https://dev.to/t/ocaml"><img src="/img/devto-graphic.png" title="#ocaml on dev.to"></a></li>
-                    <li><a href="https://discuss.ocaml.org/"><img src="/img/discourse.png" title="OCaml Discourse"></a></li>
+                    <li class="community-web"><a href="/community/mailing_lists.html"><img src="/img/mail.png" title="OCaml Mailing Lists"></a></li>
+                    <li class="community-web" ><a href="https://github.com/trending?l=ocaml&since=monthly"><img src="/img/github-mark.png" title="OCaml repos on Github"></a></li>
+                    <li class="community-web"><a href="https://bitbucket.org/repo/all?name=ocaml"><img src="/img/bitbucket-logo.png" title="OCaml repos on BitBucket"></a></li>
+                    <li class="community-web"><a href="http://stackoverflow.com/questions/tagged/ocaml"><img src="/img/stackoverflow-logo.jpg" title="OCaml tag on StackOverflow"></a></li>
+                    <li class="community-web"><a href="http://www.reddit.com/r/ocaml/"><img src="/img/reddit-alien.png" title="OCaml subreddit on Reddit"></a></li>
+                    <li class="community-web"><a href="http://www.slideshare.net/search/slideshow/?q=ocaml&qf=qf2&ud=any&ft=all&lang=**&sort=relevance"><img src="/img/slideshare-icon.png" title="OCaml mentions on SlideShare"></a></li>
+                    <li class="community-web"><a href="http://www.meetup.com/find/?keywords=ocaml&radius=Infinity"><img src="/img/meetup-logo.gif" title="OCaml groups on Meetup"></a></li>
+                    <li class="community-web"><a href="irc://irc.freenode.net/#ocaml"><img src="/img/irc-graphic.png" title="#ocaml on freenode"></a></li>
+                    <li class="community-web"><a href="https://dev.to/t/ocaml"><img src="/img/devto-graphic.png" title="#ocaml on dev.to"></a></li>
+                    <li class="community-web"><a href="https://discuss.ocaml.org/"><img src="/img/discourse.png" title="OCaml Discourse"></a></li>
                 </ul>
         </section>
     </div>

--- a/site/css/bootstrap_mod.css
+++ b/site/css/bootstrap_mod.css
@@ -144,3 +144,15 @@ html.svg .news-feed li {
 html.svg .news-feed li.announcement {
   background-image: url(../img/announcement-go.svg);
 }
+
+/* OCaml around the web : Community Page */
+
+.community-web{
+  height:130px;
+  width: 130px;
+  }
+.community-web img{
+  height:auto;
+  width:auto;
+  object-fit: contain;
+}


### PR DESCRIPTION
# Resizes the images on community page under OCaml around the web. 

Please include a summary of the issue.
The size of dev.to and discuss logo on the Community page under the section OCaml Around the web is oddly big as compared to other logos.

Fixes #1537 

## Changes Made

- added required css to fix the size of image
- added "community-web" class to respective ```<li></li>``` tags
- removed google+ links from french community page.
- fixed the logo size on french community page.
- added discourse link to french community page
### Before Screenshot
![Screenshot from 2021-04-16 18-48-35](https://user-images.githubusercontent.com/69427216/115961838-d298a180-a535-11eb-8013-7b31584510b9.png)
###  After Screenshot
![Screenshot from 2021-04-24 19-47-48](https://user-images.githubusercontent.com/69427216/115961889-1e4b4b00-a536-11eb-9dff-1eba2919fb59.png)
![Screenshot from 2021-04-24 19-48-05](https://user-images.githubusercontent.com/69427216/115961896-24412c00-a536-11eb-97f3-1476bf5d3633.png)

* **Please check if the PR fulfills these requirements**

- [X] PR is descriptively titled and links the original issue above
- [X] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
