### PR TITLE
filter unsubscribe emails

### DIFF
--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -607,7 +607,7 @@ let email_threads ?n ~l9n url =
     let title = delete_author title in
     { e with Atom.title = Atom.Text title } in
   let posts = List.map normalize_title posts in
-  (* Keep only the more recent post of redundant subjects filter out the unsubscribe emails *)
+  (* Keep only the more recent post of redundant subjects and filter out the unsubscribe emails *)
   let module S = Set.Make(String) in
   let seen = ref S.empty in
   let must_keep (e: Atom.entry) =

--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -589,7 +589,7 @@ let delete_author title =
 (* Remove the "[Caml-list]" and possible "Re:". *)
 let caml_list_re =
   Str.regexp_case_fold "^\\(Re: *\\)*\\(\\[[a-zA-Z0-9-]+\\] *\\)*"
-
+let unsubscribe_email_re= Str.regexp_case_fold ".*unsubscribe.*"
 (** [email_threads] does basically the same as [headlines] but filter
     the posts to have repeated subjects.  It also presents the subject
     better. *)
@@ -609,6 +609,7 @@ let email_threads ?n ~l9n url =
   let must_keep (e: Atom.entry) =
     let title = string_of_text_construct e.Atom.title in
     if S.mem title !seen then false
+    else if Str.string_match unsubscribe_email_re title 0 then false
     else (seen := S.add title !seen;  true) in
   let posts = List.filter must_keep posts in
   let posts = (match n with

--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -589,7 +589,11 @@ let delete_author title =
 (* Remove the "[Caml-list]" and possible "Re:". *)
 let caml_list_re =
   Str.regexp_case_fold "^\\(Re: *\\)*\\(\\[[a-zA-Z0-9-]+\\] *\\)*"
-let unsubscribe_email_re= Str.regexp_case_fold ".*unsubscribe.*"
+
+  (*Remove the unsubscribe emails*)
+let unsubscribe_email_re =
+  Str.regexp_case_fold ".*unsubscribe.*"
+
 (** [email_threads] does basically the same as [headlines] but filter
     the posts to have repeated subjects.  It also presents the subject
     better. *)
@@ -603,7 +607,7 @@ let email_threads ?n ~l9n url =
     let title = delete_author title in
     { e with Atom.title = Atom.Text title } in
   let posts = List.map normalize_title posts in
-  (* Keep only the more recent post of redundant subjects. *)
+  (* Keep only the more recent post of redundant subjects filter out the unsubscribe emails *)
   let module S = Set.Make(String) in
   let seen = ref S.empty in
   let must_keep (e: Atom.entry) =


### PR DESCRIPTION
# Issue Description
On the https://ocaml.org/community/ page, the recent email threads show all emails sent to the list, including `unsubscribe` emails.


Fixes #1513

## Changes Made
I wrote a regex in the `/rsshtml.ml` file to filter out the unsubscribe emails from  being displayed.


* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
