### PR TITLE
Add a lists tutorial

### DIFF
--- a/site/learn/tutorials/data_types_and_matching.md
+++ b/site/learn/tutorials/data_types_and_matching.md
@@ -1,34 +1,8 @@
-<!-- ((! set title Custom Data Types !)) ((! set learn !)) -->
+<!-- ((! set title Data Types and Matching !)) ((! set learn !)) -->
 
 *Table of contents*
 
-# Custom Data Types
-
-tuples
-
-records
-
-enumerations
-
-our own lists example
-
-tree example
-
-data kept along with it
-
-pattern matching on them
-
-difference between a * b and (a * b)
-
-standard type: option
-
-incomplete pattern matching
-
-'as' in pattern matching
-
-records in our own data types
-
-mathematical expression example is salvageable
+# Data Types and Matching
 
 ## Structures
 C and C++ have the concept of a simple `struct`, short for structure.

--- a/site/learn/tutorials/data_types_and_matching.md
+++ b/site/learn/tutorials/data_types_and_matching.md
@@ -1,58 +1,35 @@
-<!-- ((! set title Data Types and Matching !)) ((! set learn !)) -->
+<!-- ((! set title Custom Data Types !)) ((! set learn !)) -->
 
 *Table of contents*
 
-# Data Types and Matching
+# Custom Data Types
 
-## Linked lists
-OCaml has support for lists built into the language. All
-elements of a list in OCaml must be the same type. To write a list, use:
+tuples
 
-```ocamltop
-[1; 2; 3]
-```
-(Note semicolons, NOT commas).
+records
 
-`[]` is the empty list.
+enumerations
 
-A list has a **head** (the first element) and a **tail** (the rest of
-the elements). The head is an element, and the tail is a list, so in the
-above example, the head is the integer `1` while the tail is the *list*
-`[2; 3]`.
+our own lists example
 
-An alternative way to write a list is to use the **cons** operator
-`head :: tail`. So the following ways to write a list are exactly the
-same:
+tree example
 
-```ocaml
-[1; 2; 3]
-1 :: [2; 3]
-1 :: 2 :: [3]
-1 :: 2 :: 3 :: []
-```
-Why do I mention the cons operator? Well, it's useful when we start
-doing *pattern matching* on lists, which I'll talk about below.
+data kept along with it
 
-###  The type of a linked list
-The type of a linked list of integers is `int list`, and in general the
-type of a linked list of `foo`s is `foo list`.
+pattern matching on them
 
-This implies that all the elements of a linked list must have the same
-type. But the type can be polymorphic (ie. `'a list`), which is really
-useful if you want to write generic functions which operate on "lists of
-anything". (But note: `'a list` doesn't mean that each individual
-element has a different type - you still can't use this to construct a
-list containing, say, a mixture of ints and strings. It means that the
-type of the elements is anything, but all the same type of anything.)
+difference between a * b and (a * b)
 
-The `length` function defined as part of the OCaml `List` module is a
-good example of this. It doesn't matter if the list contains ints or
-strings or objects or small furry animals, the `List.length` function
-can still be called on it. The type of `List.length` is therefore:
+standard type: option
 
-```ocaml
-List.length : 'a list -> int
-```
+incomplete pattern matching
+
+'as' in pattern matching
+
+records in our own data types
+
+mathematical expression example is salvageable
+
 ## Structures
 C and C++ have the concept of a simple `struct`, short for structure.
 Java has classes which can be used to similar effect, albeit much more

--- a/site/learn/tutorials/index.md
+++ b/site/learn/tutorials/index.md
@@ -20,6 +20,7 @@ there to request or offer new tutorials.
 
 ### Language Features
 
+* [Lists](lists.html)
 * [Data Types and Matching](data_types_and_matching.html)
 * [Functional Programming](functional_programming.html)
 * [If Statements, Loops, and

--- a/site/learn/tutorials/lists.md
+++ b/site/learn/tutorials/lists.md
@@ -321,45 +321,94 @@ List.sort
   [(1, 3); (1, 2); (2, 3); (2, 2)];;
 ```
 
-### Two special functions: fold_left and fold_right
+### Folds
 
-1. Introduce them, and how they work, and their types
+There are two interestingly-named functions in the List module, `fold_left` and
+`fold_right`. Their job is to combine the elements of a list together, using a
+given function, accumulating an answer which is then returned. The answer
+returned depends upon the function given, the elements of the list, and the
+initial value of the accumulator supplied. So you can imagine these are very
+general functions. Let's explore `fold_left` first.
 
-2. Some little examples, expained. Bad concat example warning
-
-3. Here are some more. Can you work them out?
+In our first example, we supply the addition function and an initial accumulator value of 0:
 
 ```ocamltop
 List.fold_left ( + ) 0 [1; 2; 3];;
+```
 
+The result is the sum of the elements in the list. Now let's use OCaml's
+built-in `max` function which returns the larger of two given integers. We use
+`min_int`, the smallest possible integer, as our initial acumulator
+
+```ocamltop
 List.fold_left max min_int [2; 4; 6; 0; 1];;
+```
+
+The largest number in the list is found. Let's look at the type of the
+`fold_left` function:
+
+```ocamltop
+List.fold_left;;
+```
+
+The function is of type `'a -> 'b -> 'a` where `'a` is the accumulator and `'b`
+is the type of each element of the list. The next argument is the initial
+accumulator, which must be of type `'a`, and then finally the input list of
+type `'b list`. The result is the final value of the accumulator, so it must
+have type `'a`. Of course, in both of our examples, `'a` and `'b` are the same
+as one another. But this is not always so. 
+
+Consider the following definition of `append` which uses `List.fold_right`
+(`fold_left` considers the elements from the left, `fold_right` from the
+right):
+
+```ocamltop
+let append x y =
+  List.fold_right (fun e a -> e :: a) x y;;
+```
+
+In this example, the initial accumulator is the second list, and each element
+of the first is consed to it in turn. You can see the order of arguments to
+fold right is a little different:
+
+```ocamltop
+List.fold_right;;
+```
+
+We can use `fold_right` to define our usual `map` function too:
+
+```ocamltop
+let map f l =
+  List.fold_right (fun e a -> f e :: a) l [];;
+```
+
+But care is needed. If we try that with `List.concat`, which turns a list of lists into a list by concatenating the lists together, we get this:
+
+```ocamltop
+let concat l = List.fold_left ( @ ) [] l;;
+```
+
+Unfortunately, the order of evalution here is such that larger and larger items
+are passed to the `@` operator as its first argument, and so the function has a
+worse running time than `List.concat`.
+
+Here are some more redefintions of familiar functions in terms of `fold_left`
+or `fold_right`. Can you work out how they operate?
+
+```ocamltop
+let length l =
+  List.fold_left (fun a _ -> a + 1) 0 l;;
+
+let rev l =
+  List.fold_left (fun a e -> e :: a) [] l;;
 
 let setify l =
    List.fold_left
      (fun a e -> if List.mem e a then a else e :: a) [] l;;
-
-let all l = List.fold_left ( && ) true l;;
-
-let any l = List.fold_left ( || ) false l;;
-
-let map f l =
-  List.fold_right (fun e a -> f e :: a) l [];;
-
-let append x y =
-  List.fold_right (fun e a -> e :: a) x y;;
 
 let split l =
   List.fold_right
     (fun (x, y) (xs, ys) -> (x :: xs, y :: ys))
     l
     ([], []);;
-
-let concat l =
-  List.fold_left ( @ ) [] l (* BAD *);;
-
-let length l =
-  List.fold_left (fun a _ -> a + 1) 0 l;;
-
-let rev l =
-  List.fold_left (fun a e -> e :: a) [] l;;
 ```

--- a/site/learn/tutorials/lists.md
+++ b/site/learn/tutorials/lists.md
@@ -178,11 +178,36 @@ the exception kind.
 
 ### Maps and iterators on one and two lists
 
-map, iter
-
-map2 etc.
+We have already written a `map` function from scratch, and it is no surprise
+that one is included in the `List` module. There is also a variant for two
+lists:
 
 ```ocamltop
+List.map2 ( + ) [1; 2; 3] [4; 5; 6]
+```
+
+In addition, we have an imperative analog to `map`, called `iter`. It takes an
+imperative function of type `'a -> unit` and an `'a list` and applies the
+function to each element in turn. A suitable function might be `print_endline`,
+for which `'a` is `string`:
+
+```ocamltop
+List.iter print_endline ["frank"; "james"; "mary"];;
+```
+
+There is a variant of `iter` for two lists too:
+
+```ocamltop
+List.iter2
+  (fun a b -> print_endline (a ^ " " ^ b))
+  ["frank"; "james"; "mary"]
+  ["carter"; "lee"; "jones"];;
+```
+
+Notice that `map2` and `iter2` will fail if the lists are of unequal length:
+
+```ocamltop
+List.map2 ( + ) [1; 2; 3] [4; 5]
 ```
 
 ### List scanning
@@ -201,8 +226,10 @@ write functions to go over each element of the list, keeping a boolean check,
 or use `mem` and other functions already known to us:
 
 ```ocamltop
-let all = not (List.mem false (List.map (fun x -> x mod 2 = 0) [2; 4; 6; 8]));;
-let any = List.mem true (List.map (fun x -> x mod 2 = 0) [1; 2; 3]);;
+let all =
+  not (List.mem false (List.map (fun x -> x mod 2 = 0) [2; 4; 6; 8]));;
+let any =
+  List.mem true (List.map (fun x -> x mod 2 = 0) [1; 2; 3]);;
 ```
 
 This is rather clumsy, though. The standard library provides two useful
@@ -220,10 +247,34 @@ standalone functions.
 
 ### List searching
 
-find / filter / partition
+The function `List.find` returns the first element of a list matching a given
+predicate (a predicate is a testing function which returns either true or false
+when given an element). It raises an exception if such an element is not found:
+
 
 ```ocamltop
+List.find (fun x -> x mod 2 = 0) [1; 2; 3; 4; 5];;
+List.find (fun x -> x mod 2 = 0) [1; 3; 5];;
 ```
+
+The `filter` function again takes a predicate and tests it against each element
+in the list, but this time returns the list of all elements which test true:
+
+```ocamltop
+List.filter (fun x -> x mod 2 = 0) [1; 2; 3; 4; 5];;
+```
+
+If we wish to know also which elements did not test true, we can use
+`partition` which returns a pair of lists: the first being the list of elements
+for which the predicate is true, the second those for which it is false.
+
+```ocamltop
+List.partition (fun x -> x mod 2 = 0) [1; 2; 3; 4; 5];;
+```
+
+Note that the documentation for `filter` and `partition` tells us that the
+order of the inputs is preserved in the outputs. Where this is not stated it
+the documentation, it cannot be assumed.
 
 ### Association lists
 
@@ -241,11 +292,13 @@ List.assoc 4 [(3, "three"); (1, "one"); (4, "four")];;
 List.mem_assoc 4 [(3, "three"); (1, "one"); (4, "four")];;
 ```
 
-### Lists of pairs
-
-split / combine
+When using association lists, and for other purposes, it is sometimes useful to
+be able to make a list of pairs from a pair of lists and vice versa. The `List`
+module provides the functions `split` and `combine` for this purpose: 
 
 ```ocamltop
+List.split [(3, "three"); (1, "one"); (4, "four")];;
+List.combine [3; 1; 4] ["three"; "one"; "four"];;
 ```
 
 ### Sorting lists
@@ -266,4 +319,47 @@ List.sort compare [(1, 3); (1, 2); (2, 3); (2, 2)];;
 List.sort
   (fun a b -> compare (fst a) (fst b))
   [(1, 3); (1, 2); (2, 3); (2, 2)];;
+```
+
+### Two special functions: fold_left and fold_right
+
+1. Introduce them, and how they work, and their types
+
+2. Some little examples, expained. Bad concat example warning
+
+3. Here are some more. Can you work them out?
+
+```ocamltop
+List.fold_left ( + ) 0 [1; 2; 3];;
+
+List.fold_left max min_int [2; 4; 6; 0; 1];;
+
+let setify l =
+   List.fold_left
+     (fun a e -> if List.mem e a then a else e :: a) [] l;;
+
+let all l = List.fold_left ( && ) true l;;
+
+let any l = List.fold_left ( || ) false l;;
+
+let map f l =
+  List.fold_right (fun e a -> f e :: a) l [];;
+
+let append x y =
+  List.fold_right (fun e a -> e :: a) x y;;
+
+let split l =
+  List.fold_right
+    (fun (x, y) (xs, ys) -> (x :: xs, y :: ys))
+    l
+    ([], []);;
+
+let concat l =
+  List.fold_left ( @ ) [] l (* BAD *);;
+
+let length l =
+  List.fold_left (fun a _ -> a + 1) 0 l;;
+
+let rev l =
+  List.fold_left (fun a e -> e :: a) [] l;;
 ```

--- a/site/learn/tutorials/lists.md
+++ b/site/learn/tutorials/lists.md
@@ -5,28 +5,27 @@
 #Lists
 
 A list is an ordered sequence of elements. All elements of a list in OCaml must
-be the same type. Lists are built into the language, and have a special syntax.
+be the same type. Lists are built into the language and have a special syntax.
 Here is a list of three integers:
 
 ```ocamltop
 [1; 2; 3]
 ```
 
-Note semicolons separate the element, not commas. The empty list is written
+Note semicolons separate the elements, not commas. The empty list is written
 `[]`. The type of this list of integers is `int list`.
 
 A list, if it is not empty, has a *head* (the first element) and a *tail* (the
-list consisting of the rest of the elements). The head is an element, and the
-tail is a list, so in the above example, the head is the integer `1` while the
-tail is the *list* `[2; 3]`. An empty list has neither a head nor a tail. Here
-are some more lists:
+list consisting of the rest of the elements). In our example, the head is the
+integer `1` while the tail is the list `[2; 3]`. An empty list has neither a
+head nor a tail. Here are some more lists:
 
 ```ocamltop
 [];;
 
 [1; 2; 3];;
 
-[false; false; true];;
+[false; true; false];;
 
 [[1; 2]; [3; 4]; [5; 6]];;
 ```
@@ -57,18 +56,7 @@ let rec total l =
 total [1; 3; 5; 3; 1];;
 ```
 
-You can see how the pattern `h :: t` is used to deconstruct the list, naming
-its head and tail. If we omit a case, OCaml will notice and warn us:
-
-```ocamltop
-let rec total l =
-  match l with
-  | h :: t -> h + total t;;
-
-total [1; 3; 5; 3; 1];;
-```
-
-Consider now a function to find the length of a list:
+Consider a function to find the length of a list:
 
 ```ocamltop
 let rec length l =
@@ -78,8 +66,6 @@ let rec length l =
 ```
 
 This function operates not just on lists of integers, but on any kind of list.
-This is indicated by the type, which allows its input to be `'a list`
-(pronounced alpha list).
 
 ```ocamltop
 length [1; 2; 3];;
@@ -101,14 +87,13 @@ let rec append a b =
   | h :: t -> h :: append t b;;
 ```
 
-Can you see how it works? Notice that the memory for the second list is shared,
-but the first list is effectively copied. Such sharing is common when we use
-immutable data types (ones whose values cannot be changed).
+Notice that the memory for the second list is shared, but the first list is
+effectively copied.
 
 ##Lists and tail recursion
 
-Our length function builds up an intermediate expression of a size proportional
-to its input list:
+Our `length` function builds up an intermediate expression of a size
+proportional to its input list:
 
 ```
    length [1; 2; 3]
@@ -122,7 +107,7 @@ to its input list:
 ```
 
 For long lists, this may overflow the stack. The solution is to write our
-function with an accumulator, like this:
+function with an accumulating argument, like this:
 
 ```ocamltop
 let rec length acc l =
@@ -155,7 +140,7 @@ let rec length_inner acc l =
 let length l = length_inner 0 l;;
 ```
 
-Or, all in one function:
+Or, we can do it all in one function:
 
 ```ocamltop
 let length l =
@@ -183,41 +168,14 @@ let rec map f l =
 Notice the type of the function `f` in parentheses as part of the whole type.
 This `map` function, given a function of type `'a -> 'b` and a list of `'a`s,
 will build a list of `'b'`s. Sometimes `'a` and `'b` might be the same type, of
-course. Here are some examples of using `map`:
+course. Here are two examples showing the `map` function in use:
 
 ```ocamltop
-map total [[1; 2]; [3; 4]; [5; 6]];;
 map (fun x -> x * 2) [1; 2; 3];;
+map total [[1; 2]; [3; 4]; [5; 6]];;
 ```
 
-(The syntax `fun` ... `->` ... is used to build a function without a name - one
-we will only use in one place in the program.)
-
-We need not give a function all its arguments at once. This is called partial
-application. For example:
-
-```ocamltop
-let add a b = a + b;;
-add;;
-let f = add 6;;
-f 7;;
-```
-
-Look at the types of `add` and `f` to see what is going on. We can use partial
-application to add to each item of a list:
-
-```ocamltop
-map (add 6) [1; 2; 3];;
-```
-
-Indeed we can use partial application of our `map` function to map over lists
-of lists:
-
-```ocamltop
-map (map (fun x -> x * 2)) [[1; 2]; [3; 4]; [5; 6]];;
-```
-
-##A tour of the standard library List module
+##The standard library List module
 
 The standard library [List](https://ocaml.org/api/List.html) module contains a
 wide range of useful utility functions, including pre-written versions of many
@@ -225,32 +183,34 @@ of the functions we have written in this tutorial. A version of the module with
 labeled functions is available as part of
 [StdLabels](https://ocaml.org/api/StdLabels.html).
 
-In the List module documenation, non tail-recursive functions are marked
-specially. As always, functions which can raise an exception are marked with
-the exception kind. Such exceptions are usually the result of lists which are
-empty (and therefore have neither a head nor a tail) or lists of mismatched
+In the [List](https://ocaml.org/api/List.html) module documentation, non
+tail-recursive functions are marked specially. Functions which can raise an
+exception are marked too. Such exceptions are usually the result of lists which
+are empty (and therefore have neither a head nor a tail) or lists of mismatched
 length.
 
-###Maps and iterators on one and two lists
+###Maps and iterators
 
 We have already written a `map` function from scratch, and it is no surprise
-that one is included in the `List` module. There is also a variant for two
-lists:
+that one is included in the [List](https://ocaml.org/api/List.html) module.
+There is also a variant for two lists:
 
 ```ocamltop
 List.map2 ( + ) [1; 2; 3] [4; 5; 6]
 ```
 
-In addition, we have an imperative analog to `map`, called `iter`. It takes an
-imperative function of type `'a -> unit` and an `'a list` and applies the
-function to each element in turn. A suitable function might be `print_endline`,
-for which `'a` is `string`:
+In addition, we have an imperative analog to
+[`map`](https://ocaml.org/api/List.html#VALmap), called
+[`iter`](https://ocaml.org/api/List.html#VALiter). It takes an imperative
+function of type `'a -> unit` and an `'a list` and applies the function to each
+element in turn. A suitable function might be `print_endline`:
 
 ```ocamltop
 List.iter print_endline ["frank"; "james"; "mary"];;
 ```
 
-There is a variant of `iter` for two lists too:
+There is a variant [`iter2`](https://ocaml.org/api/List.html#VALiter2) for two
+lists too:
 
 ```ocamltop
 List.iter2
@@ -259,7 +219,9 @@ List.iter2
   ["carter"; "lee"; "jones"];;
 ```
 
-Notice that `map2` and `iter2` will fail if the lists are of unequal length:
+Notice that [`map2`](https://ocaml.org/api/List.html#VALmap2) and
+[`iter2`](https://ocaml.org/api/List.html#VALiter2) will fail if the lists are
+of unequal length:
 
 ```ocamltop
 List.map2 ( + ) [1; 2; 3] [4; 5]
@@ -297,14 +259,14 @@ List.exists (fun x -> x mod 2 = 0) [1; 2; 3];;
 ```
 
 So you can see how the standard library has evolved into its present state:
-useful pieces of frequently-rewritten code are chosen, and made into useful
-standalone functions.
+pieces of frequently-used code are turned into useful general functions.
 
 ###List searching
 
-The function `List.find` returns the first element of a list matching a given
-predicate (a predicate is a testing function which returns either true or false
-when given an element). It raises an exception if such an element is not found:
+The function [`find`](https://ocaml.org/api/List.html#VALfind) returns the
+first element of a list matching a given predicate (a predicate is a testing
+function which returns either true or false when given an element). It raises
+an exception if such an element is not found:
 
 
 ```ocamltop
@@ -312,24 +274,28 @@ List.find (fun x -> x mod 2 = 0) [1; 2; 3; 4; 5];;
 List.find (fun x -> x mod 2 = 0) [1; 3; 5];;
 ```
 
-The `filter` function again takes a predicate and tests it against each element
-in the list, but this time returns the list of all elements which test true:
+The [`filter`](https://ocaml.org/api/List.html#VALfilter) function again takes
+a predicate and tests it against each element in the list, but this time
+returns the list of all elements which test true:
 
 ```ocamltop
 List.filter (fun x -> x mod 2 = 0) [1; 2; 3; 4; 5];;
 ```
 
 If we wish to know also which elements did not test true, we can use
-`partition` which returns a pair of lists: the first being the list of elements
-for which the predicate is true, the second those for which it is false.
+[`partition`](https://ocaml.org/api/List.html#VALpartition) which returns a
+pair of lists: the first being the list of elements for which the predicate is
+true, the second those for which it is false.
 
 ```ocamltop
 List.partition (fun x -> x mod 2 = 0) [1; 2; 3; 4; 5];;
 ```
 
-Note that the documentation for `filter` and `partition` tells us that the
-order of the inputs is preserved in the outputs. Where this is not stated it
-the documentation, it cannot be assumed.
+Note that the documentation for
+[`filter`](https://ocaml.org/api/List.html#VALfilter)  and
+[`partition`](https://ocaml.org/api/List.html#VALpartition) tells us that the
+order of the input is preserved in the output. Where this is not stated it the
+documentation, it cannot be assumed.
 
 ###Association lists
 
@@ -348,8 +314,10 @@ List.mem_assoc 4 [(3, "three"); (1, "one"); (4, "four")];;
 ```
 
 When using association lists, and for other purposes, it is sometimes useful to
-be able to make a list of pairs from a pair of lists and vice versa. The `List`
-module provides the functions `split` and `combine` for this purpose: 
+be able to make a list of pairs from a pair of lists and vice versa. The
+[`List`](https://ocaml.org/api/List.html) module provides the functions
+[`split`](https://ocaml.org/api/List.html#VALsplit) and
+[`combine`](https://ocaml.org/api/List.html#VALcombine) for this purpose: 
 
 ```ocamltop
 List.split [(3, "three"); (1, "one"); (4, "four")];;
@@ -361,10 +329,10 @@ List.combine [3; 1; 4] ["three"; "one"; "four"];;
 The function [`List.sort`](https://ocaml.org/api/List.html#VALsort), given a
 comparison function of type `'a -> 'a -> int` (zero if equal, negative if first
 smaller, positive if second smaller) and an input list of type `'a list`,
-returns the list sorted according to the comparison function. Usually, we us
+returns the list sorted according to the comparison function. Typically, we use
 the built-in comparison function
-[`compare`](https://ocaml.org/api/Stdlib.html#VALcompare) which can compare two
-values of like type with the exception of functions which are incomparable.
+[`compare`](https://ocaml.org/api/Stdlib.html#VALcompare) which can compare any
+two values of like type (with the exception of functions which are incomparable).
 
 ```ocamltop
 List.sort compare [1; 4; 6; 4; 1];;
@@ -376,16 +344,22 @@ List.sort
   [(1, 3); (1, 2); (2, 3); (2, 2)];;
 ```
 
+(The function [`Fun.flip`](https://ocaml.org/api/Fun.html#VALflip) reverses the
+argument order of a binary function.)
+
 ###Folds
 
-There are two interestingly-named functions in the List module, `fold_left` and
-`fold_right`. Their job is to combine the elements of a list together, using a
-given function, accumulating an answer which is then returned. The answer
-returned depends upon the function given, the elements of the list, and the
-initial value of the accumulator supplied. So you can imagine these are very
-general functions. Let's explore `fold_left` first.
+There are two interestingly-named functions in the List module,
+[`fold_left`](https://ocaml.org/api/List.html#VALfold_left) and
+[`fold_right`](https://ocaml.org/api/List.html#VALfold_right). Their job is
+to combine the elements of a list together, using a given function,
+accumulating an answer which is then returned. The answer returned depends upon
+the function given, the elements of the list, and the initial value of the
+accumulator supplied. So you can imagine these are very general functions.
+Let's explore [`fold_left`](https://ocaml.org/api/List.html#VALfold_left)
+first.
 
-In our first example, we supply the addition function and an initial
+In this example, we supply the addition function and an initial
 accumulator value of 0:
 
 ```ocamltop
@@ -393,15 +367,16 @@ List.fold_left ( + ) 0 [1; 2; 3];;
 ```
 
 The result is the sum of the elements in the list. Now let's use OCaml's
-built-in `max` function which returns the larger of two given integers. We use
-`min_int`, the smallest possible integer, as our initial acumulator
+built-in `max` function which returns the larger of two given integers in place
+of our addition function. We use `min_int`, the smallest possible integer, as
+our initial accumulator
 
 ```ocamltop
 List.fold_left max min_int [2; 4; 6; 0; 1];;
 ```
 
 The largest number in the list is found. Let's look at the type of the
-`fold_left` function:
+[`fold_left`](https://ocaml.org/api/List.html#VALfold_left) function:
 
 ```ocamltop
 List.fold_left;;
@@ -414,9 +389,11 @@ type `'b list`. The result is the final value of the accumulator, so it must
 have type `'a`. Of course, in both of our examples, `'a` and `'b` are the same
 as one another. But this is not always so. 
 
-Consider the following definition of `append` which uses `List.fold_right`
-(`fold_left` considers the elements from the left, `fold_right` from the
-right):
+Consider the following definition of `append` which uses
+[`fold_right`](https://ocaml.org/api/List.html#VALfold_right)
+([`fold_left`](https://ocaml.org/api/List.html#VALfold_left) considers the
+elements from the left,
+[`fold_right`](https://ocaml.org/api/List.html#VALfold_right) from the right):
 
 ```ocamltop
 let append x y =
@@ -431,26 +408,33 @@ fold right is a little different:
 List.fold_right;;
 ```
 
-We can use `fold_right` to define our usual `map` function too:
+The function comes first, then the list of elements, then the initial
+accumulator value. We can use
+[`fold_right`](https://ocaml.org/api/List.html#VALfold_right) to define our
+usual `map` function:
 
 ```ocamltop
 let map f l =
   List.fold_right (fun e a -> f e :: a) l [];;
 ```
 
-But care is needed. If we try that with `List.concat`, which turns a list of
-lists into a list by concatenating the lists together, we get this:
+But care is needed. If we try that with
+[`List.concat`](https://ocaml.org/api/List.html#VALconcat), which turns a
+list of lists into a list by concatenating the lists together, we produce this:
 
 ```ocamltop
 let concat l = List.fold_left ( @ ) [] l;;
 ```
 
-Unfortunately, the order of evalution here is such that larger and larger items
-are passed to the `@` operator as its first argument, and so the function has a
-worse running time than `List.concat`.
+Unfortunately, the order of evaluation here is such that larger and larger
+items are passed to the `@` operator as its first argument, and so the function
+has a worse running time than
+[`List.concat`](https://ocaml.org/api/List.html#VALconcat).
 
-Here are some more redefintions of familiar functions in terms of `fold_left`
-or `fold_right`. Can you work out how they operate?
+Here are some more redefinitions of familiar functions in terms of
+[`fold_left`](https://ocaml.org/api/List.html#VALfold_left) or
+[`fold_right`](https://ocaml.org/api/List.html#VALfold_right). Can you work
+out how they operate?
 
 ```ocamltop
 let length l =
@@ -458,10 +442,6 @@ let length l =
 
 let rev l =
   List.fold_left (fun a e -> e :: a) [] l;;
-
-let setify l =
-   List.fold_left
-     (fun a e -> if List.mem e a then a else e :: a) [] l;;
 
 let split l =
   List.fold_right

--- a/site/learn/tutorials/lists.md
+++ b/site/learn/tutorials/lists.md
@@ -1,0 +1,56 @@
+<!-- ((! set title Lists !)) ((! set learn !)) -->
+
+*Table of contents*
+
+# Lists
+
+A list is an ordered sequence of elements. All elements of a list in OCaml
+must be the same type. Lists are built into the language, and have a special
+syntax. Here is a list of three integers:
+
+```ocamltop
+[1; 2; 3]
+```
+
+Note semicolons separate the element, not commas. The empty list is written
+`[]`. The type of this list of integers is `int list`.
+
+A list has a *head* (the first element) and a *tail* (the list consisting of
+the rest of the elements). The head is an element, and the tail is a list, so
+in the above example, the head is the integer `1` while the tail is the *list*
+`[2; 3]`.
+
+An alternative way to write a list is to use the **cons** operator
+`head :: tail`. So the following ways to write a list are exactly the
+same:
+
+```ocaml
+[1; 2; 3]
+1 :: [2; 3]
+1 :: 2 :: [3]
+1 :: 2 :: 3 :: []
+```
+
+copy & extend stuff from "A First Hour"?
+
+lists of different types. empty list and polymorphism.
+
+the list of lists
+
+cons and append.
+
+pattern matching on lists, intro pattern matching.
+
+length / sum
+
+tail recursive length / sum
+
+rev by accum
+
+non exhaustive pattern matching
+
+append ourselves
+
+example standard library list functions
+
+polymorphic functions over lists

--- a/site/learn/tutorials/lists.md
+++ b/site/learn/tutorials/lists.md
@@ -90,67 +90,6 @@ let rec append a b =
 Notice that the memory for the second list is shared, but the first list is
 effectively copied.
 
-##Lists and tail recursion
-
-Our `length` function builds up an intermediate expression of a size
-proportional to its input list:
-
-```
-   length [1; 2; 3]
-=> 1 + length [2; 3]
-=> 1 + (1 + length [3])
-=> 1 + (1 + (1 + length []))
-=> 1 + (1 + (1 + 0))
-=> 1 + (1 + 1)
-=> 1 + 2
-=> 3
-```
-
-For long lists, this may overflow the stack. The solution is to write our
-function with an accumulating argument, like this:
-
-```ocamltop
-let rec length acc l =
-  match l with
-  | [] -> acc
-  | _ :: t -> length (acc + 1) t;;
-
-let l = length 0 [1; 2; 3];;
-```
-
-This function now uses a constant amount of space on the stack:
-
-```
-   length 0 [1; 2; 3]
-=> length 1 [2; 3]
-=> length 2 [3]
-=> length 3 []
-=> 3
-```
-
-We may write a wrapper function so that the initial accumulator value is
-supplied automatically:
-
-```ocamltop
-let rec length_inner acc l =
-  match l with
-  | [] -> acc
-  | _ :: t -> length_inner (acc + 1) t;;
-
-let length l = length_inner 0 l;;
-```
-
-Or, we can do it all in one function:
-
-```ocamltop
-let length l =
-  let rec length_inner acc l =
-    match l with
-    | [] -> acc
-    | _ :: t -> length_inner (acc + 1) t
-  in
-    length_inner 0 l;;
-```
 
 ##Higher order functions on lists
 
@@ -183,11 +122,10 @@ of the functions we have written in this tutorial. A version of the module with
 labeled functions is available as part of
 [StdLabels](https://ocaml.org/api/StdLabels.html).
 
-In the [List](https://ocaml.org/api/List.html) module documentation, non
-tail-recursive functions are marked specially. Functions which can raise an
-exception are marked too. Such exceptions are usually the result of lists which
-are empty (and therefore have neither a head nor a tail) or lists of mismatched
-length.
+In the [List](https://ocaml.org/api/List.html) module documentation, functions
+which can raise an exception are marked. Such exceptions are usually the result
+of lists which are empty (and therefore have neither a head nor a tail) or
+lists of mismatched length.
 
 ###Maps and iterators
 
@@ -429,7 +367,10 @@ let concat l = List.fold_left ( @ ) [] l;;
 Unfortunately, the order of evaluation here is such that larger and larger
 items are passed to the `@` operator as its first argument, and so the function
 has a worse running time than
-[`List.concat`](https://ocaml.org/api/List.html#VALconcat).
+[`List.concat`](https://ocaml.org/api/List.html#VALconcat). You can read more
+about the time and space efficiency of lists and other common OCaml data
+structures in the [comparison of standard
+containers](comparison_of_standard_containers.html).
 
 Here are some more redefinitions of familiar functions in terms of
 [`fold_left`](https://ocaml.org/api/List.html#VALfold_left) or
@@ -449,3 +390,70 @@ let split l =
     l
     ([], []);;
 ```
+
+##Lists and tail recursion
+
+Our `length` function builds up an intermediate expression of a size
+proportional to its input list:
+
+```
+   length [1; 2; 3]
+=> 1 + length [2; 3]
+=> 1 + (1 + length [3])
+=> 1 + (1 + (1 + length []))
+=> 1 + (1 + (1 + 0))
+=> 1 + (1 + 1)
+=> 1 + 2
+=> 3
+```
+
+For long lists, this may overflow the stack (be too large for the computer to
+handle). The solution is to write our function with an accumulating argument,
+like this:
+
+```ocamltop
+let rec length acc l =
+  match l with
+  | [] -> acc
+  | _ :: t -> length (acc + 1) t;;
+
+let l = length 0 [1; 2; 3];;
+```
+
+This function now uses a constant amount of space on the stack:
+
+```
+   length 0 [1; 2; 3]
+=> length 1 [2; 3]
+=> length 2 [3]
+=> length 3 []
+=> 3
+```
+
+We call such a function *tail-recursive*. We may write a wrapper function so
+that the initial accumulator value is supplied automatically:
+
+```ocamltop
+let rec length_inner acc l =
+  match l with
+  | [] -> acc
+  | _ :: t -> length_inner (acc + 1) t;;
+
+let length l = length_inner 0 l;;
+```
+
+Or, we can do it all in one function:
+
+```ocamltop
+let length l =
+  let rec length_inner acc l =
+    match l with
+    | [] -> acc
+    | _ :: t -> length_inner (acc + 1) t
+  in
+    length_inner 0 l;;
+```
+
+In the standard library documentation, functions which are not tail-recursive
+are marked.
+

--- a/site/learn/tutorials/lists.md
+++ b/site/learn/tutorials/lists.md
@@ -18,39 +18,252 @@ Note semicolons separate the element, not commas. The empty list is written
 A list has a *head* (the first element) and a *tail* (the list consisting of
 the rest of the elements). The head is an element, and the tail is a list, so
 in the above example, the head is the integer `1` while the tail is the *list*
-`[2; 3]`.
+`[2; 3]`. An empty list has neither a head nor a tail. Here are some more lists:
 
-An alternative way to write a list is to use the **cons** operator
-`head :: tail`. So the following ways to write a list are exactly the
-same:
+```ocamltop
+[];;
 
-```ocaml
-[1; 2; 3]
-1 :: [2; 3]
-1 :: 2 :: [3]
-1 :: 2 :: 3 :: []
+[1; 2; 3];;
+
+[false; false; true];;
+
+[[1; 2]; [3; 4]; [5; 6]];;
 ```
 
-copy & extend stuff from "A First Hour"?
+Notice the type of the empty list is `'a list` (its element type is not known).
+Notice also the type of the last list - `int list list` or a list of lists of
+integers.
 
-lists of different types. empty list and polymorphism.
+There are two built-in operators on lists. The `::` or cons operator, adds one
+element to the front of a list. The `@` or append operator combines two lists:
 
-the list of lists
+```ocamltop
+1 :: [2; 3];;
 
-cons and append.
+[1] @ [2; 3];;
+```
 
-pattern matching on lists, intro pattern matching.
+## Functions on lists
 
-length / sum
+We can write functions which operate over lists by pattern matching:
 
-tail recursive length / sum
+```ocamltop
+let rec total l =
+  match l with
+  | [] -> 0
+  | h :: t -> h + total t;;
 
-rev by accum
+total [1; 3; 5; 3; 1];;
+```
 
-non exhaustive pattern matching
+You can see how the pattern `h :: t` is used to deconstruct the list, naming
+its head and tail. If we omit a case, OCaml will notice and warn us:
 
-append ourselves
+```ocamltop
+let rec total l =
+  match l with
+  | h :: t -> h + total t;;
 
-example standard library list functions
+total [1; 3; 5; 3; 1];;
+```
 
-polymorphic functions over lists
+We shall talk about the "exception" which was caused by our ignoring the
+warning later. Consider now a function to find the length of a list:
+
+```ocamltop
+let rec length l =
+  match l with
+  | [] -> 0
+  | _ :: t -> 1 + length t;;
+```
+
+This function operates not just on lists of integers, but on any kind of list.
+This is indicated by the type, which allows its input to be `'a list`
+(pronounced alpha list).
+
+```ocamltop
+length [1; 2; 3];;
+
+length ["cow"; "sheep"; "cat"];;
+
+length [[]];;
+```
+
+Why is this? Because in the pattern `_ :: t` the head of the list is not
+inspected, so its type cannot be relevant. Such a function is called
+polymorphic. Here is another polymorphic function, our own version of the `@`
+operator for appending:
+
+```ocamltop
+let rec append a b =
+  match a with
+  | [] -> b
+  | h :: t -> h :: append t b;;
+```
+
+Can you see how it works? Notice that the memory for the second list is shared,
+but the first list is effectively copied. Such sharing is common when we use
+immutable data types (ones whose values cannot be changed).
+
+## Tail Recursion with Lists
+
+length / sum rev by accum
+
+## Higher order functions on lists
+
+We might wish to apply a function to each element in a list, yielding a new
+one. We shall write a function `map` which is given another function as its
+argument - such a function is called "higher-order":
+
+```ocamltop
+let rec map f l =
+  match l with
+  | [] -> []
+  | h :: t -> f h :: map f t;;
+```
+
+Notice the type of the function `f` in parentheses as part of the whole type.
+This `map` function, given a function of type `'a -> 'b` and a list of `'a`s,
+will build a list of `'b'`s. Sometimes `'a` and `'b` might be the same type, of
+course. Here are some examples of using `map`:
+
+```ocamltop
+map total [[1; 2]; [3; 4]; [5; 6]];;
+map (fun x -> x * 2) [1; 2; 3];;
+```
+
+(The syntax `fun` ... `->` ... is used to build a function without a name - one
+we will only use in one place in the program.)
+
+We need not give a function all its arguments at once. This is called partial
+application. For example:
+
+```ocamltop
+let add a b = a + b;;
+add;;
+let f = add 6;;
+f 7;;
+```
+
+Look at the types of `add` and `f` to see what is going on. We can use partial
+application to add to each item of a list:
+
+```ocamltop
+map (add 6) [1; 2; 3];;
+```
+
+Indeed we can use partial application of our `map` function to map over lists
+of lists:
+
+```ocamltop
+map (map (fun x -> x * 2)) [[1; 2]; [3; 4]; [5; 6]];;
+```
+
+add left fold, right fold
+
+## List complexity (time and space) and hd/tl not complete problems
+
+
+## A tour of the standard library List module
+
+The standard library [List](https://ocaml.org/api/List.html) module contains a
+wide range of useful utility functions, including pre-written versions of many
+of the functions we have written in this tutorial. A version of the module with
+labeled functions is available as part of
+[StdLabels](https://ocaml.org/api/StdLabels.html).
+
+In the List module documenation, non tail-recursive functions are marked
+specially. As always, functions which can raise an exception are marked with
+the exception kind.
+
+### Maps and iterators on one and two lists
+
+map, iter
+
+map2 etc.
+
+```ocamltop
+```
+
+### List scanning
+
+The useful function [`mem`](https://ocaml.org/api/List.html#VALmem) checks
+whether a given element is a member of a list by scanning its contents:
+
+```ocamltop
+List.mem "frank" ["james"; "frank"; "mary"];;
+List.mem [] [[1; 2]; [3]; []; [5]];;
+```
+
+There are more elaborate scanning functions: imagine we wish to check to see if
+all elements of a list are even, or if any element is even. We could either
+write functions to go over each element of the list, keeping a boolean check,
+or use `mem` and other functions already known to us:
+
+```ocamltop
+let all = not (List.mem false (List.map (fun x -> x mod 2 = 0) [2; 4; 6; 8]));;
+let any = List.mem true (List.map (fun x -> x mod 2 = 0) [1; 2; 3]);;
+```
+
+This is rather clumsy, though. The standard library provides two useful
+functions [`for_all`](https://ocaml.org/api/List.html#VALfor_all) and
+[`exists`](https://ocaml.org/api/List.html#VALexists) for this common problem:
+
+```ocamltop
+List.for_all (fun x -> x mod 2 = 0) [2; 4; 6; 8];;
+List.exists (fun x -> x mod 2 = 0) [1; 2; 3];;
+```
+
+So you can see how the standard library has evolved into its present state:
+useful pieces of frequently-rewritten code are chosen, and made into useful
+standalone functions.
+
+### List searching
+
+find / filter / partition
+
+```ocamltop
+```
+
+### Association lists
+
+Association lists are a simple (and simplistic) way of implementing the
+dictionary data structure: that is to say, a group of keys each with an
+associated value. For large dictionaries, for efficiency, we would use the
+standard library's [Map](https://ocaml.org/api/Map.html) or
+[Hashtbl](https://ocaml.org/api/Hashtbl.html) modules. But these functions from
+the List module are useful for lists which are generally small, and have other
+advantages: since they are just lists of pairs, they can be built and modified
+easily. They are also easily printed in the toplevel.
+
+```ocamltop
+List.assoc 4 [(3, "three"); (1, "one"); (4, "four")];;
+List.mem_assoc 4 [(3, "three"); (1, "one"); (4, "four")];;
+```
+
+### Lists of pairs
+
+split / combine
+
+```ocamltop
+```
+
+### Sorting lists
+
+The function [`List.sort`](https://ocaml.org/api/List.html#VALsort), given a
+comparison function of type `'a -> 'a -> int` (zero if equal, negative if first
+smaller, positive if second smaller) and an input list of type `'a list`,
+returns the list sorted according to the comparison function. Usually, we us
+the built-in comparison function
+[`compare`](https://ocaml.org/api/Stdlib.html#VALcompare) which can compare two
+values of like type with the exception of functions which are incomparable.
+
+```ocamltop
+List.sort compare [1; 4; 6; 4; 1];;
+List.sort compare ["Reynolds"; "Smith"; "Barnes"];;
+List.sort (Fun.flip compare) [1; 4; 6; 4; 1];;
+List.sort compare [(1, 3); (1, 2); (2, 3); (2, 2)];;
+List.sort
+  (fun a b -> compare (fst a) (fst b))
+  [(1, 3); (1, 2); (2, 3); (2, 2)];;
+```

--- a/site/learn/tutorials/lists.md
+++ b/site/learn/tutorials/lists.md
@@ -2,11 +2,11 @@
 
 *Table of contents*
 
-# Lists
+#Lists
 
-A list is an ordered sequence of elements. All elements of a list in OCaml
-must be the same type. Lists are built into the language, and have a special
-syntax. Here is a list of three integers:
+A list is an ordered sequence of elements. All elements of a list in OCaml must
+be the same type. Lists are built into the language, and have a special syntax.
+Here is a list of three integers:
 
 ```ocamltop
 [1; 2; 3]
@@ -15,10 +15,11 @@ syntax. Here is a list of three integers:
 Note semicolons separate the element, not commas. The empty list is written
 `[]`. The type of this list of integers is `int list`.
 
-A list has a *head* (the first element) and a *tail* (the list consisting of
-the rest of the elements). The head is an element, and the tail is a list, so
-in the above example, the head is the integer `1` while the tail is the *list*
-`[2; 3]`. An empty list has neither a head nor a tail. Here are some more lists:
+A list, if it is not empty, has a *head* (the first element) and a *tail* (the
+list consisting of the rest of the elements). The head is an element, and the
+tail is a list, so in the above example, the head is the integer `1` while the
+tail is the *list* `[2; 3]`. An empty list has neither a head nor a tail. Here
+are some more lists:
 
 ```ocamltop
 [];;
@@ -43,7 +44,7 @@ element to the front of a list. The `@` or append operator combines two lists:
 [1] @ [2; 3];;
 ```
 
-## Functions on lists
+##Functions on lists
 
 We can write functions which operate over lists by pattern matching:
 
@@ -67,8 +68,7 @@ let rec total l =
 total [1; 3; 5; 3; 1];;
 ```
 
-We shall talk about the "exception" which was caused by our ignoring the
-warning later. Consider now a function to find the length of a list:
+Consider now a function to find the length of a list:
 
 ```ocamltop
 let rec length l =
@@ -105,11 +105,69 @@ Can you see how it works? Notice that the memory for the second list is shared,
 but the first list is effectively copied. Such sharing is common when we use
 immutable data types (ones whose values cannot be changed).
 
-## Tail Recursion with Lists
+##Lists and tail recursion
 
-length / sum rev by accum
+Our length function builds up an intermediate expression of a size proportional
+to its input list:
 
-## Higher order functions on lists
+```
+   length [1; 2; 3]
+=> 1 + length [2; 3]
+=> 1 + (1 + length [3])
+=> 1 + (1 + (1 + length []))
+=> 1 + (1 + (1 + 0))
+=> 1 + (1 + 1)
+=> 1 + 2
+=> 3
+```
+
+For long lists, this may overflow the stack. The solution is to write our
+function with an accumulator, like this:
+
+```ocamltop
+let rec length acc l =
+  match l with
+  | [] -> acc
+  | _ :: t -> length (acc + 1) t;;
+
+let l = length 0 [1; 2; 3];;
+```
+
+This function now uses a constant amount of space on the stack:
+
+```
+   length 0 [1; 2; 3]
+=> length 1 [2; 3]
+=> length 2 [3]
+=> length 3 []
+=> 3
+```
+
+We may write a wrapper function so that the initial accumulator value is
+supplied automatically:
+
+```ocamltop
+let rec length_inner acc l =
+  match l with
+  | [] -> acc
+  | _ :: t -> length_inner (acc + 1) t;;
+
+let length l = length_inner 0 l;;
+```
+
+Or, all in one function:
+
+```ocamltop
+let length l =
+  let rec length_inner acc l =
+    match l with
+    | [] -> acc
+    | _ :: t -> length_inner (acc + 1) t
+  in
+    length_inner 0 l;;
+```
+
+##Higher order functions on lists
 
 We might wish to apply a function to each element in a list, yielding a new
 one. We shall write a function `map` which is given another function as its
@@ -159,12 +217,7 @@ of lists:
 map (map (fun x -> x * 2)) [[1; 2]; [3; 4]; [5; 6]];;
 ```
 
-add left fold, right fold
-
-## List complexity (time and space) and hd/tl not complete problems
-
-
-## A tour of the standard library List module
+##A tour of the standard library List module
 
 The standard library [List](https://ocaml.org/api/List.html) module contains a
 wide range of useful utility functions, including pre-written versions of many
@@ -174,9 +227,11 @@ labeled functions is available as part of
 
 In the List module documenation, non tail-recursive functions are marked
 specially. As always, functions which can raise an exception are marked with
-the exception kind.
+the exception kind. Such exceptions are usually the result of lists which are
+empty (and therefore have neither a head nor a tail) or lists of mismatched
+length.
 
-### Maps and iterators on one and two lists
+###Maps and iterators on one and two lists
 
 We have already written a `map` function from scratch, and it is no surprise
 that one is included in the `List` module. There is also a variant for two
@@ -210,7 +265,7 @@ Notice that `map2` and `iter2` will fail if the lists are of unequal length:
 List.map2 ( + ) [1; 2; 3] [4; 5]
 ```
 
-### List scanning
+###List scanning
 
 The useful function [`mem`](https://ocaml.org/api/List.html#VALmem) checks
 whether a given element is a member of a list by scanning its contents:
@@ -245,7 +300,7 @@ So you can see how the standard library has evolved into its present state:
 useful pieces of frequently-rewritten code are chosen, and made into useful
 standalone functions.
 
-### List searching
+###List searching
 
 The function `List.find` returns the first element of a list matching a given
 predicate (a predicate is a testing function which returns either true or false
@@ -276,7 +331,7 @@ Note that the documentation for `filter` and `partition` tells us that the
 order of the inputs is preserved in the outputs. Where this is not stated it
 the documentation, it cannot be assumed.
 
-### Association lists
+###Association lists
 
 Association lists are a simple (and simplistic) way of implementing the
 dictionary data structure: that is to say, a group of keys each with an
@@ -301,7 +356,7 @@ List.split [(3, "three"); (1, "one"); (4, "four")];;
 List.combine [3; 1; 4] ["three"; "one"; "four"];;
 ```
 
-### Sorting lists
+###Sorting lists
 
 The function [`List.sort`](https://ocaml.org/api/List.html#VALsort), given a
 comparison function of type `'a -> 'a -> int` (zero if equal, negative if first
@@ -321,7 +376,7 @@ List.sort
   [(1, 3); (1, 2); (2, 3); (2, 2)];;
 ```
 
-### Folds
+###Folds
 
 There are two interestingly-named functions in the List module, `fold_left` and
 `fold_right`. Their job is to combine the elements of a list together, using a
@@ -330,7 +385,8 @@ returned depends upon the function given, the elements of the list, and the
 initial value of the accumulator supplied. So you can imagine these are very
 general functions. Let's explore `fold_left` first.
 
-In our first example, we supply the addition function and an initial accumulator value of 0:
+In our first example, we supply the addition function and an initial
+accumulator value of 0:
 
 ```ocamltop
 List.fold_left ( + ) 0 [1; 2; 3];;
@@ -382,7 +438,8 @@ let map f l =
   List.fold_right (fun e a -> f e :: a) l [];;
 ```
 
-But care is needed. If we try that with `List.concat`, which turns a list of lists into a list by concatenating the lists together, we get this:
+But care is needed. If we try that with `List.concat`, which turns a list of
+lists into a list by concatenating the lists together, we get this:
 
 ```ocamltop
 let concat l = List.fold_left ( @ ) [] l;;


### PR DESCRIPTION
Oddly, ocaml.org has never had a tutorial on lists. This PR adds one, and deletes a section from "Data Types and Matching" which is about lists. Next week I will propose a PR to replace the "Data Types and Matching" tutorial too.

(A little content is re-used from "A First Hour with OCaml", but edited for length).