### PR TITLE
manual: fix manual_dirs patterns for 5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ staging: pre-build
 
 # Pattern for directories containing the reference manuals
 # and other release material
-MANUAL_DIRS=site/releases/[1-9].[0-9][0-9]
+MANUAL_DIRS=site/releases/[1-9].[0-9]*
 
 syncotherfiles:
 	rsync --exclude '*~' --exclude '*.md' --exclude '*.html' \


### PR DESCRIPTION
This is a simple fix which is expand the pattern used to detect the manual repositories to work with the 5.0 manual.