### PR TITLE
Added bsc to the list of alternative compilers.

### DIFF
--- a/site/releases/4.13.0.md
+++ b/site/releases/4.13.0.md
@@ -86,6 +86,9 @@ targets traditionally associated with other languages:
 
 * [Js_of_ocaml](http://ocsigen.org/js_of_ocaml/) is a stable OCaml
   to JavaScript compiler.
+* [bsc](https://rescript-lang.org/) is a stable OCaml/ReScript
+  to JavaScript compiler
+  (easy to use, well documented and with a supporting community.)
 
 ![](../img/doc.gif "") User's manual
 ------------------------------------


### PR DESCRIPTION
Added `bsc` to the list of alternative compilers.

bsc (the rescript compiler) is also able to translate ocaml code to javascript.