### PR TITLE
Update front page and create 4.13.1 releage page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ocaml/opam:debian-10-ocaml-4.10
-RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 1003e5965fbc38d98b88570ac280b519fdae302f && opam update -u -y
+RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 3606210eb2472a23e8ef7960ce143026e43e507d && opam update -u -y
 WORKDIR /home/opam/src
 RUN sudo chown opam /home/opam/src
 COPY --chown=opam *.opam /home/opam/src

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,5 +1,5 @@
 FROM ocaml/opam:debian-10-ocaml-4.10 as build
-RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 1003e5965fbc38d98b88570ac280b519fdae302f && opam update -u -y
+RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 3606210eb2472a23e8ef7960ce143026e43e507d && opam update -u -y
 WORKDIR /home/opam/src
 RUN sudo chown opam /home/opam/src
 COPY --chown=opam *.opam /home/opam/src

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -1,5 +1,5 @@
 FROM ocaml/opam:debian-10-ocaml-4.10 as build
-RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 1003e5965fbc38d98b88570ac280b519fdae302f && opam update -u -y
+RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 3606210eb2472a23e8ef7960ce143026e43e507d && opam update -u -y
 WORKDIR /home/opam/src
 RUN sudo chown opam /home/opam/src
 COPY --chown=opam *.opam /home/opam/src

--- a/site/index.fr.md
+++ b/site/index.fr.md
@@ -102,6 +102,7 @@
 				/><img class="png" src="/img/rss.png" alt="RSS" /></a>
             </h1>
 			<ul class="news-feed" style="margin-bottom: 0px">
+			<!-- Commented between workshop
 			<li class="announcement"><article>
 			  <h1><a title="OCaml Users and Developers Workshop"
 			       href="/meetings/ocaml/2020/">OCaml 2020</a></h1>
@@ -111,12 +112,12 @@
 			    <img alt="" src="/img/announcement.svg" class="svg" />
 			    <img alt="" src="/img/announcement.png" class="png" />
 			  </a>
-			</article></li>
+			</article></li> -->
 			<li class="announcement"><article>
 			  <h1><a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
 			       href="/releases/{{! get LATEST_OCAML_VERSION !}}.html"
 				   >Parution d'OCaml {{! get LATEST_OCAML_VERSION !}}</a></h1>
-			   <p>24 février 2021</p>
+			   <p>1er octobre 2021</p>
 			   <a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
 			      href="/releases/{{! get LATEST_OCAML_VERSION !}}.html">
 			    <img alt="" src="/img/announcement.svg" class="svg" />

--- a/site/index.md
+++ b/site/index.md
@@ -103,7 +103,7 @@
             </h1>
 			<ul class="news-feed" style="margin-bottom: 0px">
 
-            <!-- Commented out between workshops -->
+            <!-- Commented out between workshops
 			<li class="announcement"><article>
 			  <h1><a title="OCaml Users and Developers Workshop"
 			       href="/meetings/ocaml/2020/">OCaml 2020</a></h1>
@@ -114,11 +114,12 @@
 			    <img alt="" src="/img/announcement.png" class="png" />
 			  </a>
 			</article></li>
+             -->
 			<li class="announcement"><article>
 			  <h1><a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
 			       href="/releases/{{! get LATEST_OCAML_VERSION !}}.html"
 				   >Release of OCaml {{! get LATEST_OCAML_VERSION !}}</a></h1>
-			   <p>February 24, 2021</p>
+			   <p>October 1, 2021</p>
 			   <a title="Release of OCaml {{! get LATEST_OCAML_VERSION !}}"
 			      href="/releases/{{! get LATEST_OCAML_VERSION !}}.html">
 			    <img alt="" src="/img/announcement.svg" class="svg" />

--- a/site/releases/4.13.1.md
+++ b/site/releases/4.13.1.md
@@ -1,0 +1,60 @@
+<!-- ((! set title OCaml 4.13.1 !)) -->
+
+# OCaml 4.13.1
+
+This page describes OCaml **4.13.1**, released on Oct 1, 2021.
+This is a bug-fix release of [OCaml 4.13.0](4.13.0.html).
+
+
+
+Configuration options
+---------------------
+
+The configuration of the installed opam switch can be tuned with the
+following options:
+
+- ocaml-option-32bit: set OCaml to be compiled in 32-bit mode for 64-bit Linux and OS X hosts
+- ocaml-option-afl: set OCaml to be compiled with afl-fuzz instrumentation
+- ocaml-option-bytecode-only: compile OCaml without the native-code compiler
+- ocaml-option-default-unsafe-string: set OCaml to be compiled without safe strings by default
+- ocaml-option-flambda: set OCaml to be compiled with flambda activated
+- ocaml-option-fp: set OCaml to be compiled with frame-pointers enabled
+- ocaml-option-musl: set OCaml to be compiled with musl-gcc
+- ocaml-option-nnp : set OCaml to be compiled with --disable-naked-pointers
+- ocaml-option-nnpchecker: set OCaml to be compiled with --enable-naked-pointers-checker
+- ocaml-option-no-flat-float-array: set OCaml to be compiled with --disable-flat-float-array
+- ocaml-option-static :set OCaml to be compiled with musl-gcc -static
+
+For instance, one can install a switch with both `flambda` and the naked-pointer checker enabled with
+
+```
+opam switch create 4.13.1+flambda+nnpchecker --package=ocaml-variants.4.13.1+options,ocaml-option-flambda,ocaml-option-nnpchecker
+```
+
+or with opam 2.1:
+
+```
+opam switch create 4.13.1+flambda -ocaml-variants.4.13.1+options ocaml-option-flambda
+```
+
+
+![](../img/source.gif "") Source distribution
+---------------------------------------------
+
+- [Source
+  tarball](https://github.com/ocaml/ocaml/archive/4.13.1.tar.gz)
+  (.tar.gz) for compilation under Unix (including Linux and macOS)
+  and Microsoft Windows (including Cygwin).
+- Also available in
+  [.zip](https://github.com/ocaml/ocaml/archive/4.13.1.zip)
+  format.
+- The official development repo is hosted on
+  [GitHub](https://github.com/ocaml/ocaml).
+
+Changes
+-------
+
+### Regression fix
+
+- [#10661](https://github.com/ocaml/ocaml/issues/10661), [#10662](https://github.com/ocaml/ocaml/issues/10662): fix a bug with classes named "row"
+  (Gabriel Scherer, report by Nicolás Ojeda Bär)

--- a/site/releases/4.13/notes/Changes
+++ b/site/releases/4.13/notes/Changes
@@ -1,3 +1,12 @@
+OCaml 4.13.1 (01 October 2021)
+--------------------------------
+
+### Bug fixes
+
+- #10661, #10662: fix a bug with classes named "row"
+  (Gabriel Scherer, report by Nicolás Ojeda Bär)
+
+
 OCaml 4.13.0 (24 September 2021)
 --------------------------------
 

--- a/site/releases/index.fr.md
+++ b/site/releases/index.fr.md
@@ -10,6 +10,7 @@ instructions pour installer OCaml par d'autres moyens que la
 compilation des sources, comme par exemple le gestionnaire de paquets
 OPAM et les gestionnaire de paquets spécifiques à une plateforme.
 
+* OCaml [4.13.1](4.13.1.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.13.1.tar.gz), publiée le 1er octobre, 2021.
 * OCaml [4.13.0](4.13.0.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.13.0.tar.gz), publiée le 24 septembre 2021.
 * OCaml [4.12.1](4.12.1.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.12.1.tar.gz), publiée le 24 septembre 2021.
 * OCaml [4.12.0](4.12.0.html), [téléchargé](https://github.com/ocaml/ocaml/archive/4.12.0.tar.gz), publiée le 24 février 2021.

--- a/site/releases/index.md
+++ b/site/releases/index.md
@@ -9,6 +9,7 @@ See also the [install](/docs/install.html) page for instructions on
 installing OCaml by other means, such as the OPAM package manager and
 platform specific package managers.
 
+* OCaml [4.13.1](4.13.1.html), [Download](https://github.com/ocaml/ocaml/archive/4.13.1.tar.gz), released Oct 1, 2021.
 * OCaml [4.13.0](4.13.0.html), [Download](https://github.com/ocaml/ocaml/archive/4.13.0.tar.gz), released Sep 24, 2021.
 * OCaml [4.12.1](4.12.1.html), [Download](https://github.com/ocaml/ocaml/archive/4.12.1.tar.gz), released Sep 24, 2021.
 * OCaml [4.12.0](4.12.0.html), [Download](https://github.com/ocaml/ocaml/archive/4.12.0.tar.gz), released Feb 24, 2021.


### PR DESCRIPTION
This PR adds a release page for 4.13.1, updates the list of releases and the date of the last version of OCaml, and comments out the OCaml workshop announce in News on the frontpage.