### PR TITLE
Add a PR requirement to sync content with ocaml/ood

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -10,6 +10,7 @@ Please describe the changes that you made.
 
 * **Please check if the PR fulfills these requirements**
 
+- [ ] ❗ If the PR changes a markdown document in `site/`, a comment was added in https://github.com/ocaml/ood/issues/52 with a link to the PR
 - [ ] PR is descriptively titled and links the original issue above
 - [ ] Before/after screenshots (if this is a layout change)
 - [ ] Details of which platforms the change was tested on (if this is a browser-specific change)


### PR DESCRIPTION
As described in [discuss](https://discuss.ocaml.org/t/v3-ocaml-org-a-roadmap-for-ocamls-online-presence/8368/19), the content of the next version of ocaml.org is stored in [ocaml/ood](https://github.com/ocaml/ood/).

The team has been importing content from the current ocaml.org in ood, but until the new site goes live, contributions are continuously made to the current repository. In order to stay in sync and not miss any new content or content change, we'd like to ask contributors to link their PRs in ood, so that we can easily identify the PRs that need to be synced.

This PR adds a requirement to the PR template to add a link in https://github.com/ocaml/ood/issues/52. Alternatively, we could ask contributors to open new issues or ask them to land a counterpart PR in ood when they contribute to ocaml.org's content.