### PR TITLE
Added OCaml Manual button on Documentation page

### DIFF
--- a/site/docs/index.fr.md
+++ b/site/docs/index.fr.md
@@ -104,6 +104,12 @@
 	<a id="refman-info"
 	   href="/releases/4.12/ocaml-4.12-refman.info.tar.gz">archive de fichiers Emacs Info</a>.
       </p>
+
+     <p class="doc-link-wrapper">
+		<a id="manual"
+		href="/manual/index.html" class="btn btn-default" >
+	   Manuel OCaml</a>
+	  </p
     </section>
 
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -102,6 +102,11 @@
 	   href="/releases/4.12/ocaml-4.12-refman.info.tar.gz">bundle of
 	  Emacs Info files</a>.
       </p>
+	  <p class="doc-link-wrapper">
+		<a id="manual"
+		href="/manual/index.html" class="btn btn-default" >
+	   OCaml Manual</a>
+	  </p
     </section>
 
 


### PR DESCRIPTION
# Issue Description

The Documentation page was missing a button for OCaml Manual on both english as well as french version of site

![Screenshot from 2021-04-23 19-55-51](https://user-images.githubusercontent.com/58878761/116391424-c6198f00-a83c-11eb-8738-0fd3dbdb5b4a.png)

![Screenshot from 2021-04-23 19-56-27](https://user-images.githubusercontent.com/58878761/116391478-d7fb3200-a83c-11eb-8151-b13c773c20f5.png)


Fixes #1468 

## Changes Made

Added OCaml Manual button on both english as well as french version of site.

![Screenshot from 2021-04-23 19-56-07](https://user-images.githubusercontent.com/58878761/116391501-de89a980-a83c-11eb-9219-36a3f8ba997f.png)

![Screenshot from 2021-04-23 19-56-32](https://user-images.githubusercontent.com/58878761/116391516-e47f8a80-a83c-11eb-8bbc-73cce948fe41.png)

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
