### PR TITLE
Documentation: fix and clarify opam 2.1 switch creation

### DIFF
--- a/site/releases/4.12.1.md
+++ b/site/releases/4.12.1.md
@@ -34,7 +34,7 @@ opam switch create 4.12.1+flambda+nnpchecker --package=ocaml-variants.4.12.1+opt
 or with opam 2.1:
 
 ```
-opam switch create 4.12.1+flambda -ocaml-variants.4.12.1+options ocaml-option-flambda
+opam switch create 4.12.1+flambda+nnpchecker ocaml-variants.4.12.1+options ocaml-option-flambda ocaml-option-nnpchecker
 ```
 
 

--- a/site/releases/4.13.0.md
+++ b/site/releases/4.13.0.md
@@ -51,7 +51,7 @@ opam switch create 4.13.0+flambda+nnpchecker --package=ocaml-variants.4.13.0+opt
 or with opam 2.1:
 
 ```
-opam switch create 4.13.0+flambda -ocaml-variants.4.13.0+options ocaml-option-flambda
+opam switch create 4.13.0+flambda+nnpchecker ocaml-variants.4.13.0+options ocaml-option-flambda ocaml-option-nnpchecker
 ```
 
 

--- a/site/releases/4.13.1.md
+++ b/site/releases/4.13.1.md
@@ -34,7 +34,7 @@ opam switch create 4.13.1+flambda+nnpchecker --package=ocaml-variants.4.13.1+opt
 or with opam 2.1:
 
 ```
-opam switch create 4.13.1+flambda -ocaml-variants.4.13.1+options ocaml-option-flambda
+opam switch create 4.13.1+flambda+nnpchecker ocaml-variants.4.13.1+options ocaml-option-flambda ocaml-option-nnpchecker
 ```
 
 


### PR DESCRIPTION
# Issue Description

The opam 2.1 switch creation examples in the release notes for OCaml 4.12.1+ included an incorrect extra `-` and did not match the <2.1 example with two options.

## Changes Made

In the three release notes' opam 2.1 example, I removed the extra `-` and added the missing `nnpchecker` option to match the other example and show how multiple options are now separated by spaces instead of commas.

* **Please check if the PR fulfills these requirements**

- [x] ❗ If the PR changes a markdown document in `site/`, a comment was added in https://github.com/ocaml/ood/issues/52 with a link to the PR
- [x] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
