### PR TITLE
docs/install.md: update Fedora badge for Fedora 35

### DIFF
--- a/site/docs/install.fr.md
+++ b/site/docs/install.fr.md
@@ -68,7 +68,7 @@ apt install ocaml-nox # Plus léger, si vous ne voulez pas le support de X11
 Les autres paquets Unbuntu liés à OCaml sont
 [listés ici](http://packages.ubuntu.com/search?keywords=ocaml) (en anglais).
 
-### [Fedora](https://getfedora.org/) [![Fedora 32](https://repology.org/badge/version-only-for-repo/fedora_32/ocaml.svg)](https://repology.org/metapackage/ocaml)
+### [Fedora](https://getfedora.org/) [![Fedora 35](https://repology.org/badge/version-only-for-repo/fedora_35/ocaml.svg)](https://repology.org/metapackage/ocaml)
 
 ```bash
 yum install ocaml

--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -73,7 +73,7 @@ apt install ocaml
 Other Ubuntu packages related to OCaml are
 [listed here](http://packages.ubuntu.com/search?keywords=ocaml).
 
-### [Fedora](https://getfedora.org/) [![Fedora 32](https://repology.org/badge/version-only-for-repo/fedora_32/ocaml.svg)](https://repology.org/metapackage/ocaml)
+### [Fedora](https://getfedora.org/) [![Fedora 35](https://repology.org/badge/version-only-for-repo/fedora_35/ocaml.svg)](https://repology.org/metapackage/ocaml)
 
 
 ```bash


### PR DESCRIPTION
# Issue Description

Update OCaml version badge for Fedora.

## Changes Made

Version badge used in the master bracnh is for Fedora 32 (reached EOL in May), this commit changes the badge to Fedora 35 (expected to be released in within this month).

- [x] ❗ If the PR changes a markdown document in `site/`, a comment was added in https://github.com/ocaml/ood/issues/52 with a link to the PR
- [x] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [x] Context for what motivated the change (if this is a change to some content)
