### PR TITLE
Fix typo in "A First Hour with OCaml"

### DIFF
--- a/site/learn/tutorials/a_first_hour_with_ocaml.md
+++ b/site/learn/tutorials/a_first_hour_with_ocaml.md
@@ -414,7 +414,7 @@ let rec map f l =
 
 Notice the type of the function `f` in parentheses as part of the whole type.
 This `map` function, given a function of type `'a -> 'b` and a list of `'a`s,
-will build a list of `'b'`s. Sometimes `'a` and `'b` might be the same type, of
+will build a list of `'b`s. Sometimes `'a` and `'b` might be the same type, of
 course. Here are some examples of using `map`:
 
 ```ocamltop


### PR DESCRIPTION
# Issue Description

Fix typo in tutorial page `A First Hour with OCaml`

## Changes Made

Changed the `'b'` in "Lists" example to `'b`.

![image](https://user-images.githubusercontent.com/4816479/117716979-bcdbdb00-b1c9-11eb-818f-cbc89fbfedc3.png)

# Issue Description

Please include a summary of the issue.

Fixes # (issue)

## Changes Made

Please describe the changes that you made.

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [x] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
