### PR TITLE
Update last10_updates to https

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -39,7 +39,7 @@ template/%_code_snippet.html:template/%_code_snippet.md $(OMD_PP)
 	cat "$<" | $(OMD_PP) | ${OMD} -o $@
 
 opam_update_list: script/generate_opam_update_list
-	curl -O http://opam.ocaml.org/json/last10_updates.json
+	curl -O https://opam.ocaml.org/json/last10_updates.json
 	script/generate_opam_update_list
 
 script/generate_opam_update_list: script/generate_opam_update_list.ml


### PR DESCRIPTION
# Issue Description

I believe opam.ocaml.org has been fully swapped to `https` now (i.e. http redirects to https) which means the `curl` for the latest updates no longer works causing the build to fail.

## Changes Made

Change http to https
