### PR TITLE
changed portability links from old inria site to /learn/portability.html

### DIFF
--- a/site/releases/3.12.1.md
+++ b/site/releases/3.12.1.md
@@ -74,7 +74,7 @@ compatible with Mac OS 10.4.x):
 ## ![](../img/windows.gif "")Precompiled binaries for Microsoft Windows
 Four ports of OCaml for Microsoft Windows are currently available. For
 additional information, please consult the list of [portability
-issues](http://caml.inria.fr/ocaml/portability.en.html) or the [Windows
+issues](/learn/portability.html) or the [Windows
 release
 notes](3.12/notes/README.win32).
 

--- a/site/releases/4.00.1.md
+++ b/site/releases/4.00.1.md
@@ -67,7 +67,7 @@ not compatible with earlier versions of Mac OS X):
 ## ![](../img/windows.gif "")Precompiled binaries for Microsoft Windows
 Four ports of OCaml for Microsoft Windows are currently available. For
 additional information, please consult the list of [portability
-issues](http://caml.inria.fr/ocaml/portability.en.html) or the [Windows
+issues](/learn/portability.html) or the [Windows
 release
 notes](4.00/notes/README.win32).
 


### PR DESCRIPTION
# Issue Description

Portability links in Release notes still point back to the old caml inria site. They should instead point to http://preview.ocaml.org/learn/portability.html

Fixes #294 

Now the release notes point to /learn/portability.html.
Only 2 files were pointing to the old site.
