### PR TITLE
Fix cheatsheet links

### DIFF
--- a/site/docs/cheat_sheets.md
+++ b/site/docs/cheat_sheets.md
@@ -5,16 +5,16 @@
 [OCamlPro](http://www.ocamlpro.com/) has published cheat sheets (one or
 two-page summaries) on OCaml:
 
-* [The OCaml Language](http://www.ocamlpro.com/wp-content/uploads/2019/09/ocaml-lang.pdf) (PDF, September 2019)  
+* [The OCaml Language](https://ocamlpro.github.io/ocaml-cheat-sheets/ocaml-lang.pdf) (PDF, September 2019)
 General overview of the OCaml language: basic data types, basic
 concepts, functions, modules, etc.
 
-* [OCaml Standard Tools](http://www.ocamlpro.com/files/ocaml-tools.pdf) (PDF, June 2011)  
+* [OCaml Standard Tools](https://ocamlpro.github.io/ocaml-cheat-sheets/ocaml-tools.pdf) (PDF, June 2011)
 Overview of OCaml compilers and their options, tools for lexing and
 parsing, Makefile rules, etc.
 
-* [OCaml Standard Library](http://www.ocamlpro.com/wp-content/uploads/2019/09/ocaml-stdlib.pdf) (PDF, September 2019)  
+* [OCaml Standard Library](https://ocamlpro.github.io/ocaml-cheat-sheets/ocaml-stdlib.pdf) (PDF, September 2019)
 Overview of the standard library's most common modules.
 
-* [OCaml Emacs Mode (Tuareg)](http://www.ocamlpro.com/files/tuareg-mode.pdf) (PDF, June 2011)  
+* [OCaml Emacs Mode (Tuareg)](https://ocamlpro.github.io/ocaml-cheat-sheets/tuareg-mode.pdf) (PDF, June 2011)
 Overview of the Emacs Tuareg mode keyboard shortcuts.


### PR DESCRIPTION
Source for cheat sheet links: https://ocamlpro.github.io/ocaml-cheat-sheets/ (via #1561)

# Issue Description

Old cheatsheet links were broken. This PR fixes the links.

Fixes #1561

## Changes Made

Updated all markdown links to working PDF targets.

* **Please check if the PR fulfills these requirements**

- [x] ❗ If the PR changes a markdown document in `site/`, a comment was added in https://github.com/ocaml/ood/issues/52 with a link to the PR
- [x] PR is descriptively titled and links the original issue above
- [N/A] Before/after screenshots (if this is a layout change)
- [N/A] Details of which platforms the change was tested on (if this is a browser-specific change)
- [c] Context for what motivated the change (if this is a change to some content)
