### PR TITLE
update irc section to libera.chat

### DIFF
--- a/site/community/index.fr.md
+++ b/site/community/index.fr.md
@@ -77,8 +77,8 @@
             <h1 class="ruled">Obtenir du support</h1>
             <p>En plus des <a href="/community/mailing_lists.fr.html">listes de discussion</a>, vous
             pouvez poser des questions sur les canaux IRC OCaml
-            (<a href="irc://irc.freenode.net/ocaml">en</a
-			>, <a href="irc://irc.freenode.net/ocaml-fr">fr</a>).</p>
+            (<a href="irc://irc.libera.chat/ocaml">en</a
+			>, <a href="irc://irc.libera.chat/ocaml-fr">fr</a>).</p>
 
             <p>ou voir la <a href="support.fr.html">liste des fournisseurs</a> de support professionnel.</p>
 
@@ -166,7 +166,7 @@
                     <li><a href="http://www.reddit.com/r/ocaml/"><img src="/img/reddit-alien.png" title="OCaml subreddit on Reddit"></a></li>
                     <li><a href="http://www.slideshare.net/search/slideshow/?q=ocaml&qf=qf2&ud=any&ft=all&lang=**&sort=relevance"><img src="/img/slideshare-icon.png" title="OCaml mentions on SlideShare"></a></li>
                     <li><a href="http://www.meetup.com/find/?keywords=ocaml&radius=Infinity"><img src="/img/meetup-logo.gif" title="OCaml groups on Meetup"></a></li>
-                    <li><a href="irc://irc.freenode.net/#ocaml"><img src="/img/irc-graphic.png" title="#ocaml on freenode"></a></li>
+                    <li><a href="irc://irc.libera.chat/#ocaml"><img src="/img/irc-graphic.png" title="#ocaml on libera.chat"></a></li>
                     <li><a href="https://dev.to/t/ocaml"><img src="/img/devto-graphic.png" title="#ocaml on dev.to"></a></li>
                 </ul>
         </section>

--- a/site/community/index.md
+++ b/site/community/index.md
@@ -163,7 +163,7 @@
                     <li><a href="http://www.reddit.com/r/ocaml/"><img src="/img/reddit-alien.png" title="OCaml subreddit on Reddit"></a></li>
                     <li><a href="http://www.slideshare.net/search/slideshow/?q=ocaml&qf=qf2&ud=any&ft=all&lang=**&sort=relevance"><img src="/img/slideshare-icon.png" title="OCaml mentions on SlideShare"></a></li>
                     <li><a href="http://www.meetup.com/find/?keywords=ocaml&radius=Infinity"><img src="/img/meetup-logo.gif" title="OCaml groups on Meetup"></a></li>
-                    <li><a href="irc://irc.freenode.net/#ocaml"><img src="/img/irc-graphic.png" title="#ocaml on freenode"></a></li>
+                    <li><a href="irc://irc.libera.chat/#ocaml"><img src="/img/irc-graphic.png" title="#ocaml on libera.chat"></a></li>
                     <li><a href="https://dev.to/t/ocaml"><img src="/img/devto-graphic.png" title="#ocaml on dev.to"></a></li>
                     <li><a href="https://discuss.ocaml.org/"><img src="/img/discourse.png" title="OCaml Discourse"></a></li>
                 </ul>

--- a/site/community/mailing_lists.fr.md
+++ b/site/community/mailing_lists.fr.md
@@ -62,6 +62,11 @@ demandez pas si vous pouvez poser une question, posez la question
 directement ; faites preuve de patience : tout le monde ne vit pas dans
 le même fuseau horaire. Vous pouvez accéder au canal de discussion au
 travers de n'importe quel client IRC.
+Un client web est [disponible](https://web.libera.chat/#ocaml).
+
+### irc.libera.chat #ocaml-fr
+*irc.libera.chat #ocaml-fr*
+Similaire à #ocaml mais francophone.
 
 ##  Groupes de News
 

--- a/site/community/mailing_lists.fr.md
+++ b/site/community/mailing_lists.fr.md
@@ -53,7 +53,7 @@ documents, etc. concernant OCaml.
 
 ##  Canaux IRC 
 
-### irc.freenode.net #ocaml
+### irc.libera.chat #ocaml
 
 IRC est un moyen de communication en temps réel, où il est possible de
 demander de l'aide dans un salon de discussion. Il y a en moyenne une
@@ -61,9 +61,7 @@ centaine d'utilisateurs présents dans ce canal de discussion ; ne
 demandez pas si vous pouvez poser une question, posez la question
 directement ; faites preuve de patience : tout le monde ne vit pas dans
 le même fuseau horaire. Vous pouvez accéder au canal de discussion au
-travers de l'[interface
-web](http://webchat.freenode.net/?channels=#ocaml) ou à l'aide de
-n'importe quel client IRC.
+travers de n'importe quel client IRC.
 
 ##  Groupes de News
 

--- a/site/community/mailing_lists.md
+++ b/site/community/mailing_lists.md
@@ -70,7 +70,7 @@ This is a real-time communication channel, where you can ask for help.
 There are about a hundred users hanging around; don't ask if you can
 ask, just ask, and be patient: not everyone is in the same timezone.
 
-The IRC Channel was previously on freenode but moved to [Libera chat](https://libera.chat/). There is no web interface yet.
+The IRC Channel was previously on freenode but moved to [Libera chat](https://libera.chat/).
 No official presence is retained on freenode, and the #ocaml channel there is not affiliated with the OCaml community.
 A web client is [available](https://web.libera.chat/#ocaml).
 

--- a/site/community/mailing_lists.md
+++ b/site/community/mailing_lists.md
@@ -65,18 +65,15 @@ releases and new OCaml-related software, libraries, documents, etc.
 ## Discussion Groups
 
 ### IRC Channel - English
-*irc.freenode.net #ocaml*
+*irc.libera.chat #ocaml*
 This is a real-time communication channel, where you can ask for help.
 There are about a hundred users hanging around; don't ask if you can
-ask, just ask, and be patient: not everyone is in the same timezone. The
-IRC Channel can be accessed through a web interface or any regular IRC
-client.
+ask, just ask, and be patient: not everyone is in the same timezone.
+
+The IRC Channel was previously on freenode but moved to [Libera](https://libera.chat/).
+There is no web interface yet.
 
 Public channel logs are available at <http://irclog.whitequark.org/ocaml/>
-
-If you wish to use a web-based IRC client, you can use Freenode's
-webchat <https://webchat.freenode.net/>.
-
 
 ### Discord Server
 

--- a/site/community/mailing_lists.md
+++ b/site/community/mailing_lists.md
@@ -70,10 +70,10 @@ This is a real-time communication channel, where you can ask for help.
 There are about a hundred users hanging around; don't ask if you can
 ask, just ask, and be patient: not everyone is in the same timezone.
 
-The IRC Channel was previously on freenode but moved to [Libera](https://libera.chat/).
-There is no web interface yet.
+The IRC Channel was previously on freenode but moved to [Libera chat](https://libera.chat/). There is no web interface yet.
+No official presence is retained on freenode, and the #ocaml channel there is not affiliated with the OCaml community.
 
-Public channel logs are available at <http://irclog.whitequark.org/ocaml/>
+Public channel logs are available at <https://libera.irclog.whitequark.org/ocaml/>
 
 ### Discord Server
 

--- a/site/community/mailing_lists.md
+++ b/site/community/mailing_lists.md
@@ -72,6 +72,7 @@ ask, just ask, and be patient: not everyone is in the same timezone.
 
 The IRC Channel was previously on freenode but moved to [Libera chat](https://libera.chat/). There is no web interface yet.
 No official presence is retained on freenode, and the #ocaml channel there is not affiliated with the OCaml community.
+A web client is [available](https://web.libera.chat/#ocaml).
 
 Public channel logs are available at <https://libera.irclog.whitequark.org/ocaml/>
 
@@ -84,7 +85,7 @@ ability to have multiple channels. One of the channels is called #IRC,
 and automatically connects to the main IRC channel.
 
 ### IRC Channel - French
-*irc.freenode.net #ocaml-fr*
+*irc.libera.chat #ocaml-fr*
 As above, but for French speakers.
 
 ### About ML


### PR DESCRIPTION
# Issue Description

The irc channel moved to libera.chat since freenode became hostile.
