### PR TITLE
Correct order of magnitude of packages on opam

### DIFF
--- a/site/index.fr.md
+++ b/site/index.fr.md
@@ -55,7 +55,7 @@
 					</a>
                     <h1><a href="https://opam.ocaml.org">Contributions</a></h1>
                     <p>Le gestionnaire de paquets <a href="https://opam.ocaml.org">OPAM</a> vous donne accès aux multiples versions de
-					<a href="https://opam.ocaml.org/packages/">de milliers de paquets</a>.</p>
+					<a href="https://opam.ocaml.org/packages/">milliers de paquets</a>.</p>
                 </section>
                 <section class="span4 home-feature">
                     <a href="/community/index.fr.html">

--- a/site/index.fr.md
+++ b/site/index.fr.md
@@ -55,7 +55,7 @@
 					</a>
                     <h1><a href="https://opam.ocaml.org">Contributions</a></h1>
                     <p>Le gestionnaire de paquets <a href="https://opam.ocaml.org">OPAM</a> vous donne accès aux multiples versions de
-					<a href="https://opam.ocaml.org/packages/">centaines de paquets</a>.</p>
+					<a href="https://opam.ocaml.org/packages/">de milliers de paquets</a>.</p>
                 </section>
                 <section class="span4 home-feature">
                     <a href="/community/index.fr.html">

--- a/site/index.md
+++ b/site/index.md
@@ -54,7 +54,7 @@
                     <h1><a href="https://opam.ocaml.org">Packages</a></h1>
                     <p>The <a href="https://opam.ocaml.org">OCaml Package
 					Manager</a>, gives you access to multiple versions of
-					<a href="https://opam.ocaml.org/packages/">hundreds of
+					<a href="https://opam.ocaml.org/packages/">thousands of
 					packages</a>.</p>
                 </section>
                 <section class="span4 home-feature">


### PR DESCRIPTION
## Changes Made

Opam currently has around 3.5k packages! 🎉  So this tiny wording change will give prospective users a more accurate sense of the current amount of libraries available.

- [x] PR is descriptively titled and links the original issue above
- [x] Context for what motivated the change (if this is a change to some content)
