### PR TITLE
On Planet: Link to Blog itself 

### DIFF
--- a/planet_feeds.txt
+++ b/planet_feeds.txt
@@ -1,72 +1,72 @@
-Andrej Bauer|http://math.andrej.com/feed.xml
-Andy Ray|http://www.ujamjar.com/ocaml.xml
-Ashish Agarwal|http://ashishagarwal.org/tag/ocaml/feed/
-CUFP|http://cufp.org/blog/all.rss.xml
-Cameleon news|http://www.blogger.com/feeds/7617521785419311079/posts/default
-Caml INRIA|http://caml.inria.fr/news.en.rss
-Caml Spotting|http://camlspotter.blogspot.com/feeds/posts/default?alt=rss
-Coherent Graphics|https://coherentpdf.com/blog/?tag=ocaml&feed=rss2
-Coq|https://coq.inria.fr/rss.xml
-Cranial Burnout|http://www.blogger.com/feeds/9108979482982930820/posts/default/-/OCaml
-Daniel Bünzli|https://erratique.ch/feeds/news.atom
-Daniel Bünzli (log)|https://erratique.ch/log/feed.atom
-Dario Teixeira|http://nleyten.com/feed/tag/ocaml/atom
-David Baelde|http://www.blogger.com/feeds/17133288/posts/default/-/ocaml
-David Mentré|http://blog.bentobako.org/index.php?feed/tag/ocaml/atom
-David Teller|https://dutherenverseauborddelatable.wordpress.com/category/ocaml/feed/
-Eray Özkural|https://examachine.net/blog/category/ocaml/feed/
-Erik de Castro Lopo|http://www.mega-nerd.com/erikd/Blog/index.rss20
-Etienne Millon|http://blog.emillon.org/feeds/ocaml.xml
-Frama-C|http://frama-c.com/rss.xml
-GaGallium|http://gallium.inria.fr/blog/index.rss
-Gaius Hammond|https://gaius.tech/category/ocaml/feed/
-Gemma Gordon (OCaml Labs)|http://reynard.io/feed.xml
-Gerd Stolpmann|http://blog.camlcity.org/blog/rss
-GitHub Jobs|https://jobs.github.com/positions.atom?description=ocaml
-Grant Rettke|https://www.wisdomandwonder.com/tag/OCaml/feed
-Hannes Mehnert|https://hannes.nqsb.io/atom
-Hong bo Zhang|https://hongboz.wordpress.com/feed/
-Jake Donham|http://ambassadortothecomputers.blogspot.com/feeds/posts/default?alt=rss
-Jane Street|https://blog.janestreet.com/feed.xml
-KC Sivaramakrishnan|https://kcsrk.info/atom-ocaml.xml
-Leo White|http://lpw25.net/rss.xml
-Magnus Skjegstad|http://www.skjegstad.com/feeds/ocaml.tag.atom.xml
-Marc Simpson|https://blog.0branch.com/rss.xml
-Matthias Puech|https://syntaxexclamation.wordpress.com/tag/ocaml/feed/
-Matías Giovannini|http://www.blogger.com/feeds/5888658295182480819/posts/default
-Mindy Preston|https://www.somerandomidiot.com/blog/categories/ocaml/atom.xml
-Mike Lin|http://www.blogger.com/feeds/3693082774051755513/posts/default/-/OCaml
-Mike McClurg|https://mcclurmc.wordpress.com/feed/
-MirageOS|https://mirage.io/blog/atom.xml
-OCaml Book|http://ocaml-book.com/blog?format=rss
-OCaml Labs compiler hacking|http://ocamllabs.io/compiler-hacking/rss.xml
-OCamlCore.com|http://www.ocamlcore.com/wp/feed/?amp;language=en&language=en
-OCamlPro|https://www.ocamlpro.com/feed/
-ODNS project|http://odns.tuxfamily.org/feed/
-Ocaml XMPP project|http://ox.tuxfamily.org/feed/
-Ocsigen project|https://ocsigen.org/feed.xml
-Opa|http://www.blogger.com/feeds/2073503406800427577/posts/default
-Orbitz|http://functional-orbitz.blogspot.com/feeds/posts/default/-/planetocaml?alt=rss
-Paolo Donadeo|http://www.donadeo.net/facets/programming-languages/objective-caml/feed/
-Perpetually Curious|http://lambdafoo.com/blog/categories/ocaml/atom.xml
-Peter Zotov|https://whitequark.org/blog/categories/ocaml/atom.xml
-Psellos|http://psellos.com/atom.xml
-Richard Jones|https://rwmj.wordpress.com/tag/ocaml/feed/
-Rudenoise|http://rudenoise.uk/ocaml.rss
-Rudi Grinberg|http://rgrinberg.com/blog/atom.xml
-Sebastien Mondet|https://seb.mondet.org/b/OCaml.rss
-Shayne Fletcher|http://blog.shaynefletcher.org/feeds/posts/default/-/OCaml
-Stefano Zacchiroli|https://upsilon.cc/~zack/tags/ocaml/index.rss
-Thomas Leonard|http://roscidus.com/blog/blog/categories/ocaml/atom.xml
-Till Varoquaux|http://www.blogger.com/feeds/6115529230232389198/posts/default
-Yan Shvartzshnaider|http://yansnotes.blogspot.com/feeds/posts/default/-/ocaml
-OCaml-Java|http://www.ocamljava.org/feed.xml
-OCaml Platform|http://opam.ocaml.org/blog/feed.xml
-Xinuo Chen|http://typeocaml.com/rss/
-Cryptosense|https://cryptosense.com/blog/tag/ocaml/feed/
-Gabriel Radanne|http://drup.github.io/feed-ocaml.xml
-The BAP Blog|https://binaryanalysisplatform.github.io/feed.xml
-Tarides|https://tarides.com/feed.xml
-Ahrefs|https://medium.com/feed/ahrefs/tagged/ocaml
-Reason Documentation Blog|https://rescript-lang.org/blog/feed.xml
-Daniil Baturin|https://baturin.org/blog/atom-ocaml.xml
+Andrej Bauer|http://math.andrej.com/feed.xml|http://math.andrej.com/
+Andy Ray|http://www.ujamjar.com/ocaml.xml|http://www.ujamjar.com/
+Ashish Agarwal|http://ashishagarwal.org/tag/ocaml/feed/|http://ashishagarwal.org/
+CUFP|http://cufp.org/blog/all.rss.xml|http://cufp.org/2017/
+Cameleon news|http://www.blogger.com/feeds/7617521785419311079/posts/default|http://ocameleon.blogspot.com/
+Caml INRIA|http://caml.inria.fr/news.en.rss|http://caml.inria.fr/
+Caml Spotting|http://camlspotter.blogspot.com/feeds/posts/default?alt=rss|http://camlspotter.blogspot.com/
+Coherent Graphics|https://coherentpdf.com/blog/?tag=ocaml&feed=rss2|https://coherentpdf.com/blog/
+Coq|https://coq.inria.fr/rss.xml|https://coq.inria.fr/
+Cranial Burnout|http://www.blogger.com/feeds/9108979482982930820/posts/default/-/OCaml|http://cranialburnout.blogspot.com/search/label/OCaml
+Daniel Bünzli|https://erratique.ch/feeds/news.atom|https://erratique.ch/contact.en
+Daniel Bünzli (log)|https://erratique.ch/log/feed.atom|https://erratique.ch/log/
+Dario Teixeira|http://nleyten.com/feed/tag/ocaml/atom|http://nleyten.com/feed/tag/ocaml/atom
+David Baelde|http://www.blogger.com/feeds/17133288/posts/default/-/ocaml|http://misterpingouin.blogspot.com/search/label/ocaml
+David Mentré|http://blog.bentobako.org/index.php?feed/tag/ocaml/atom|http://blog.bentobako.org/index.php?
+David Teller|https://dutherenverseauborddelatable.wordpress.com/category/ocaml/feed/|https://dutherenverseauborddelatable.wordpress.com/
+Eray Özkural|https://examachine.net/blog/category/ocaml/feed/|https://examachine.net/blog/category/ocaml/feed/
+Erik de Castro Lopo|http://www.mega-nerd.com/erikd/Blog/index.rss20|http://www.mega-nerd.com/erikd/Blog/
+Etienne Millon|http://blog.emillon.org/feeds/ocaml.xml|http://blog.emillon.org/
+Frama-C|http://frama-c.com/rss.xml|https://frama-c.com/
+GaGallium|http://gallium.inria.fr/blog/index.rss|http://gallium.inria.fr/blog/
+Gaius Hammond|https://gaius.tech/category/ocaml/feed/|https://gaius.tech/
+Gemma Gordon (OCaml Labs)|http://reynard.io/feed.xml|http://reynard.io/
+Gerd Stolpmann|http://blog.camlcity.org/blog/rss|http://blog.camlcity.org/blog
+GitHub Jobs|https://jobs.github.com/positions.atom?description=ocaml|https://jobs.github.com/
+Grant Rettke|https://www.wisdomandwonder.com/tag/OCaml/feed|https://www.wisdomandwonder.com/
+Hannes Mehnert|https://hannes.nqsb.io/atom|Posts/NGI
+Hong bo Zhang|https://hongboz.wordpress.com/feed/|https://hongboz.wordpress.com/
+Jake Donham|http://ambassadortothecomputers.blogspot.com/feeds/posts/default?alt=rss|http://ambassadortothecomputers.blogspot.com/
+Jane Street|https://blog.janestreet.com/feed.xml|https://blog.janestreet.com/
+KC Sivaramakrishnan|https://kcsrk.info/atom-ocaml.xml|https://kcsrk.info/
+Leo White|http://lpw25.net/rss.xml|http://www.lpw25.net/
+Magnus Skjegstad|http://www.skjegstad.com/feeds/ocaml.tag.atom.xml|http://www.skjegstad.com/
+Marc Simpson|https://blog.0branch.com/rss.xml|https://blog.0branch.com/
+Matthias Puech|https://syntaxexclamation.wordpress.com/tag/ocaml/feed/|https://syntaxexclamation.wordpress.com/
+Matías Giovannini|http://www.blogger.com/feeds/5888658295182480819/posts/default|http://alaska-kamtchatka.blogspot.com/
+Mindy Preston|https://www.somerandomidiot.com/blog/categories/ocaml/atom.xml|https://www.somerandomidiot.com/blog
+Mike Lin|http://www.blogger.com/feeds/3693082774051755513/posts/default/-/OCaml|http://blog.mlin.net/search/label/OCaml
+Mike McClurg|https://mcclurmc.wordpress.com/feed/|https://mcclurmc.wordpress.com/
+MirageOS|https://mirage.io/blog/atom.xml|https://mirage.io/blog/
+OCaml Book|http://ocaml-book.com/blog?format=rss|http://ocaml-book.com/blog/
+OCaml Labs compiler hacking|http://ocamllabs.io/compiler-hacking/rss.xml|https://ocamllabs.github.com/compiler-hacking/
+OCamlCore.com|http://www.ocamlcore.com/wp/feed/?amp;language=en&language=en|https://www.ocamlcore.com/wp/index.html
+OCamlPro|https://www.ocamlpro.com/feed/|https://www.ocamlpro.com/
+ODNS project|http://odns.tuxfamily.org/feed/|http://odns.tuxfamily.org/
+Ocaml XMPP project|http://ox.tuxfamily.org/feed/|http://ox.tuxfamily.org/
+Ocsigen project|https://ocsigen.org/feed.xml|https://ocsigen.org/home/intro.html
+Opa|http://www.blogger.com/feeds/2073503406800427577/posts/default|http://blog.opalang.org/
+Orbitz|http://functional-orbitz.blogspot.com/feeds/posts/default/-/planetocaml?alt=rss|http://functional-orbitz.blogspot.com/search/label/planetocaml
+Paolo Donadeo|http://www.donadeo.net/facets/programming-languages/objective-caml/feed/|http://www.donadeo.net/
+Perpetually Curious|http://lambdafoo.com/blog/categories/ocaml/atom.xml|https://lambdafoo.com/blog
+Peter Zotov|https://whitequark.org/blog/categories/ocaml/atom.xml|https://whitequark.org/blog//
+Psellos|http://psellos.com/atom.xml|http://psellos.com/
+Richard Jones|https://rwmj.wordpress.com/tag/ocaml/feed/|https://rwmj.wordpress.com
+Rudenoise|http://rudenoise.uk/ocaml.rss|https://rudenoise.uk/
+Rudi Grinberg|http://rgrinberg.com/blog/atom.xml|http://rgrinberg.com
+Sebastien Mondet|https://seb.mondet.org/b/OCaml.rss|https://seb.mondet.org/b/
+Shayne Fletcher|http://blog.shaynefletcher.org/feeds/posts/default/-/OCaml|http://blog.shaynefletcher.org/search/label/OCaml
+Stefano Zacchiroli|https://upsilon.cc/~zack/tags/ocaml/index.rss|http://upsilon.cc/~zack/tags/ocaml/
+Thomas Leonard|http://roscidus.com/blog/blog/categories/ocaml/atom.xml|https://roscidus.com/blog/
+Till Varoquaux|http://www.blogger.com/feeds/6115529230232389198/posts/default|http://till-varoquaux.blogspot.com/
+Yan Shvartzshnaider|http://yansnotes.blogspot.com/feeds/posts/default/-/ocaml|http://yansnotes.blogspot.com/search/label/ocaml
+OCaml-Java|http://www.ocamljava.org/feed.xml|http://www.ocamljava.org/
+OCaml Platform|http://opam.ocaml.org/blog/feed.xml|https://opam.ocaml.org/blog/feed.xml
+Xinuo Chen|http://typeocaml.com/rss/|http://typeocaml.com/
+Cryptosense|https://cryptosense.com/blog/tag/ocaml/feed/|https://cryptosense.com/blog
+Gabriel Radanne|http://drup.github.io/feed-ocaml.xml|https://drup.github.io/
+The BAP Blog|https://binaryanalysisplatform.github.io/feed.xml|http://binaryanalysisplatform.github.io/
+Tarides|https://tarides.com/feed.xml|https://tarides.com
+Ahrefs|https://medium.com/feed/ahrefs/tagged/ocaml|https://tech.ahrefs.com/tagged/ocaml
+Reason Documentation Blog|https://rescript-lang.org/blog/feed.xml|https://rescript-lang.org
+Daniil Baturin|https://baturin.org/blog/atom-ocaml.xml|https://baturin.org/blog/

--- a/script/rss2html.ml
+++ b/script/rss2html.ml
@@ -150,11 +150,12 @@ let broken_feed name url reason =
   (* See Syndic.Opml1.of_atom for the convention on the length. *)
   Atom.set_self_link feed url ~length:(-1)
 
-let feed_of_url ~name url =
+let feed_of_url ~name url=
   try
     let xml = `String(0, Http.get(Uri.to_string url)) in
     let feed =
       try Atom.parse ~self:url ~xmlbase:url (Xmlm.make_input xml)
+         
       with Atom.Error.Error _ ->
         Rss2.parse ~xmlbase:url (Xmlm.make_input xml)
         |> Rss2.to_atom ~self:url in
@@ -173,11 +174,36 @@ let planet_feeds =
     try
       let i = String.index line '|' in
       let name = String.sub line 0 i in
-      let url = String.sub line (i+1) (String.length line - i - 1) in
+      let blog_i = String.index_from line (i+1) '|' in
+      let url = String.sub line (i+1) (blog_i - i - 1) in
       feed_of_url ~name (Uri.of_string url) :: acc
+    
     with Not_found -> acc in
   lazy(List.fold_left add_feed [] (Utils.lines_of_file planet_feeds_file))
 
+  (* add actual blog_links next to each blog *)
+  let blog_feeds=
+    let add_feed acc line =
+      try
+      let i = String.index line '|' in
+      let name = String.sub line 0 i in
+      let blog_i = String.index_from line (i+1) '|' in
+      let blog_url = String.sub line (blog_i+1) (String.length line - blog_i - 1) in 
+      (name,blog_url):: acc
+    
+    with Not_found -> acc in
+  List.fold_left add_feed [] (Utils.lines_of_file planet_feeds_file)
+
+  let lexicographic_compare (x,y) (x',y') =
+    let compare_fst = String.compare x x' in
+    if compare_fst <> 0 then compare_fst
+    else String.compare y y' 
+
+  (*sort the blog_feed_url according to name*)
+  let blogs = List.sort lexicographic_compare blog_feeds
+  let blogs= List.map (fun (_,x)->("href",x)) blogs
+  (*let blog-url,name = List.split blog_feeds*)
+  
 let get_opml () =
   let feeds = Lazy.force planet_feeds in
   let date_modified =
@@ -192,8 +218,13 @@ let get_opml () =
   let by_name o1 o2 = String.compare o1.Opml1.text o2.Opml1.text in
   { opml with Opml1.body = List.sort by_name opml.Opml1.body }
 
-let opml fname =
+
+ let opml fname =
   Opml1.write (get_opml()) fname
+
+  let i=ref 0 
+  let incr_i() = 
+      i := !i + 1
 
 let html_contributors () =
   let open Opml1 in
@@ -204,7 +235,17 @@ let html_contributors () =
                    :: List.map (fun ((_,n), v) -> (n,v)) o.attrs in
        let attrs = if o.is_comment then ("class", "broken") :: attrs
                    else attrs in
-       Element("li", [], [Element("a", attrs, [Data o.text])])
+       
+        let attrs_b= if !i< List.length blogs then List.nth blogs !i :: [] 
+                     else [] in
+        let j = incr_i() in
+                            
+        Element("li", [], [Element("a", attrs, [Data o.text]);
+                          Element("span", ["class", "share"],
+                                    [Element("a", attrs_b,
+                                        [Element("img", ["src", "/img/chain-link-icon.png";
+                                         "alt", ""], []) ] )] )] )
+
     | None -> Element("li", [], [Data o.text]) in
   [Element("ul", [], List.map contrib_html (get_opml()).body)]
 
@@ -382,7 +423,9 @@ let html_of_post e =
                      "title", "Go to the original post"] in
        let post =
          Netencoding.Url.encode (planet_full_url ^ "#" ^ title_anchor) in
-
+       let google = ["href", "https://plus.google.com/share?url="
+                             ^ (Netencoding.Url.encode url_orig);
+                     "target", "_blank"; "title", "Share on Google+"] in
        let fb = ["href", "https://www.facebook.com/share.php?u=" ^ post
                          ^ "&amp;t=" ^ (Netencoding.Url.encode title);
                  "target", "_blank"; "title", "Share on Facebook"] in
@@ -405,7 +448,9 @@ let html_of_post e =
                 Element("a", a_args,
                         [Element("img", ["src", "/img/chain-link-icon.png";
                                          "alt", ""], []) ])
-
+                :: Element("a", ("class", "googleplus") :: google,
+                           [Element("img", ["src", "/img/googleplus.png";
+                                            "alt", "Google+"], []) ])
                 :: Element("a", ("class", "facebook") :: fb,
                            [Element("img", ["src", "/img/facebook.png";
                                             "alt", "FB"], []) ])

--- a/site/css/ocamlorg.css
+++ b/site/css/ocamlorg.css
@@ -226,6 +226,9 @@ div.subscribers {
 .subscribers li {
   line-height: 100%;
 }
+.subscribers li .share a{
+  margin-left : 5px;
+}
 
 .subscribers .broken {
   text-decoration: line-through;


### PR DESCRIPTION
# Issue Description

Fixes #1529 

## Changes Made

On the right of the planet page (Home -> Community -> OCaml Planet) there is a list of blogs. Clicking on one of them opens the rss rather than the blog itself. I have added a link to the blog itself so that if one of the blogs is clicked, then the main page of the blog opens up.

![image](https://user-images.githubusercontent.com/53967592/115989308-5eb0d480-a5db-11eb-8900-39de479f1ba1.png)

**Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
