### PR TITLE
Fix wrong description about currying

### DIFF
--- a/site/learn/tutorials/functional_programming.md
+++ b/site/learn/tutorials/functional_programming.md
@@ -103,7 +103,7 @@ that it's trying to save.
 Now look at the definition of `receiver_fn`. This function is a closure
 alright because it keeps a reference to `chan` from its environment.
 
-## Partial function applications and currying
+## Partial function applications
 Let's define a plus function which just adds two integers:
 
 ```ocamltop
@@ -168,14 +168,7 @@ rationale for the strange `->` arrow notation used for function types:
   plus 2 : int -> int
 plus 2 3 : int
 ```
-This process is called **currying** (or perhaps it's called
-**uncurrying**, I never was really sure which was which). It is called
-this after Haskell Curry who did some important stuff related to the
-lambda calculus. Since I'm trying to avoid entering into the mathematics
-behind OCaml because that makes for a very boring and irrelevant
-tutorial, I won't go any further on the subject. You can find much more
-information about currying if it interests you by [doing a search on
-Google](http://www.google.com/search?q=currying "http://www.google.com/search?q=currying").
+This process is called **partial application** of a function.
 
 Remember our `double` and `multiply` functions from earlier on?
 `multiply` was defined as this:
@@ -219,7 +212,7 @@ identical definition of the `plus` function as before:
 let plus = ( + );;
 plus 2 3;;
 ```
-Here's some more currying fun:
+Here's some more examples of partial application:
 
 ```ocamltop
 List.map (plus 2) [1; 2; 3];;


### PR DESCRIPTION
# Issue Description

Fix wrong description about currying

## Changes Made

- Fix word misuse (currying -> partial application)
- Omit description about currying


## Backgrounds for changes

### 1. These examples are about partial application, not currying.

They are totally different concepts.
Current description is wrong and misunderstands these concepts.


#### Rough explanation for functional-programming newbies

Suppose there are functions like these (the example is JavaScript):

```javascript

function plus(a, b) {
  return a + b;
}

function curried_plus(a, b) {
  return function(b) {
    return a + b;
  };
}

function plus_one(y) {
  return 1 + y;
}

// Usages
plus(5, 7) //=> 12
curried_plus(5)(7) //=> 12
plus_one(3) //=> 4
```

In the example above,
- "currying" is converting `plus` to `curried_plus`.
- "partial application" is converting `plus` to `plus_one` (which means, fixing the value of `plus`'s nth argument).


### 2. Usually we do not need manual currying

In OCaml, all functions are automatically curried when defined. 

For example, if you define a function whose arity is more than one:

```ocaml
let plus a b = a + b
```

then OCaml compiler automatically curries it. 
The function above is equivalent to:

```ocaml
let plus = fun a -> fun b -> a + b
```

Effectively, all OCaml functions are arity-1.
In normal use case, we do not need manual currying.


### 3. It is hard to explain (real) currying with OCaml code

Due to automatic conversion which is described above, it is a little bit difficult to explain (real) currying with OCaml code.

So, if you want to `avoid entering into the mathematics behind OCaml`, then you should just omit description about currying.
In any case, we should not have wrong description in **official tutorial**.


---

* **Please check if the PR fulfills these requirements**

- [x] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
