### PR TITLE
Make learn section Install button do same thing as front page install button

### DIFF
--- a/site/learn/index.md
+++ b/site/learn/index.md
@@ -13,7 +13,7 @@
         </section>
         <div id="platform-download" class="span3"
 		  style="padding-top:2ex">
-            <p><a href="/docs/install.html" class="btn">Install OCaml</a></p>
+            <p><a href="/learn/tutorials/up_and_running.html" class="btn">Install OCaml</a></p>
 <!--
             <p>
                 <a href="#">Other systems</a> |


### PR DESCRIPTION
This PR fixes an inconsistency where the front page install button would link to "Up and Running" but the learn index page install button would not.