### PR TITLE
Replacement "Data Types and Matching" tutorial

### DIFF
--- a/site/learn/tutorials/a_first_hour_with_ocaml.md
+++ b/site/learn/tutorials/a_first_hour_with_ocaml.md
@@ -356,11 +356,11 @@ You can see how the pattern `h :: t` is used to deconstruct the list, naming
 its head and tail. If we omit a case, OCaml will notice and warn us:
 
 ```ocamltop
-let rec total l =
+let rec total_wrong l =
   match l with
-  | h :: t -> h + total t;;
+  | h :: t -> h + total_wrong t;;
 
-total [1; 3; 5; 3; 1];;
+total_wrong [1; 3; 5; 3; 1];;
 ```
 
 We shall talk about the "exception" which was caused by our ignoring the
@@ -505,13 +505,14 @@ a binary tree carrying any kind of data:
 
 ```ocamltop
 type 'a tree =
-  | Lf
-  | Br of 'a tree * 'a * 'a tree;;
+  | Leaf
+  | Node of 'a tree * 'a * 'a tree;;
 
-let t = Br (Br (Lf, 1, Lf), 2, Br (Br (Lf, 3, Lf), 4, Lf));;
+let t =
+  Node (Node (Leaf, 1, Leaf), 2, Node (Node (Leaf, 3, Leaf), 4, Leaf));;
 ```
 
-A `Lf` leaf holds no information, just like an empty list. A `Br` branch holds
+A `Leaf` holds no information, just like an empty list. A `Node` holds
 a left tree, a value of type `'a` and a right tree. Now we can write recursive
 and polymorphic functions over these trees, by pattern matching on our new
 constructors:
@@ -519,13 +520,13 @@ constructors:
 ```ocamltop
 let rec total t =
   match t with
-  | Lf -> 0
-  | Br (l, x, r) -> total l + x + total r;;
+  | Leaf -> 0
+  | Node (l, x, r) -> total l + x + total r;;
 
 let rec flip t =
   match t with
-  | Lf -> Lf
-  | Br (l, x, r) -> Br (flip r, x, flip l);;
+  | Leaf -> Leaf
+  | Node (l, x, r) -> Node (flip r, x, flip l);;
 ```
 
 Let's try our new functions out:

--- a/site/learn/tutorials/data_types_and_matching.md
+++ b/site/learn/tutorials/data_types_and_matching.md
@@ -112,16 +112,80 @@ let example = function
 
 ## Constructors with data
 
+We can do more than just enumerations. 
+
+```ocamltop
+type colour2 =
+  | Red
+  | Green
+  | Blue
+  | Yellow
+  | RGB of float * float * float
+  | Mix of float * colour2 * colour2
+```
+
 difference between a * b and (a * b)
 
-records in our own data type
+recursive:
 
-incomplete pattern matching
+```ocamltop
+type colour2 =
+  | Red
+  | Green
+  | Blue
+  | Yellow
+  | RGB of float * float * float
+  | Mix of float * colour2 * colour2
+```
 
+incomplete pattern matching example - what function?
 _ in pattern matching - reminder of when appropriate
 
+function to get rgb from any
+function to get any from rgb (yellow?)
+
+records in our own data type (put labels on existing data type, effectively *)
 
 ## Example: trees
+
+Data types may be polymorphic and recursive too. Here is an OCaml data type for
+a binary tree carrying any kind of data:
+
+```ocamltop
+type 'a tree =
+  | Lf
+  | Br of 'a tree * 'a * 'a tree;;
+
+let t = Br (Br (Lf, 1, Lf), 2, Br (Br (Lf, 3, Lf), 4, Lf));;
+```
+
+A `Lf` leaf holds no information, just like an empty list. A `Br` branch holds
+a left tree, a value of type `'a` and a right tree. Now we can write recursive
+and polymorphic functions over these trees, by pattern matching on our new
+constructors:
+
+```ocamltop
+let rec total t =
+  match t with
+  | Lf -> 0
+  | Br (l, x, r) -> total l + x + total r;;
+
+let rec flip t =
+  match t with
+  | Lf -> Lf
+  | Br (l, x, r) -> Br (flip r, x, flip l);;
+```
+
+Let's try our new functions out:
+
+```ocamltop
+let all = total t;;
+
+let flipped = flip t;;
+
+t = flip flipped;;
+```
+
 
 Fixed types vs paramerarized
 

--- a/site/learn/tutorials/data_types_and_matching.md
+++ b/site/learn/tutorials/data_types_and_matching.md
@@ -12,7 +12,7 @@ functions which process this new data.
 We have already seen simple data types such as `int`, `float`, `string`, and
 `bool`.  Let's recap the built-in compound data types we can use in OCaml to
 combine such values. First, we have lists which are ordered collections of any
-nuumber of elements of like type:
+number of elements of like type:
 
 ```ocamltop
 [];;
@@ -37,6 +37,11 @@ type point = {x : float; y : float};;
 let a = {x = 5.0; y = 6.5};;
 type colour = {websafe : bool; r : float; g : float; b : float; name : string};;
 let b = {websafe = true; r = 0.0; g = 0.45; b = 0.73; name = "french blue"};;
+```
+
+A record must contain all fields:
+
+```ocamltop
 let c = {name = "puce"};;
 ```
 
@@ -52,9 +57,9 @@ let birthday p =
   p.age <- p.age + 1;;
 ```
 
-Another mutable compound data type is the fixed-length array, which like a list
-must contain elements of like type. However, its elements may be accessed in
-constant time:
+Another mutable compound data type is the fixed-length array which, just as a
+list, must contain elements of like type. However, its elements may be accessed
+in constant time:
 
 ```ocamltop
 let arr = [|1; 2; 3|];;
@@ -66,7 +71,7 @@ arr;;
 In this tutorial, we will define our own compound data types, using the `type`
 keyword, and some of these built-in structures as building blocks.
 
-## A simple type
+## A simple custom type
 
 We can define a new data type `colour` which can take one of four values.
 
@@ -119,12 +124,12 @@ let rec is_primary = function
 
 ## Constructors with data
 
-In fact, each constructor in a data type can carry additional data. Let's
+Each constructor in a data type can carry additional information with it. Let's
 extend our `colour` type to allow arbitrary RGB triples, each element begin a
 number from 0 (no colour) to 1 (full colour): 
 
 ```ocamltop
-type colour2 =
+type colour =
   | Red
   | Green
   | Blue
@@ -138,18 +143,18 @@ Types, just like functions, may be recursively-defined. We extend our data type
 to allow mixing of colours:
 
 ```ocamltop
-type colour3 =
+type colour =
   | Red
   | Green
   | Blue
   | Yellow
   | RGB of float * float * float
-  | Mix of float * colour3 * colour3;;
+  | Mix of float * colour * colour;;
 
 Mix (0.5, Red, Mix (0.5, Blue, Green));; 
 ```
 
-Here is a function over our new `colour3` data type:
+Here is a function over our new `colour` data type:
 
 ```ocamltop
 let rec rgb_of_colour = function
@@ -167,13 +172,13 @@ let rec rgb_of_colour = function
 We can use records directly in the data type instead to label our components:
 
 ```ocamltop
-type colour4 =
+type colour =
   | Red
   | Green
   | Blue
   | Yellow
   | RGB of {r : float; g : float; b : float}
-  | Mix of {proportion : float; c1 : colour4; c2 : colour4}
+  | Mix of {proportion : float; c1 : colour; c2 : colour}
 ```
 
 ## Example: trees
@@ -206,7 +211,8 @@ let rec flip = function
   | Br (l, x, r) -> Br (flip r, x, flip l);;
 ```
 
-Let's try our new functions out:
+Here, `flip` is polymorphic while `total` operates only on trees of type `int
+tree`. Let's try our new functions out:
 
 ```ocamltop
 let all = total t;;
@@ -219,7 +225,7 @@ t = flip flipped;;
 Instead of integers, we could build a tree of key-value pairs. Then, if we
 insist that the keys are unique and that a smaller key is always left of a
 larger key, we have a data structure for dictionaries which performs better
-than a simple list of pairs:
+than a simple list of pairs. It is known as a *binary search tree*:
 
 ```ocamltop
 let rec insert (k, v) = function
@@ -326,8 +332,8 @@ multiplied out too (if you only wanted to multiply out the very top level of an
 expression, then you could replace all the remaining patterns with a simple `e
 -> e` rule).
 
-Can we do the reverse (ie. factorizing out common subexpressions)? We can! (But
-it's a bit more complicated). The following version only works for the top
+Can we do the reverse (i.e. factorizing out common subexpressions)? We can!
+(But it's a bit more complicated). The following version only works for the top
 level expression. You could certainly extend it to cope with all levels of an
 expression and more complex cases:
 
@@ -378,7 +384,7 @@ Data types may be mutually-recursive when declared with `and`:
 type t = A | B of t' and t' = C | D of t;;
 ```
 
-One common use for mutally-recursive data types is to *decorate* a tree, by
+One common use for mutually-recursive data types is to *decorate* a tree, by
 adding information to each node using mutually-recursive types, one of which is
 a tuple or record. For example:
 

--- a/site/learn/tutorials/data_types_and_matching.md
+++ b/site/learn/tutorials/data_types_and_matching.md
@@ -164,8 +164,8 @@ let rec rgb_of_colour = function
   | Yellow -> (1.0, 1.0, 0.0)
   | RGB (r, g, b) -> (r, g, b)
   | Mix (p, a, b) ->
-      let r1, g1, b1 = rgb_of_colour a in
-      let r2, g2, b2 = rgb_of_colour b in
+      let (r1, g1, b1) = rgb_of_colour a in
+      let (r2, g2, b2) = rgb_of_colour b in
       let mix x y = x *. p +. y *. (1.0 -. p) in
         (mix r1 r2, mix g1 g2, mix b1 b2)
 ```
@@ -189,27 +189,28 @@ for a binary tree carrying any kind of data:
 
 ```ocamltop
 type 'a tree =
-  | Lf
-  | Br of 'a tree * 'a * 'a tree;;
+  | Leaf
+  | Node of 'a tree * 'a * 'a tree;;
 
-let t = Br (Br (Lf, 1, Lf), 2, Br (Br (Lf, 3, Lf), 4, Lf));;
+let t =
+  Node (Node (Leaf, 1, Leaf), 2, Node (Node (Leaf, 3, Leaf), 4, Leaf));;
 ```
 
 Notice that we give the type parameter `'a` before the type name (if there is
-more than one, we write `('a, 'b)` etc).  A `Lf` leaf holds no information,
-just like an empty list. A `Br` branch holds a left tree, a value of type `'a`
+more than one, we write `('a, 'b)` etc).  A `Leaf` holds no information,
+just like an empty list. A `Node` holds a left tree, a value of type `'a`
 and a right tree. In our example, we built an integer tree, but any type can be
 used. Now we can write recursive and polymorphic functions over these trees, by
 pattern matching on our new constructors:
 
 ```ocamltop
 let rec total = function
-  | Lf -> 0
-  | Br (l, x, r) -> total l + x + total r;;
+  | Leaf -> 0
+  | Node (l, x, r) -> total l + x + total r;;
 
 let rec flip = function
-  | Lf -> Lf
-  | Br (l, x, r) -> Br (flip r, x, flip l);;
+  | Leaf -> Leaf
+  | Node (l, x, r) -> Node (flip r, x, flip l);;
 ```
 
 Here, `flip` is polymorphic while `total` operates only on trees of type `int
@@ -230,11 +231,11 @@ than a simple list of pairs. It is known as a *binary search tree*:
 
 ```ocamltop
 let rec insert (k, v) = function
-  | Lf -> Br (Lf, (k, v), Lf)
-  | Br (l, (k', v'), r) ->
-      if k < k' then Br (insert (k, v) l, (k', v'), r) 
-      else if k > k' then Br (l, (k', v'), insert (k, v) r)
-      else Br (l, (k, v), r);;
+  | Leaf -> Node (Leaf, (k, v), Leaf)
+  | Node (l, (k', v'), r) ->
+      if k < k' then Node (insert (k, v) l, (k', v'), r) 
+      else if k > k' then Node (l, (k', v'), insert (k, v) r)
+      else Node (l, (k, v), r);;
 ```
 
 Similar functions can be written to look up values in a dictionary, to convert
@@ -374,7 +375,7 @@ example:
 ```ocaml
 Name ("/DeviceGray" | "/DeviceRGB" | "/DeviceCMYK") as n -> n
 
-Br (l, ((k, _) as pair), r) when k = k' -> Some pair
+Node (l, ((k, _) as pair), r) when k = k' -> Some pair
 ```
 
 ## Mutually recursive data types

--- a/site/learn/tutorials/data_types_and_matching.md
+++ b/site/learn/tutorials/data_types_and_matching.md
@@ -135,7 +135,8 @@ type colour2 =
 [Red; Blue; RGB (0.5, 0.65, 0.12)];;
 ```
 
-Types, just like functions, may be recursively-defined. We extend our data type to allow mixing of colours:
+Types, just like functions, may be recursively-defined. We extend our data type
+to allow mixing of colours:
 
 ```ocamltop
 type colour3 =
@@ -189,11 +190,12 @@ type 'a tree =
 let t = Br (Br (Lf, 1, Lf), 2, Br (Br (Lf, 3, Lf), 4, Lf));;
 ```
 
-Notice that we give the type parameter `'a` before the type name.  A `Lf` leaf
-holds no information, just like an empty list. A `Br` branch holds a left tree,
-a value of type `'a` and a right tree. In our example, we built an integer
-tree, but any type can be used. Now we can write recursive and polymorphic
-functions over these trees, by pattern matching on our new constructors:
+Notice that we give the type parameter `'a` before the type name (if there is
+more than one, we write `('a, 'b)` etc).  A `Lf` leaf holds no information,
+just like an empty list. A `Br` branch holds a left tree, a value of type `'a`
+and a right tree. In our example, we built an integer tree, but any type can be
+used. Now we can write recursive and polymorphic functions over these trees, by
+pattern matching on our new constructors:
 
 ```ocamltop
 let rec total t =
@@ -217,7 +219,22 @@ let flipped = flip t;;
 t = flip flipped;;
 ```
 
-'as' in pattern matching
+Instead of integers, we could build a tree of key-value pairs. Then, if we
+insist that the keys are unique and that a smaller key is always left of a
+larger key, we have a data structure for dictionaries which performs better
+than a simple list of pairs:
+
+```ocamltop
+let rec insert (k, v) = function
+  | Lf -> Br (Lf, (k, v), Lf)
+  | Br (l, (k', v'), r) ->
+      if k < k' then Br (insert (k, v) l, (k', v'), r) 
+      else if k > k' then Br (l, (k', v'), insert (k, v) r)
+      else Br (l, (k, v), r);;
+```
+
+Similar functions can be written to lookup values in a dictionary, to convert a
+list of pairs to or from a tree dictionary and so on.
 
 ## Example: mathematical expressions
 
@@ -357,6 +374,15 @@ The second feature is the `=` operator which tests for "structural
 equality" between two expressions. That means it goes recursively into
 each expression checking they're exactly the same at all levels down.
 
+The `as` keyword can be used to name part of an expression. We can use it to
+match on the inner part of a pattern:
+
+```ocaml
+Name ("/DeviceGray" | "/DeviceRGB" | "/DeviceCMYK") as n -> n
+
+Br (l, ((k, _) as pair), r) when k = k' -> Some pair
+```
+
 ## Mutually recursive data types
 
 Data types may be mutually-recursive when declared with `and`:
@@ -387,6 +413,9 @@ and sum_t {annotation; data} =
   if annotation <> "" then Printf.printf "Touching %s\n" annotation;
   sum_t' data
 ```
+
+
+
 
 ## A note on tupled constructors
 

--- a/site/learn/tutorials/data_types_and_matching.md
+++ b/site/learn/tutorials/data_types_and_matching.md
@@ -4,22 +4,21 @@
 
 # Custom Data Types
 
-In this tutorial we learn how to build our own custom data types in OCaml, and
-how to write functions which process this new data.
+In this tutorial we learn how to build our own types in OCaml, and how to write
+functions which process this new data.
 
 ## Built-in compound types
 
-We have already seen the atomic data types such as `int`, `float`, `string`,
-`bool` and so on. Let's recap the built-in compound data types we can use in
-OCaml to combine such values. First, we have lists which are ordered
-collections of any nuumber of elements of like type:
+We have already seen simple data types such as `int`, `float`, `string`, and
+`bool`.  Let's recap the built-in compound data types we can use in OCaml to
+combine such values. First, we have lists which are ordered collections of any
+nuumber of elements of like type:
 
 ```ocamltop
 [];;
 [1; 2; 3];;
 [[1; 2]; [3; 4]; [5; 6]];;
 [false; true; false];;
-[1; false];;
 ```
 
 Next, we have tuples, which collect a fixed number of elements together:
@@ -64,22 +63,21 @@ arr.(0) <- 0;;
 arr;;
 ```
 
-In this tutorial, we will define our own custom compound data types, using some
-of these structures as building blocks.
+In this tutorial, we will define our own compound data types, using the `type`
+keyword, and some of these built-in structures as building blocks.
 
-## Enumerations
+## A simple type
 
-The simplest custom data type is an enumeration - we are simply creating some
-new names to represent values:
+We can define a new data type `colour` which can take one of four values.
 
 ```ocamltop
 type colour = Red | Green | Blue | Yellow
 ```
 
-Our new type is called `sign`, and has three constructors, `Positive`, `Zero`
-and `Negative`. The name of the type must begin with a lower case letter, and
-the names of the constructors with upper case letters. We can use our new type
-anywhere a built-in type could be used:
+Our new type is called `colour`, and has four *constructors* `Red`, `Green`,
+`Blue` and `Yellow`. The name of the type must begin with a lower case letter,
+and the names of the constructors with upper case letters. We can use our new
+type anywhere a built-in type could be used:
 
 ```ocamltop
 let additive_primaries = (Red, Green, Blue);;
@@ -87,7 +85,8 @@ let additive_primaries = (Red, Green, Blue);;
 let pattern = [(1, Red); (3, Green); (1, Red); (2, Green)];;
 ```
 
-We can pattern match on our new type, just like any built-in type:
+Notice the types inferred by OCaml for these expressions. We can pattern-match
+on our new type, just as with any built-in type:
 
 ```ocamltop
 let example c =
@@ -110,7 +109,7 @@ let example = function
   | Yellow -> "banana";;
 ```
 
-We can match on more than one case at a time:
+We can match on more than one case at a time too:
 
 ```ocamltop
 let rec is_primary = function
@@ -158,7 +157,7 @@ let rec rgb_of_colour = function
   | Green -> (0.0, 1.0, 0.0)
   | Blue -> (0.0, 0.0, 1.0)
   | Yellow -> (1.0, 1.0, 0.0)
-  | RGB (r, g, b) -> (r, g, b) (* Note not RGB c -> c. See below. *)
+  | RGB (r, g, b) -> (r, g, b)
   | Mix (p, a, b) ->
       let r1, g1, b1 = rgb_of_colour a in
       let r2, g2, b2 = rgb_of_colour b in
@@ -198,13 +197,11 @@ used. Now we can write recursive and polymorphic functions over these trees, by
 pattern matching on our new constructors:
 
 ```ocamltop
-let rec total t =
-  match t with
+let rec total = function
   | Lf -> 0
   | Br (l, x, r) -> total l + x + total r;;
 
-let rec flip t =
-  match t with
+let rec flip = function
   | Lf -> Lf
   | Br (l, x, r) -> Br (flip r, x, flip l);;
 ```
@@ -233,8 +230,8 @@ let rec insert (k, v) = function
       else Br (l, (k, v), r);;
 ```
 
-Similar functions can be written to lookup values in a dictionary, to convert a
-list of pairs to or from a tree dictionary and so on.
+Similar functions can be written to look up values in a dictionary, to convert
+a list of pairs to or from a tree dictionary and so on.
 
 ## Example: mathematical expressions
 
@@ -278,26 +275,16 @@ let print_expr e =
   print_endline (to_string e);;
 ```
 
-We separate the function into two so that our `to_string` function is usable in
-other contexts. Here's the `print_expr` function in action:
+(The `^` operator concatenates strings). We separate the function into two so
+that our `to_string` function is usable in other contexts. Here's the
+`print_expr` function in action:
 
 ```ocamltop
 print_expr (Times (Var "n", Plus (Var "x", Var "y")));;
 ```
 
-The general form of pattern matching is:
-
-```ocaml
-match value with
-| pattern -> result
-| pattern -> result
-  ...
-```
-
-The patterns on the left hand side can be simple, as in the `to_string`
-function above, or complex and nested. The next example is our function to
-multiply out expressions of the form `n * (x + y)` or `(x + y) * n` and for
-this we will use a nested pattern:
+We can write a function to multiply out expressions of the form `n * (x + y)`
+or `(x + y) * n` and for this we will use a nested pattern:
 
 ```ocamltop
 let rec multiply_out e =
@@ -330,8 +317,7 @@ patterns. The first pattern is `Times (e1, Plus (e2, e3))` which matches
 expressions of the form `e1 * (e2 + e3)`. Now look at the right hand side of
 this first pattern match, and convince yourself that it is the equivalent of
 `(e1 * e2) + (e1 * e3)`. The second pattern does the same thing, except for
-expressions of the form `(e1
-+ e2) * e3`.
+expressions of the form `(e1 + e2) * e3`.
 
 The remaining patterns don't change the form of the expression, but they
 crucially *do* call the `multiply_out` function recursively on their
@@ -370,12 +356,13 @@ match value with
   ...
 ```
 
-The second feature is the `=` operator which tests for "structural
-equality" between two expressions. That means it goes recursively into
-each expression checking they're exactly the same at all levels down.
+The second feature is the `=` operator which tests for "structural equality"
+between two expressions. That means it goes recursively into each expression
+checking they're exactly the same at all levels down.
 
-The `as` keyword can be used to name part of an expression. We can use it to
-match on the inner part of a pattern:
+Another feature which is useful when we build more complicated nested patterns
+is the `as` keyword, which can be used to name part of an expression. For
+example:
 
 ```ocaml
 Name ("/DeviceGray" | "/DeviceRGB" | "/DeviceCMYK") as n -> n
@@ -391,9 +378,9 @@ Data types may be mutually-recursive when declared with `and`:
 type t = A | B of t' and t' = C | D of t;;
 ```
 
-One common use of this is to *decorate* a tree, by adding information to each
-node using mutually-recursive types, one of which is a tuple or record. For
-example:
+One common use for mutally-recursive data types is to *decorate* a tree, by
+adding information to each node using mutually-recursive types, one of which is
+a tuple or record. For example:
 
 ```ocamltop
 type t' = Int of int | Add of t * t
@@ -414,17 +401,14 @@ and sum_t {annotation; data} =
   sum_t' data
 ```
 
-
-
-
 ## A note on tupled constructors
 
-Note that there is a difference between `RGB of float * float * float` and `RGB
-of (float * float * float)`. The first is a constructor with three pieces of
-data associated with it, the second is a constructor with one tuple associated
-with it. There are two ways this matters: the memory layout differs between the
-two (a tuple is an extra indirection), and the ability to create or match using
-a tuple:
+There is a difference between `RGB of float * float * float` and `RGB of (float
+* float * float)`. The first is a constructor with three pieces of data
+associated with it, the second is a constructor with one tuple associated with
+it. There are two ways this matters: the memory layout differs between the two
+(a tuple is an extra indirection), and the ability to create or match using a
+tuple:
 
 ```ocamltop
 type t = T of int * int;;
@@ -442,7 +426,7 @@ match T2 (1, 2) with T2 x -> fst x;;
 match T (1, 2) with T x -> fst x;;
 ```
 
-Note, however, that OCaml allows us to use the always-match `_` in either
+Note, however, that OCaml allows us to use the always-matching `_` in either
 version:
 
 ```ocamltop

--- a/site/learn/tutorials/data_types_and_matching.md
+++ b/site/learn/tutorials/data_types_and_matching.md
@@ -166,7 +166,8 @@ let rec rgb_of_colour = function
   | Mix (p, a, b) ->
       let r1, g1, b1 = rgb_of_colour a in
       let r2, g2, b2 = rgb_of_colour b in
-        (r1 +. r2 /. 2.0, g1 +. g2 /. 2.0, b1 +. b2 /. 2.0)
+      let mix x y = x *. p +. y *. (1.0 -. p) in
+        (mix r1 r2, mix g1 g2, mix b1 b2)
 ```
 
 We can use records directly in the data type instead to label our components:


### PR DESCRIPTION
This PR replaces the "Data types and matching" tutorial.

The nice symbolic algebra example from the original tutorial is retained in modified form, but the rest is new.

We may need to rebase this after the new lists tutorial is merged, and we may need to think about changing the file name now that the title has changed (perhaps it should not be changed?). But the content may be reviewed now.
