### PR TITLE
upgrade the Ocaml scripts to match the latest Omd version

### DIFF
--- a/script/code.ml
+++ b/script/code.ml
@@ -139,7 +139,7 @@ let highlight_ocaml =
                            phrase subst in
     (* Wrap the code in a <pre> block so no Omd.Paragraph are generated, etc. *)
     match Omd.of_string ("<pre>" ^ p ^ "</pre>") with
-    | [Omd.Html_block(_,_,o)] -> o
+    | Omd.[{ bl_desc = Html_block o; _ }] -> o
     | _ -> assert false
   )
 


### PR DESCRIPTION
# Issue Description
This issue is to upgrade the OCaml scripts which use Omd to the latest version of Omd.

Please include a summary of the issue.
Trying to perform some actions would return errors due to some changes in the Omd library so some instances in the script files have to be updated(updated syntaxes) to match the new Omd library.
Fixes # (issue)
Fixes #1321
## Changes Made
Making changes in the Ocaml script files
Please describe the changes that you made.
Identifying and updates instances that need to be changed in the script files to match the latest Omd version
* **Please check if the PR fulfills these requirements**

- [ ] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
