### PR TITLE
Sort modules in the stdlib api index in alphabetical order

### DIFF
--- a/site/releases/4.13/api/index.html
+++ b/site/releases/4.13/api/index.html
@@ -9,79 +9,79 @@
 <link title="Index of values" rel="Appendix" href="index_values.html">
 <link title="Index of modules" rel="Appendix" href="index_modules.html">
 <link title="Index of module types" rel="Appendix" href="index_module_types.html">
-<link title="Ocaml_operators" rel="Chapter" href="Ocaml_operators.html">
 <link title="Format_tutorial" rel="Chapter" href="Format_tutorial.html">
-<link title="CamlinternalFormatBasics" rel="Chapter" href="CamlinternalFormatBasics.html">
-<link title="CamlinternalAtomic" rel="Chapter" href="CamlinternalAtomic.html">
-<link title="Stdlib" rel="Chapter" href="Stdlib.html">
-<link title="Seq" rel="Chapter" href="Seq.html">
-<link title="Option" rel="Chapter" href="Option.html">
-<link title="Either" rel="Chapter" href="Either.html">
-<link title="Result" rel="Chapter" href="Result.html">
-<link title="Bool" rel="Chapter" href="Bool.html">
-<link title="Char" rel="Chapter" href="Char.html">
-<link title="Uchar" rel="Chapter" href="Uchar.html">
-<link title="Sys" rel="Chapter" href="Sys.html">
-<link title="List" rel="Chapter" href="List.html">
-<link title="Int" rel="Chapter" href="Int.html">
-<link title="Bytes" rel="Chapter" href="Bytes.html">
-<link title="String" rel="Chapter" href="String.html">
-<link title="Unit" rel="Chapter" href="Unit.html">
-<link title="Marshal" rel="Chapter" href="Marshal.html">
-<link title="Obj" rel="Chapter" href="Obj.html">
-<link title="Array" rel="Chapter" href="Array.html">
-<link title="Float" rel="Chapter" href="Float.html">
-<link title="Int32" rel="Chapter" href="Int32.html">
-<link title="Int64" rel="Chapter" href="Int64.html">
-<link title="Nativeint" rel="Chapter" href="Nativeint.html">
-<link title="Lexing" rel="Chapter" href="Lexing.html">
-<link title="Parsing" rel="Chapter" href="Parsing.html">
-<link title="Set" rel="Chapter" href="Set.html">
-<link title="Map" rel="Chapter" href="Map.html">
-<link title="Stack" rel="Chapter" href="Stack.html">
-<link title="Queue" rel="Chapter" href="Queue.html">
-<link title="CamlinternalLazy" rel="Chapter" href="CamlinternalLazy.html">
-<link title="Lazy" rel="Chapter" href="Lazy.html">
-<link title="Stream" rel="Chapter" href="Stream.html">
-<link title="Buffer" rel="Chapter" href="Buffer.html">
-<link title="CamlinternalFormat" rel="Chapter" href="CamlinternalFormat.html">
-<link title="Printf" rel="Chapter" href="Printf.html">
+<link title="Ocaml_operators" rel="Chapter" href="Ocaml_operators.html">
 <link title="Arg" rel="Chapter" href="Arg.html">
+<link title="Array" rel="Chapter" href="Array.html">
+<link title="ArrayLabels" rel="Chapter" href="ArrayLabels.html">
 <link title="Atomic" rel="Chapter" href="Atomic.html">
-<link title="Printexc" rel="Chapter" href="Printexc.html">
+<link title="Bigarray" rel="Chapter" href="Bigarray.html">
+<link title="Bool" rel="Chapter" href="Bool.html">
+<link title="Buffer" rel="Chapter" href="Buffer.html">
+<link title="Bytes" rel="Chapter" href="Bytes.html">
+<link title="BytesLabels" rel="Chapter" href="BytesLabels.html">
+<link title="Callback" rel="Chapter" href="Callback.html">
+<link title="Char" rel="Chapter" href="Char.html">
+<link title="Complex" rel="Chapter" href="Complex.html">
+<link title="Condition" rel="Chapter" href="Condition.html">
+<link title="Digest" rel="Chapter" href="Digest.html">
+<link title="Dynlink" rel="Chapter" href="Dynlink.html">
+<link title="Either" rel="Chapter" href="Either.html">
+<link title="Ephemeron" rel="Chapter" href="Ephemeron.html">
+<link title="Event" rel="Chapter" href="Event.html">
+<link title="Filename" rel="Chapter" href="Filename.html">
+<link title="Float" rel="Chapter" href="Float.html">
+<link title="Format" rel="Chapter" href="Format.html">
 <link title="Fun" rel="Chapter" href="Fun.html">
 <link title="Gc" rel="Chapter" href="Gc.html">
-<link title="Digest" rel="Chapter" href="Digest.html">
-<link title="Random" rel="Chapter" href="Random.html">
-<link title="Hashtbl" rel="Chapter" href="Hashtbl.html">
-<link title="Weak" rel="Chapter" href="Weak.html">
-<link title="Format" rel="Chapter" href="Format.html">
-<link title="Scanf" rel="Chapter" href="Scanf.html">
-<link title="Callback" rel="Chapter" href="Callback.html">
-<link title="CamlinternalOO" rel="Chapter" href="CamlinternalOO.html">
-<link title="Oo" rel="Chapter" href="Oo.html">
-<link title="CamlinternalMod" rel="Chapter" href="CamlinternalMod.html">
 <link title="Genlex" rel="Chapter" href="Genlex.html">
-<link title="Ephemeron" rel="Chapter" href="Ephemeron.html">
-<link title="Filename" rel="Chapter" href="Filename.html">
-<link title="Complex" rel="Chapter" href="Complex.html">
-<link title="ArrayLabels" rel="Chapter" href="ArrayLabels.html">
+<link title="Hashtbl" rel="Chapter" href="Hashtbl.html">
+<link title="Int" rel="Chapter" href="Int.html">
+<link title="Int32" rel="Chapter" href="Int32.html">
+<link title="Int64" rel="Chapter" href="Int64.html">
+<link title="Lazy" rel="Chapter" href="Lazy.html">
+<link title="Lexing" rel="Chapter" href="Lexing.html">
+<link title="List" rel="Chapter" href="List.html">
 <link title="ListLabels" rel="Chapter" href="ListLabels.html">
-<link title="BytesLabels" rel="Chapter" href="BytesLabels.html">
-<link title="StringLabels" rel="Chapter" href="StringLabels.html">
+<link title="Map" rel="Chapter" href="Map.html">
+<link title="Marshal" rel="Chapter" href="Marshal.html">
 <link title="MoreLabels" rel="Chapter" href="MoreLabels.html">
+<link title="Mutex" rel="Chapter" href="Mutex.html">
+<link title="Nativeint" rel="Chapter" href="Nativeint.html">
+<link title="Obj" rel="Chapter" href="Obj.html">
+<link title="Oo" rel="Chapter" href="Oo.html">
+<link title="Option" rel="Chapter" href="Option.html">
+<link title="Parsing" rel="Chapter" href="Parsing.html">
+<link title="Printexc" rel="Chapter" href="Printexc.html">
+<link title="Printf" rel="Chapter" href="Printf.html">
+<link title="Queue" rel="Chapter" href="Queue.html">
+<link title="Random" rel="Chapter" href="Random.html">
+<link title="Result" rel="Chapter" href="Result.html">
+<link title="Scanf" rel="Chapter" href="Scanf.html">
+<link title="Semaphore" rel="Chapter" href="Semaphore.html">
+<link title="Seq" rel="Chapter" href="Seq.html">
+<link title="Set" rel="Chapter" href="Set.html">
+<link title="Stack" rel="Chapter" href="Stack.html">
 <link title="StdLabels" rel="Chapter" href="StdLabels.html">
-<link title="Bigarray" rel="Chapter" href="Bigarray.html">
-<link title="Dynlink" rel="Chapter" href="Dynlink.html">
+<link title="Stdlib" rel="Chapter" href="Stdlib.html">
 <link title="Str" rel="Chapter" href="Str.html">
+<link title="Stream" rel="Chapter" href="Stream.html">
+<link title="String" rel="Chapter" href="String.html">
+<link title="StringLabels" rel="Chapter" href="StringLabels.html">
+<link title="Sys" rel="Chapter" href="Sys.html">
+<link title="Thread" rel="Chapter" href="Thread.html">
+<link title="ThreadUnix" rel="Chapter" href="ThreadUnix.html">
+<link title="Uchar" rel="Chapter" href="Uchar.html">
+<link title="Unit" rel="Chapter" href="Unit.html">
 <link title="Unix" rel="Chapter" href="Unix.html">
 <link title="UnixLabels" rel="Chapter" href="UnixLabels.html">
-<link title="Thread" rel="Chapter" href="Thread.html">
-<link title="Condition" rel="Chapter" href="Condition.html">
-<link title="Mutex" rel="Chapter" href="Mutex.html">
-<link title="Event" rel="Chapter" href="Event.html">
-<link title="ThreadUnix" rel="Chapter" href="ThreadUnix.html">
-<link title="Semaphore" rel="Chapter" href="Semaphore.html"><title>OCaml library</title>
+<link title="Weak" rel="Chapter" href="Weak.html">
+<link title="CamlinternalAtomic" rel="Chapter" href="CamlinternalAtomic.html">
+<link title="CamlinternalFormat" rel="Chapter" href="CamlinternalFormat.html">
+<link title="CamlinternalFormatBasics" rel="Chapter" href="CamlinternalFormatBasics.html">
+<link title="CamlinternalLazy" rel="Chapter" href="CamlinternalLazy.html">
+<link title="CamlinternalMod" rel="Chapter" href="CamlinternalMod.html">
+<link title="CamlinternalOO" rel="Chapter" href="CamlinternalOO.html"><title>OCaml library</title>
 <script src="search.js"></script><script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
 <body><div class="api"><div id="sidebar-button"><span>☰</span></div><h1>The OCaml API</h1><div class="api_search"><input type="text" name="apisearch" id="api_search" class="api_search" oninput="mySearch(true);" onkeypress="this.oninput();" onclick="this.oninput();" onpaste="this.oninput();">
 <img src="search_icon.svg" alt="Search" class="api_search svg" onclick="mySearch(true)"><span class="search_comment">(search values, type signatures, and descriptions - case sensitive)<div class="search_help"><ul><li>You may search bare values, like <code>map</code>, or indicate the module, like <code>List.map</code>, or type signatures, like <code>int -&gt; float</code>.</li><li>To combine several keywords, just separate them by a space. Quotes "like this" can be used to prevent from splitting words at spaces.</li><li>You may use the special chars <code>^</code> and <code>$</code> to indicate where the matched string should start or end, respectively.</li></ul></div></span></div>
@@ -99,95 +99,18 @@
 </div>
 
 <table class="indextable module-list">
-<tbody><tr><td class="module"><a href="Ocaml_operators.html">Ocaml_operators</a></td><td><div class="info">
-<p>Precedence level and associativity of operators</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Format_tutorial.html">Format_tutorial</a></td><td><div class="info">
+<tbody><tr><td class="module"><a href="Format_tutorial.html">Format_tutorial</a></td><td><div class="info">
 <p>Principles</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="CamlinternalFormatBasics.html">CamlinternalFormatBasics</a></td><td></td></tr>
-<tr><td class="module"><a href="CamlinternalAtomic.html">CamlinternalAtomic</a></td><td></td></tr>
-<tr><td class="module"><a href="Stdlib.html">Stdlib</a></td><td><div class="info">
-<p>The OCaml Standard library.</p>
+<tr><td class="module"><a href="Ocaml_operators.html">Ocaml_operators</a></td><td><div class="info">
+<p>Precedence level and associativity of operators</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Seq.html">Seq</a></td><td><div class="info">
-<p>Sequences (functional iterators).</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Option.html">Option</a></td><td><div class="info">
-<p>Option values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Either.html">Either</a></td><td><div class="info">
-<p>Either type.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Result.html">Result</a></td><td><div class="info">
-<p>Result values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Bool.html">Bool</a></td><td><div class="info">
-<p>Boolean values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Char.html">Char</a></td><td><div class="info">
-<p>Character operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Uchar.html">Uchar</a></td><td><div class="info">
-<p>Unicode characters.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Sys.html">Sys</a></td><td><div class="info">
-<p>System interface.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="List.html">List</a></td><td><div class="info">
-<p>List operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Int.html">Int</a></td><td><div class="info">
-<p>Integer values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Bytes.html">Bytes</a></td><td><div class="info">
-<p>Byte sequence operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="String.html">String</a></td><td><div class="info">
-<p>Strings.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Unit.html">Unit</a></td><td><div class="info">
-<p>Unit values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Marshal.html">Marshal</a></td><td><div class="info">
-<p>Marshaling of data structures.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Obj.html">Obj</a></td><td><div class="info">
-<p>Operations on internal representations of values.</p>
+<tr><td class="module"><a href="Arg.html">Arg</a></td><td><div class="info">
+<p>Parsing of command line arguments.</p>
 
 </div>
 </td></tr>
@@ -196,84 +119,8 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Float.html">Float</a></td><td><div class="info">
-<p>Floating-point arithmetic.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Int32.html">Int32</a></td><td><div class="info">
-<p>32-bit integers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Int64.html">Int64</a></td><td><div class="info">
-<p>64-bit integers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Nativeint.html">Nativeint</a></td><td><div class="info">
-<p>Processor-native integers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Lexing.html">Lexing</a></td><td><div class="info">
-<p>The run-time library for lexers generated by <code class="code">ocamllex</code>.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Parsing.html">Parsing</a></td><td><div class="info">
-<p>The run-time library for parsers generated by <code class="code">ocamlyacc</code>.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Set.html">Set</a></td><td><div class="info">
-<p>Sets over ordered types.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Map.html">Map</a></td><td><div class="info">
-<p>Association tables over ordered types.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Stack.html">Stack</a></td><td><div class="info">
-<p>Last-in first-out stacks.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Queue.html">Queue</a></td><td><div class="info">
-<p>First-in first-out queues.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="CamlinternalLazy.html">CamlinternalLazy</a></td><td><div class="info">
-<p>Run-time support for lazy values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Lazy.html">Lazy</a></td><td><div class="info">
-<p>Deferred computations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Stream.html">Stream</a></td><td><div class="info">
-<p>Streams and parsers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Buffer.html">Buffer</a></td><td><div class="info">
-<p>Extensible buffers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="CamlinternalFormat.html">CamlinternalFormat</a></td><td></td></tr>
-<tr><td class="module"><a href="Printf.html">Printf</a></td><td><div class="info">
-<p>Formatted output functions.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Arg.html">Arg</a></td><td><div class="info">
-<p>Parsing of command line arguments.</p>
+<tr><td class="module"><a href="ArrayLabels.html">ArrayLabels</a></td><td><div class="info">
+<p>Array operations.</p>
 
 </div>
 </td></tr>
@@ -284,8 +131,88 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Printexc.html">Printexc</a></td><td><div class="info">
-<p>Facilities for printing exceptions and inspecting current call stack.</p>
+<tr><td class="module"><a href="Bigarray.html">Bigarray</a></td><td><div class="info">
+<p>Large, multi-dimensional, numerical arrays.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Bool.html">Bool</a></td><td><div class="info">
+<p>Boolean values.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Buffer.html">Buffer</a></td><td><div class="info">
+<p>Extensible buffers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Bytes.html">Bytes</a></td><td><div class="info">
+<p>Byte sequence operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="BytesLabels.html">BytesLabels</a></td><td><div class="info">
+<p>Byte sequence operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Callback.html">Callback</a></td><td><div class="info">
+<p>Registering OCaml values with the C runtime.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Char.html">Char</a></td><td><div class="info">
+<p>Character operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Complex.html">Complex</a></td><td><div class="info">
+<p>Complex numbers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Condition.html">Condition</a></td><td><div class="info">
+<p>Condition variables to synchronize between threads.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Digest.html">Digest</a></td><td><div class="info">
+<p>MD5 message digest.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Dynlink.html">Dynlink</a></td><td><div class="info">
+<p>Dynamic loading of .cmo, .cma and .cmxs files.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Either.html">Either</a></td><td><div class="info">
+<p>Either type.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Ephemeron.html">Ephemeron</a></td><td><div class="info">
+<p>Ephemerons and weak hash tables.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Event.html">Event</a></td><td><div class="info">
+<p>First-class synchronous communication.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Filename.html">Filename</a></td><td><div class="info">
+<p>Operations on file names.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Float.html">Float</a></td><td><div class="info">
+<p>Floating-point arithmetic.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Format.html">Format</a></td><td><div class="info">
+<p>Pretty-printing.</p>
 
 </div>
 </td></tr>
@@ -299,13 +226,8 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Digest.html">Digest</a></td><td><div class="info">
-<p>MD5 message digest.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Random.html">Random</a></td><td><div class="info">
-<p>Pseudo-random number generators (PRNG).</p>
+<tr><td class="module"><a href="Genlex.html">Genlex</a></td><td><div class="info">
+<p>A generic lexical analyzer.</p>
 
 </div>
 </td></tr>
@@ -314,63 +236,33 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Weak.html">Weak</a></td><td><div class="info">
-<p>Arrays of weak pointers and hash sets of weak pointers.</p>
+<tr><td class="module"><a href="Int.html">Int</a></td><td><div class="info">
+<p>Integer values.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Format.html">Format</a></td><td><div class="info">
-<p>Pretty-printing.</p>
+<tr><td class="module"><a href="Int32.html">Int32</a></td><td><div class="info">
+<p>32-bit integers.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Scanf.html">Scanf</a></td><td><div class="info">
-<p>Formatted input functions.</p>
+<tr><td class="module"><a href="Int64.html">Int64</a></td><td><div class="info">
+<p>64-bit integers.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Callback.html">Callback</a></td><td><div class="info">
-<p>Registering OCaml values with the C runtime.</p>
+<tr><td class="module"><a href="Lazy.html">Lazy</a></td><td><div class="info">
+<p>Deferred computations.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="CamlinternalOO.html">CamlinternalOO</a></td><td><div class="info">
-<p>Run-time support for objects and classes.</p>
+<tr><td class="module"><a href="Lexing.html">Lexing</a></td><td><div class="info">
+<p>The run-time library for lexers generated by <code class="code">ocamllex</code>.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Oo.html">Oo</a></td><td><div class="info">
-<p>Operations on objects</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="CamlinternalMod.html">CamlinternalMod</a></td><td><div class="info">
-<p>Run-time support for recursive modules.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Genlex.html">Genlex</a></td><td><div class="info">
-<p>A generic lexical analyzer.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Ephemeron.html">Ephemeron</a></td><td><div class="info">
-<p>Ephemerons and weak hash tables.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Filename.html">Filename</a></td><td><div class="info">
-<p>Operations on file names.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Complex.html">Complex</a></td><td><div class="info">
-<p>Complex numbers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="ArrayLabels.html">ArrayLabels</a></td><td><div class="info">
-<p>Array operations.</p>
+<tr><td class="module"><a href="List.html">List</a></td><td><div class="info">
+<p>List operations.</p>
 
 </div>
 </td></tr>
@@ -379,13 +271,13 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="BytesLabels.html">BytesLabels</a></td><td><div class="info">
-<p>Byte sequence operations.</p>
+<tr><td class="module"><a href="Map.html">Map</a></td><td><div class="info">
+<p>Association tables over ordered types.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="StringLabels.html">StringLabels</a></td><td><div class="info">
-<p>Strings.</p>
+<tr><td class="module"><a href="Marshal.html">Marshal</a></td><td><div class="info">
+<p>Marshaling of data structures.</p>
 
 </div>
 </td></tr>
@@ -394,23 +286,138 @@
 
 </div>
 </td></tr>
+<tr><td class="module"><a href="Mutex.html">Mutex</a></td><td><div class="info">
+<p>Locks for mutual exclusion.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Nativeint.html">Nativeint</a></td><td><div class="info">
+<p>Processor-native integers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Obj.html">Obj</a></td><td><div class="info">
+<p>Operations on internal representations of values.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Oo.html">Oo</a></td><td><div class="info">
+<p>Operations on objects</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Option.html">Option</a></td><td><div class="info">
+<p>Option values.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Parsing.html">Parsing</a></td><td><div class="info">
+<p>The run-time library for parsers generated by <code class="code">ocamlyacc</code>.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Printexc.html">Printexc</a></td><td><div class="info">
+<p>Facilities for printing exceptions and inspecting current call stack.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Printf.html">Printf</a></td><td><div class="info">
+<p>Formatted output functions.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Queue.html">Queue</a></td><td><div class="info">
+<p>First-in first-out queues.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Random.html">Random</a></td><td><div class="info">
+<p>Pseudo-random number generators (PRNG).</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Result.html">Result</a></td><td><div class="info">
+<p>Result values.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Scanf.html">Scanf</a></td><td><div class="info">
+<p>Formatted input functions.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Semaphore.html">Semaphore</a></td><td><div class="info">
+<p>Semaphores</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Seq.html">Seq</a></td><td><div class="info">
+<p>Sequences (functional iterators).</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Set.html">Set</a></td><td><div class="info">
+<p>Sets over ordered types.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Stack.html">Stack</a></td><td><div class="info">
+<p>Last-in first-out stacks.</p>
+
+</div>
+</td></tr>
 <tr><td class="module"><a href="StdLabels.html">StdLabels</a></td><td><div class="info">
 <p>Standard labeled libraries.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Bigarray.html">Bigarray</a></td><td><div class="info">
-<p>Large, multi-dimensional, numerical arrays.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Dynlink.html">Dynlink</a></td><td><div class="info">
-<p>Dynamic loading of .cmo, .cma and .cmxs files.</p>
+<tr><td class="module"><a href="Stdlib.html">Stdlib</a></td><td><div class="info">
+<p>The OCaml Standard library.</p>
 
 </div>
 </td></tr>
 <tr><td class="module"><a href="Str.html">Str</a></td><td><div class="info">
 <p>Regular expressions and high-level string processing</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Stream.html">Stream</a></td><td><div class="info">
+<p>Streams and parsers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="String.html">String</a></td><td><div class="info">
+<p>Strings.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="StringLabels.html">StringLabels</a></td><td><div class="info">
+<p>Strings.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Sys.html">Sys</a></td><td><div class="info">
+<p>System interface.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Thread.html">Thread</a></td><td><div class="info">
+<p>Lightweight threads for Posix <code class="code">1003.1c</code> and Win32.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="ThreadUnix.html">ThreadUnix</a></td><td><div class="info">
+<span class="deprecated"><p>Thread-compatible system calls.</p>
+
+</span></div>
+</td></tr>
+<tr><td class="module"><a href="Uchar.html">Uchar</a></td><td><div class="info">
+<p>Unicode characters.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Unit.html">Unit</a></td><td><div class="info">
+<p>Unit values.</p>
 
 </div>
 </td></tr>
@@ -424,33 +431,26 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Thread.html">Thread</a></td><td><div class="info">
-<p>Lightweight threads for Posix <code class="code">1003.1c</code> and Win32.</p>
+<tr><td class="module"><a href="Weak.html">Weak</a></td><td><div class="info">
+<p>Arrays of weak pointers and hash sets of weak pointers.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Condition.html">Condition</a></td><td><div class="info">
-<p>Condition variables to synchronize between threads.</p>
+<tr><td class="module"><a href="CamlinternalAtomic.html">CamlinternalAtomic</a></td><td></td></tr>
+<tr><td class="module"><a href="CamlinternalFormat.html">CamlinternalFormat</a></td><td></td></tr>
+<tr><td class="module"><a href="CamlinternalFormatBasics.html">CamlinternalFormatBasics</a></td><td></td></tr>
+<tr><td class="module"><a href="CamlinternalLazy.html">CamlinternalLazy</a></td><td><div class="info">
+<p>Run-time support for lazy values.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Mutex.html">Mutex</a></td><td><div class="info">
-<p>Locks for mutual exclusion.</p>
+<tr><td class="module"><a href="CamlinternalMod.html">CamlinternalMod</a></td><td><div class="info">
+<p>Run-time support for recursive modules.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Event.html">Event</a></td><td><div class="info">
-<p>First-class synchronous communication.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="ThreadUnix.html">ThreadUnix</a></td><td><div class="info">
-<span class="deprecated"><p>Thread-compatible system calls.</p>
-
-</span></div>
-</td></tr>
-<tr><td class="module"><a href="Semaphore.html">Semaphore</a></td><td><div class="info">
-<p>Semaphores</p>
+<tr><td class="module"><a href="CamlinternalOO.html">CamlinternalOO</a></td><td><div class="info">
+<p>Run-time support for objects and classes.</p>
 
 </div>
 </td></tr>

--- a/site/releases/4.14/api/index.html
+++ b/site/releases/4.14/api/index.html
@@ -9,81 +9,81 @@
 <link title="Index of values" rel="Appendix" href="index_values.html">
 <link title="Index of modules" rel="Appendix" href="index_modules.html">
 <link title="Index of module types" rel="Appendix" href="index_module_types.html">
-<link title="Ocaml_operators" rel="Chapter" href="Ocaml_operators.html">
 <link title="Format_tutorial" rel="Chapter" href="Format_tutorial.html">
-<link title="CamlinternalFormatBasics" rel="Chapter" href="CamlinternalFormatBasics.html">
-<link title="CamlinternalAtomic" rel="Chapter" href="CamlinternalAtomic.html">
-<link title="Stdlib" rel="Chapter" href="Stdlib.html">
-<link title="Either" rel="Chapter" href="Either.html">
-<link title="Sys" rel="Chapter" href="Sys.html">
-<link title="Obj" rel="Chapter" href="Obj.html">
-<link title="CamlinternalLazy" rel="Chapter" href="CamlinternalLazy.html">
-<link title="Lazy" rel="Chapter" href="Lazy.html">
-<link title="Seq" rel="Chapter" href="Seq.html">
-<link title="Option" rel="Chapter" href="Option.html">
-<link title="Result" rel="Chapter" href="Result.html">
-<link title="Bool" rel="Chapter" href="Bool.html">
-<link title="Char" rel="Chapter" href="Char.html">
-<link title="Uchar" rel="Chapter" href="Uchar.html">
-<link title="List" rel="Chapter" href="List.html">
-<link title="Int" rel="Chapter" href="Int.html">
-<link title="Bytes" rel="Chapter" href="Bytes.html">
-<link title="String" rel="Chapter" href="String.html">
-<link title="Unit" rel="Chapter" href="Unit.html">
-<link title="Marshal" rel="Chapter" href="Marshal.html">
-<link title="Array" rel="Chapter" href="Array.html">
-<link title="Float" rel="Chapter" href="Float.html">
-<link title="Int32" rel="Chapter" href="Int32.html">
-<link title="Int64" rel="Chapter" href="Int64.html">
-<link title="Nativeint" rel="Chapter" href="Nativeint.html">
-<link title="Lexing" rel="Chapter" href="Lexing.html">
-<link title="Parsing" rel="Chapter" href="Parsing.html">
-<link title="Set" rel="Chapter" href="Set.html">
-<link title="Map" rel="Chapter" href="Map.html">
-<link title="Stack" rel="Chapter" href="Stack.html">
-<link title="Queue" rel="Chapter" href="Queue.html">
-<link title="Stream" rel="Chapter" href="Stream.html">
-<link title="Buffer" rel="Chapter" href="Buffer.html">
-<link title="CamlinternalFormat" rel="Chapter" href="CamlinternalFormat.html">
-<link title="Printf" rel="Chapter" href="Printf.html">
+<link title="Ocaml_operators" rel="Chapter" href="Ocaml_operators.html">
 <link title="Arg" rel="Chapter" href="Arg.html">
+<link title="Array" rel="Chapter" href="Array.html">
+<link title="ArrayLabels" rel="Chapter" href="ArrayLabels.html">
 <link title="Atomic" rel="Chapter" href="Atomic.html">
-<link title="Printexc" rel="Chapter" href="Printexc.html">
+<link title="Bigarray" rel="Chapter" href="Bigarray.html">
+<link title="Bool" rel="Chapter" href="Bool.html">
+<link title="Buffer" rel="Chapter" href="Buffer.html">
+<link title="Bytes" rel="Chapter" href="Bytes.html">
+<link title="BytesLabels" rel="Chapter" href="BytesLabels.html">
+<link title="Callback" rel="Chapter" href="Callback.html">
+<link title="Char" rel="Chapter" href="Char.html">
+<link title="Complex" rel="Chapter" href="Complex.html">
+<link title="Condition" rel="Chapter" href="Condition.html">
+<link title="Digest" rel="Chapter" href="Digest.html">
+<link title="Dynlink" rel="Chapter" href="Dynlink.html">
+<link title="Either" rel="Chapter" href="Either.html">
+<link title="Ephemeron" rel="Chapter" href="Ephemeron.html">
+<link title="Event" rel="Chapter" href="Event.html">
+<link title="Filename" rel="Chapter" href="Filename.html">
+<link title="Float" rel="Chapter" href="Float.html">
+<link title="Format" rel="Chapter" href="Format.html">
 <link title="Fun" rel="Chapter" href="Fun.html">
 <link title="Gc" rel="Chapter" href="Gc.html">
-<link title="Digest" rel="Chapter" href="Digest.html">
-<link title="Random" rel="Chapter" href="Random.html">
-<link title="Hashtbl" rel="Chapter" href="Hashtbl.html">
-<link title="Weak" rel="Chapter" href="Weak.html">
-<link title="Format" rel="Chapter" href="Format.html">
-<link title="Scanf" rel="Chapter" href="Scanf.html">
-<link title="Callback" rel="Chapter" href="Callback.html">
-<link title="CamlinternalOO" rel="Chapter" href="CamlinternalOO.html">
-<link title="Oo" rel="Chapter" href="Oo.html">
-<link title="CamlinternalMod" rel="Chapter" href="CamlinternalMod.html">
 <link title="Genlex" rel="Chapter" href="Genlex.html">
-<link title="Ephemeron" rel="Chapter" href="Ephemeron.html">
-<link title="Filename" rel="Chapter" href="Filename.html">
-<link title="Complex" rel="Chapter" href="Complex.html">
-<link title="ArrayLabels" rel="Chapter" href="ArrayLabels.html">
-<link title="ListLabels" rel="Chapter" href="ListLabels.html">
-<link title="BytesLabels" rel="Chapter" href="BytesLabels.html">
-<link title="StringLabels" rel="Chapter" href="StringLabels.html">
-<link title="MoreLabels" rel="Chapter" href="MoreLabels.html">
-<link title="StdLabels" rel="Chapter" href="StdLabels.html">
-<link title="Bigarray" rel="Chapter" href="Bigarray.html">
+<link title="Hashtbl" rel="Chapter" href="Hashtbl.html">
 <link title="In_channel" rel="Chapter" href="In_channel.html">
+<link title="Int" rel="Chapter" href="Int.html">
+<link title="Int32" rel="Chapter" href="Int32.html">
+<link title="Int64" rel="Chapter" href="Int64.html">
+<link title="Lazy" rel="Chapter" href="Lazy.html">
+<link title="Lexing" rel="Chapter" href="Lexing.html">
+<link title="List" rel="Chapter" href="List.html">
+<link title="ListLabels" rel="Chapter" href="ListLabels.html">
+<link title="Map" rel="Chapter" href="Map.html">
+<link title="Marshal" rel="Chapter" href="Marshal.html">
+<link title="MoreLabels" rel="Chapter" href="MoreLabels.html">
+<link title="Mutex" rel="Chapter" href="Mutex.html">
+<link title="Nativeint" rel="Chapter" href="Nativeint.html">
+<link title="Obj" rel="Chapter" href="Obj.html">
+<link title="Oo" rel="Chapter" href="Oo.html">
+<link title="Option" rel="Chapter" href="Option.html">
 <link title="Out_channel" rel="Chapter" href="Out_channel.html">
-<link title="Dynlink" rel="Chapter" href="Dynlink.html">
+<link title="Parsing" rel="Chapter" href="Parsing.html">
+<link title="Printexc" rel="Chapter" href="Printexc.html">
+<link title="Printf" rel="Chapter" href="Printf.html">
+<link title="Queue" rel="Chapter" href="Queue.html">
+<link title="Random" rel="Chapter" href="Random.html">
+<link title="Result" rel="Chapter" href="Result.html">
+<link title="Scanf" rel="Chapter" href="Scanf.html">
+<link title="Semaphore" rel="Chapter" href="Semaphore.html">
+<link title="Seq" rel="Chapter" href="Seq.html">
+<link title="Set" rel="Chapter" href="Set.html">
+<link title="Stack" rel="Chapter" href="Stack.html">
+<link title="StdLabels" rel="Chapter" href="StdLabels.html">
+<link title="Stdlib" rel="Chapter" href="Stdlib.html">
 <link title="Str" rel="Chapter" href="Str.html">
+<link title="Stream" rel="Chapter" href="Stream.html">
+<link title="String" rel="Chapter" href="String.html">
+<link title="StringLabels" rel="Chapter" href="StringLabels.html">
+<link title="Sys" rel="Chapter" href="Sys.html">
+<link title="Thread" rel="Chapter" href="Thread.html">
+<link title="ThreadUnix" rel="Chapter" href="ThreadUnix.html">
+<link title="Uchar" rel="Chapter" href="Uchar.html">
+<link title="Unit" rel="Chapter" href="Unit.html">
 <link title="Unix" rel="Chapter" href="Unix.html">
 <link title="UnixLabels" rel="Chapter" href="UnixLabels.html">
-<link title="Thread" rel="Chapter" href="Thread.html">
-<link title="Condition" rel="Chapter" href="Condition.html">
-<link title="Mutex" rel="Chapter" href="Mutex.html">
-<link title="Event" rel="Chapter" href="Event.html">
-<link title="ThreadUnix" rel="Chapter" href="ThreadUnix.html">
-<link title="Semaphore" rel="Chapter" href="Semaphore.html"><title>OCaml library</title>
+<link title="Weak" rel="Chapter" href="Weak.html">
+<link title="CamlinternalAtomic" rel="Chapter" href="CamlinternalAtomic.html">
+<link title="CamlinternalFormat" rel="Chapter" href="CamlinternalFormat.html">
+<link title="CamlinternalFormatBasics" rel="Chapter" href="CamlinternalFormatBasics.html">
+<link title="CamlinternalLazy" rel="Chapter" href="CamlinternalLazy.html">
+<link title="CamlinternalMod" rel="Chapter" href="CamlinternalMod.html">
+<link title="CamlinternalOO" rel="Chapter" href="CamlinternalOO.html"><title>OCaml library</title>
 <script src="search.js"></script><script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
 <body><div class="api"><div id="sidebar-button"><span>☰</span></div><h1>The OCaml API</h1><div class="api_search"><input type="text" name="apisearch" id="api_search" class="api_search" oninput="mySearch(true);" onkeypress="this.oninput();" onclick="this.oninput();" onpaste="this.oninput();">
 <img src="search_icon.svg" alt="Search" class="api_search svg" onclick="mySearch(true)"><span class="search_comment">(search values, type signatures, and descriptions - case sensitive)<span id="help_icon" onclick="showHelp()">ⓘ</span><div id="search_help" class="hide"><ul><li>You may search bare values, like <code>map</code>, or indicate the module, like <code>List.map</code>, or type signatures, like <code>int -&gt; float</code>.</li><li>To combine several keywords, just separate them by a space. Quotes can be used to prevent from splitting words at spaces. For instance, <code>int array</code> will search for <code>int</code> and/or <code>array</code>, while <code>"int array"</code> will only list functions whose signature contains the <code>int array</code> type.</li><li>You may use the special chars <code>^</code> and <code>$</code> to indicate where the matched string should start or end, respectively. For instance <code>^zip</code> will not show you the <code>unzip</code> function.</li></ul></div></span></div>
@@ -101,105 +101,18 @@
 </div>
 
 <table class="indextable module-list">
-<tbody><tr><td class="module"><a href="Ocaml_operators.html">Ocaml_operators</a></td><td><div class="info">
-<p>Precedence level and associativity of operators</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Format_tutorial.html">Format_tutorial</a></td><td><div class="info">
+<tbody><tr><td class="module"><a href="Format_tutorial.html">Format_tutorial</a></td><td><div class="info">
 <p>Using the Format module</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="CamlinternalFormatBasics.html">CamlinternalFormatBasics</a></td><td></td></tr>
-<tr><td class="module"><a href="CamlinternalAtomic.html">CamlinternalAtomic</a></td><td></td></tr>
-<tr><td class="module"><a href="Stdlib.html">Stdlib</a></td><td><div class="info">
-<p>The OCaml Standard library.</p>
+<tr><td class="module"><a href="Ocaml_operators.html">Ocaml_operators</a></td><td><div class="info">
+<p>Precedence level and associativity of operators</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Either.html">Either</a></td><td><div class="info">
-<p>Either type.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Sys.html">Sys</a></td><td><div class="info">
-<p>System interface.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Obj.html">Obj</a></td><td><div class="info">
-<p>Operations on internal representations of values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="CamlinternalLazy.html">CamlinternalLazy</a></td><td><div class="info">
-<p>Run-time support for lazy values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Lazy.html">Lazy</a></td><td><div class="info">
-<p>Deferred computations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Seq.html">Seq</a></td><td><div class="info">
-<p>Sequences.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Option.html">Option</a></td><td><div class="info">
-<p>Option values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Result.html">Result</a></td><td><div class="info">
-<p>Result values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Bool.html">Bool</a></td><td><div class="info">
-<p>Boolean values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Char.html">Char</a></td><td><div class="info">
-<p>Character operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Uchar.html">Uchar</a></td><td><div class="info">
-<p>Unicode characters.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="List.html">List</a></td><td><div class="info">
-<p>List operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Int.html">Int</a></td><td><div class="info">
-<p>Integer values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Bytes.html">Bytes</a></td><td><div class="info">
-<p>Byte sequence operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="String.html">String</a></td><td><div class="info">
-<p>Strings.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Unit.html">Unit</a></td><td><div class="info">
-<p>Unit values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Marshal.html">Marshal</a></td><td><div class="info">
-<p>Marshaling of data structures.</p>
+<tr><td class="module"><a href="Arg.html">Arg</a></td><td><div class="info">
+<p>Parsing of command line arguments.</p>
 
 </div>
 </td></tr>
@@ -208,74 +121,8 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Float.html">Float</a></td><td><div class="info">
-<p>Floating-point arithmetic.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Int32.html">Int32</a></td><td><div class="info">
-<p>32-bit integers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Int64.html">Int64</a></td><td><div class="info">
-<p>64-bit integers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Nativeint.html">Nativeint</a></td><td><div class="info">
-<p>Processor-native integers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Lexing.html">Lexing</a></td><td><div class="info">
-<p>The run-time library for lexers generated by <code class="code">ocamllex</code>.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Parsing.html">Parsing</a></td><td><div class="info">
-<p>The run-time library for parsers generated by <code class="code">ocamlyacc</code>.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Set.html">Set</a></td><td><div class="info">
-<p>Sets over ordered types.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Map.html">Map</a></td><td><div class="info">
-<p>Association tables over ordered types.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Stack.html">Stack</a></td><td><div class="info">
-<p>Last-in first-out stacks.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Queue.html">Queue</a></td><td><div class="info">
-<p>First-in first-out queues.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Stream.html">Stream</a></td><td><div class="info">
-<p>Streams and parsers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Buffer.html">Buffer</a></td><td><div class="info">
-<p>Extensible buffers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="CamlinternalFormat.html">CamlinternalFormat</a></td><td></td></tr>
-<tr><td class="module"><a href="Printf.html">Printf</a></td><td><div class="info">
-<p>Formatted output functions.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Arg.html">Arg</a></td><td><div class="info">
-<p>Parsing of command line arguments.</p>
+<tr><td class="module"><a href="ArrayLabels.html">ArrayLabels</a></td><td><div class="info">
+<p>Array operations.</p>
 
 </div>
 </td></tr>
@@ -286,8 +133,88 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Printexc.html">Printexc</a></td><td><div class="info">
-<p>Facilities for printing exceptions and inspecting current call stack.</p>
+<tr><td class="module"><a href="Bigarray.html">Bigarray</a></td><td><div class="info">
+<p>Large, multi-dimensional, numerical arrays.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Bool.html">Bool</a></td><td><div class="info">
+<p>Boolean values.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Buffer.html">Buffer</a></td><td><div class="info">
+<p>Extensible buffers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Bytes.html">Bytes</a></td><td><div class="info">
+<p>Byte sequence operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="BytesLabels.html">BytesLabels</a></td><td><div class="info">
+<p>Byte sequence operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Callback.html">Callback</a></td><td><div class="info">
+<p>Registering OCaml values with the C runtime.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Char.html">Char</a></td><td><div class="info">
+<p>Character operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Complex.html">Complex</a></td><td><div class="info">
+<p>Complex numbers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Condition.html">Condition</a></td><td><div class="info">
+<p>Condition variables to synchronize between threads.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Digest.html">Digest</a></td><td><div class="info">
+<p>MD5 message digest.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Dynlink.html">Dynlink</a></td><td><div class="info">
+<p>Dynamic loading of .cmo, .cma and .cmxs files.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Either.html">Either</a></td><td><div class="info">
+<p>Either type.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Ephemeron.html">Ephemeron</a></td><td><div class="info">
+<p>Ephemerons and weak hash tables.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Event.html">Event</a></td><td><div class="info">
+<p>First-class synchronous communication.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Filename.html">Filename</a></td><td><div class="info">
+<p>Operations on file names.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Float.html">Float</a></td><td><div class="info">
+<p>Floating-point arithmetic.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Format.html">Format</a></td><td><div class="info">
+<p>Pretty-printing.</p>
 
 </div>
 </td></tr>
@@ -301,13 +228,8 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Digest.html">Digest</a></td><td><div class="info">
-<p>MD5 message digest.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Random.html">Random</a></td><td><div class="info">
-<p>Pseudo-random number generators (PRNG).</p>
+<tr><td class="module"><a href="Genlex.html">Genlex</a></td><td><div class="info">
+<p>A generic lexical analyzer.</p>
 
 </div>
 </td></tr>
@@ -316,63 +238,38 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Weak.html">Weak</a></td><td><div class="info">
-<p>Arrays of weak pointers and hash sets of weak pointers.</p>
+<tr><td class="module"><a href="In_channel.html">In_channel</a></td><td><div class="info">
+<p>Input channels.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Format.html">Format</a></td><td><div class="info">
-<p>Pretty-printing.</p>
+<tr><td class="module"><a href="Int.html">Int</a></td><td><div class="info">
+<p>Integer values.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Scanf.html">Scanf</a></td><td><div class="info">
-<p>Formatted input functions.</p>
+<tr><td class="module"><a href="Int32.html">Int32</a></td><td><div class="info">
+<p>32-bit integers.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Callback.html">Callback</a></td><td><div class="info">
-<p>Registering OCaml values with the C runtime.</p>
+<tr><td class="module"><a href="Int64.html">Int64</a></td><td><div class="info">
+<p>64-bit integers.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="CamlinternalOO.html">CamlinternalOO</a></td><td><div class="info">
-<p>Run-time support for objects and classes.</p>
+<tr><td class="module"><a href="Lazy.html">Lazy</a></td><td><div class="info">
+<p>Deferred computations.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Oo.html">Oo</a></td><td><div class="info">
-<p>Operations on objects</p>
+<tr><td class="module"><a href="Lexing.html">Lexing</a></td><td><div class="info">
+<p>The run-time library for lexers generated by <code class="code">ocamllex</code>.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="CamlinternalMod.html">CamlinternalMod</a></td><td><div class="info">
-<p>Run-time support for recursive modules.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Genlex.html">Genlex</a></td><td><div class="info">
-<p>A generic lexical analyzer.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Ephemeron.html">Ephemeron</a></td><td><div class="info">
-<p>Ephemerons and weak hash tables.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Filename.html">Filename</a></td><td><div class="info">
-<p>Operations on file names.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Complex.html">Complex</a></td><td><div class="info">
-<p>Complex numbers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="ArrayLabels.html">ArrayLabels</a></td><td><div class="info">
-<p>Array operations.</p>
+<tr><td class="module"><a href="List.html">List</a></td><td><div class="info">
+<p>List operations.</p>
 
 </div>
 </td></tr>
@@ -381,13 +278,13 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="BytesLabels.html">BytesLabels</a></td><td><div class="info">
-<p>Byte sequence operations.</p>
+<tr><td class="module"><a href="Map.html">Map</a></td><td><div class="info">
+<p>Association tables over ordered types.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="StringLabels.html">StringLabels</a></td><td><div class="info">
-<p>Strings.</p>
+<tr><td class="module"><a href="Marshal.html">Marshal</a></td><td><div class="info">
+<p>Marshaling of data structures.</p>
 
 </div>
 </td></tr>
@@ -396,18 +293,28 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="StdLabels.html">StdLabels</a></td><td><div class="info">
-<p>Standard labeled libraries.</p>
+<tr><td class="module"><a href="Mutex.html">Mutex</a></td><td><div class="info">
+<p>Locks for mutual exclusion.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Bigarray.html">Bigarray</a></td><td><div class="info">
-<p>Large, multi-dimensional, numerical arrays.</p>
+<tr><td class="module"><a href="Nativeint.html">Nativeint</a></td><td><div class="info">
+<p>Processor-native integers.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="In_channel.html">In_channel</a></td><td><div class="info">
-<p>Input channels.</p>
+<tr><td class="module"><a href="Obj.html">Obj</a></td><td><div class="info">
+<p>Operations on internal representations of values.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Oo.html">Oo</a></td><td><div class="info">
+<p>Operations on objects</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Option.html">Option</a></td><td><div class="info">
+<p>Option values.</p>
 
 </div>
 </td></tr>
@@ -416,13 +323,113 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Dynlink.html">Dynlink</a></td><td><div class="info">
-<p>Dynamic loading of .cmo, .cma and .cmxs files.</p>
+<tr><td class="module"><a href="Parsing.html">Parsing</a></td><td><div class="info">
+<p>The run-time library for parsers generated by <code class="code">ocamlyacc</code>.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Printexc.html">Printexc</a></td><td><div class="info">
+<p>Facilities for printing exceptions and inspecting current call stack.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Printf.html">Printf</a></td><td><div class="info">
+<p>Formatted output functions.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Queue.html">Queue</a></td><td><div class="info">
+<p>First-in first-out queues.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Random.html">Random</a></td><td><div class="info">
+<p>Pseudo-random number generators (PRNG).</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Result.html">Result</a></td><td><div class="info">
+<p>Result values.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Scanf.html">Scanf</a></td><td><div class="info">
+<p>Formatted input functions.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Semaphore.html">Semaphore</a></td><td><div class="info">
+<p>Semaphores</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Seq.html">Seq</a></td><td><div class="info">
+<p>Sequences.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Set.html">Set</a></td><td><div class="info">
+<p>Sets over ordered types.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Stack.html">Stack</a></td><td><div class="info">
+<p>Last-in first-out stacks.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="StdLabels.html">StdLabels</a></td><td><div class="info">
+<p>Standard labeled libraries.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Stdlib.html">Stdlib</a></td><td><div class="info">
+<p>The OCaml Standard library.</p>
 
 </div>
 </td></tr>
 <tr><td class="module"><a href="Str.html">Str</a></td><td><div class="info">
 <p>Regular expressions and high-level string processing</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Stream.html">Stream</a></td><td><div class="info">
+<p>Streams and parsers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="String.html">String</a></td><td><div class="info">
+<p>Strings.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="StringLabels.html">StringLabels</a></td><td><div class="info">
+<p>Strings.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Sys.html">Sys</a></td><td><div class="info">
+<p>System interface.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Thread.html">Thread</a></td><td><div class="info">
+<p>Lightweight threads for Posix <code class="code">1003.1c</code> and Win32.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="ThreadUnix.html">ThreadUnix</a></td><td><div class="info">
+<span class="deprecated"><p>Thread-compatible system calls.</p>
+
+</span></div>
+</td></tr>
+<tr><td class="module"><a href="Uchar.html">Uchar</a></td><td><div class="info">
+<p>Unicode characters.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Unit.html">Unit</a></td><td><div class="info">
+<p>Unit values.</p>
 
 </div>
 </td></tr>
@@ -436,33 +443,26 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Thread.html">Thread</a></td><td><div class="info">
-<p>Lightweight threads for Posix <code class="code">1003.1c</code> and Win32.</p>
+<tr><td class="module"><a href="Weak.html">Weak</a></td><td><div class="info">
+<p>Arrays of weak pointers and hash sets of weak pointers.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Condition.html">Condition</a></td><td><div class="info">
-<p>Condition variables to synchronize between threads.</p>
+<tr><td class="module"><a href="CamlinternalAtomic.html">CamlinternalAtomic</a></td><td></td></tr>
+<tr><td class="module"><a href="CamlinternalFormat.html">CamlinternalFormat</a></td><td></td></tr>
+<tr><td class="module"><a href="CamlinternalFormatBasics.html">CamlinternalFormatBasics</a></td><td></td></tr>
+<tr><td class="module"><a href="CamlinternalLazy.html">CamlinternalLazy</a></td><td><div class="info">
+<p>Run-time support for lazy values.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Mutex.html">Mutex</a></td><td><div class="info">
-<p>Locks for mutual exclusion.</p>
+<tr><td class="module"><a href="CamlinternalMod.html">CamlinternalMod</a></td><td><div class="info">
+<p>Run-time support for recursive modules.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Event.html">Event</a></td><td><div class="info">
-<p>First-class synchronous communication.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="ThreadUnix.html">ThreadUnix</a></td><td><div class="info">
-<span class="deprecated"><p>Thread-compatible system calls.</p>
-
-</span></div>
-</td></tr>
-<tr><td class="module"><a href="Semaphore.html">Semaphore</a></td><td><div class="info">
-<p>Semaphores</p>
+<tr><td class="module"><a href="CamlinternalOO.html">CamlinternalOO</a></td><td><div class="info">
+<p>Run-time support for objects and classes.</p>
 
 </div>
 </td></tr>

--- a/site/releases/5.0/api/index.html
+++ b/site/releases/5.0/api/index.html
@@ -9,80 +9,80 @@
 <link title="Index of values" rel="Appendix" href="index_values.html">
 <link title="Index of modules" rel="Appendix" href="index_modules.html">
 <link title="Index of module types" rel="Appendix" href="index_module_types.html">
-<link title="Ocaml_operators" rel="Chapter" href="Ocaml_operators.html">
 <link title="Format_tutorial" rel="Chapter" href="Format_tutorial.html">
-<link title="CamlinternalFormatBasics" rel="Chapter" href="CamlinternalFormatBasics.html">
-<link title="Stdlib" rel="Chapter" href="Stdlib.html">
-<link title="Either" rel="Chapter" href="Either.html">
-<link title="Sys" rel="Chapter" href="Sys.html">
-<link title="Obj" rel="Chapter" href="Obj.html">
-<link title="Atomic" rel="Chapter" href="Atomic.html">
-<link title="CamlinternalLazy" rel="Chapter" href="CamlinternalLazy.html">
-<link title="Lazy" rel="Chapter" href="Lazy.html">
-<link title="Seq" rel="Chapter" href="Seq.html">
-<link title="Option" rel="Chapter" href="Option.html">
-<link title="Result" rel="Chapter" href="Result.html">
-<link title="Bool" rel="Chapter" href="Bool.html">
-<link title="Char" rel="Chapter" href="Char.html">
-<link title="Uchar" rel="Chapter" href="Uchar.html">
-<link title="List" rel="Chapter" href="List.html">
-<link title="Int" rel="Chapter" href="Int.html">
-<link title="Bytes" rel="Chapter" href="Bytes.html">
-<link title="String" rel="Chapter" href="String.html">
-<link title="Unit" rel="Chapter" href="Unit.html">
-<link title="Marshal" rel="Chapter" href="Marshal.html">
-<link title="Array" rel="Chapter" href="Array.html">
-<link title="Float" rel="Chapter" href="Float.html">
-<link title="Int32" rel="Chapter" href="Int32.html">
-<link title="Int64" rel="Chapter" href="Int64.html">
-<link title="Nativeint" rel="Chapter" href="Nativeint.html">
-<link title="Lexing" rel="Chapter" href="Lexing.html">
-<link title="Parsing" rel="Chapter" href="Parsing.html">
-<link title="Set" rel="Chapter" href="Set.html">
-<link title="Map" rel="Chapter" href="Map.html">
-<link title="Stack" rel="Chapter" href="Stack.html">
-<link title="Queue" rel="Chapter" href="Queue.html">
-<link title="Buffer" rel="Chapter" href="Buffer.html">
-<link title="Mutex" rel="Chapter" href="Mutex.html">
-<link title="Condition" rel="Chapter" href="Condition.html">
-<link title="Semaphore" rel="Chapter" href="Semaphore.html">
-<link title="Domain" rel="Chapter" href="Domain.html">
-<link title="CamlinternalFormat" rel="Chapter" href="CamlinternalFormat.html">
-<link title="Printf" rel="Chapter" href="Printf.html">
+<link title="Ocaml_operators" rel="Chapter" href="Ocaml_operators.html">
 <link title="Arg" rel="Chapter" href="Arg.html">
-<link title="Printexc" rel="Chapter" href="Printexc.html">
+<link title="Array" rel="Chapter" href="Array.html">
+<link title="ArrayLabels" rel="Chapter" href="ArrayLabels.html">
+<link title="Atomic" rel="Chapter" href="Atomic.html">
+<link title="Bigarray" rel="Chapter" href="Bigarray.html">
+<link title="Bool" rel="Chapter" href="Bool.html">
+<link title="Buffer" rel="Chapter" href="Buffer.html">
+<link title="Bytes" rel="Chapter" href="Bytes.html">
+<link title="BytesLabels" rel="Chapter" href="BytesLabels.html">
+<link title="Callback" rel="Chapter" href="Callback.html">
+<link title="Char" rel="Chapter" href="Char.html">
+<link title="Complex" rel="Chapter" href="Complex.html">
+<link title="Condition" rel="Chapter" href="Condition.html">
+<link title="Digest" rel="Chapter" href="Digest.html">
+<link title="Domain" rel="Chapter" href="Domain.html">
+<link title="Dynlink" rel="Chapter" href="Dynlink.html">
+<link title="Effect" rel="Chapter" href="Effect.html">
+<link title="Either" rel="Chapter" href="Either.html">
+<link title="Ephemeron" rel="Chapter" href="Ephemeron.html">
+<link title="Event" rel="Chapter" href="Event.html">
+<link title="Filename" rel="Chapter" href="Filename.html">
+<link title="Float" rel="Chapter" href="Float.html">
+<link title="Format" rel="Chapter" href="Format.html">
 <link title="Fun" rel="Chapter" href="Fun.html">
 <link title="Gc" rel="Chapter" href="Gc.html">
-<link title="Digest" rel="Chapter" href="Digest.html">
-<link title="Bigarray" rel="Chapter" href="Bigarray.html">
-<link title="Random" rel="Chapter" href="Random.html">
 <link title="Hashtbl" rel="Chapter" href="Hashtbl.html">
-<link title="Weak" rel="Chapter" href="Weak.html">
-<link title="Format" rel="Chapter" href="Format.html">
-<link title="Scanf" rel="Chapter" href="Scanf.html">
-<link title="Callback" rel="Chapter" href="Callback.html">
-<link title="CamlinternalOO" rel="Chapter" href="CamlinternalOO.html">
-<link title="Oo" rel="Chapter" href="Oo.html">
-<link title="CamlinternalMod" rel="Chapter" href="CamlinternalMod.html">
-<link title="Ephemeron" rel="Chapter" href="Ephemeron.html">
-<link title="Filename" rel="Chapter" href="Filename.html">
-<link title="Complex" rel="Chapter" href="Complex.html">
-<link title="ArrayLabels" rel="Chapter" href="ArrayLabels.html">
-<link title="ListLabels" rel="Chapter" href="ListLabels.html">
-<link title="BytesLabels" rel="Chapter" href="BytesLabels.html">
-<link title="StringLabels" rel="Chapter" href="StringLabels.html">
-<link title="MoreLabels" rel="Chapter" href="MoreLabels.html">
-<link title="StdLabels" rel="Chapter" href="StdLabels.html">
 <link title="In_channel" rel="Chapter" href="In_channel.html">
+<link title="Int" rel="Chapter" href="Int.html">
+<link title="Int32" rel="Chapter" href="Int32.html">
+<link title="Int64" rel="Chapter" href="Int64.html">
+<link title="Lazy" rel="Chapter" href="Lazy.html">
+<link title="Lexing" rel="Chapter" href="Lexing.html">
+<link title="List" rel="Chapter" href="List.html">
+<link title="ListLabels" rel="Chapter" href="ListLabels.html">
+<link title="Map" rel="Chapter" href="Map.html">
+<link title="Marshal" rel="Chapter" href="Marshal.html">
+<link title="MoreLabels" rel="Chapter" href="MoreLabels.html">
+<link title="Mutex" rel="Chapter" href="Mutex.html">
+<link title="Nativeint" rel="Chapter" href="Nativeint.html">
+<link title="Obj" rel="Chapter" href="Obj.html">
+<link title="Oo" rel="Chapter" href="Oo.html">
+<link title="Option" rel="Chapter" href="Option.html">
 <link title="Out_channel" rel="Chapter" href="Out_channel.html">
-<link title="Effect" rel="Chapter" href="Effect.html">
-<link title="Dynlink" rel="Chapter" href="Dynlink.html">
+<link title="Parsing" rel="Chapter" href="Parsing.html">
+<link title="Printexc" rel="Chapter" href="Printexc.html">
+<link title="Printf" rel="Chapter" href="Printf.html">
+<link title="Queue" rel="Chapter" href="Queue.html">
+<link title="Random" rel="Chapter" href="Random.html">
+<link title="Result" rel="Chapter" href="Result.html">
+<link title="Runtime_events" rel="Chapter" href="Runtime_events.html">
+<link title="Scanf" rel="Chapter" href="Scanf.html">
+<link title="Semaphore" rel="Chapter" href="Semaphore.html">
+<link title="Seq" rel="Chapter" href="Seq.html">
+<link title="Set" rel="Chapter" href="Set.html">
+<link title="Stack" rel="Chapter" href="Stack.html">
+<link title="StdLabels" rel="Chapter" href="StdLabels.html">
+<link title="Stdlib" rel="Chapter" href="Stdlib.html">
 <link title="Str" rel="Chapter" href="Str.html">
+<link title="String" rel="Chapter" href="String.html">
+<link title="StringLabels" rel="Chapter" href="StringLabels.html">
+<link title="Sys" rel="Chapter" href="Sys.html">
+<link title="Thread" rel="Chapter" href="Thread.html">
+<link title="Uchar" rel="Chapter" href="Uchar.html">
+<link title="Unit" rel="Chapter" href="Unit.html">
 <link title="Unix" rel="Chapter" href="Unix.html">
 <link title="UnixLabels" rel="Chapter" href="UnixLabels.html">
-<link title="Thread" rel="Chapter" href="Thread.html">
-<link title="Event" rel="Chapter" href="Event.html">
-<link title="Runtime_events" rel="Chapter" href="Runtime_events.html"><title>OCaml library</title>
+<link title="Weak" rel="Chapter" href="Weak.html">
+<link title="CamlinternalFormat" rel="Chapter" href="CamlinternalFormat.html">
+<link title="CamlinternalFormatBasics" rel="Chapter" href="CamlinternalFormatBasics.html">
+<link title="CamlinternalLazy" rel="Chapter" href="CamlinternalLazy.html">
+<link title="CamlinternalMod" rel="Chapter" href="CamlinternalMod.html">
+<link title="CamlinternalOO" rel="Chapter" href="CamlinternalOO.html"><title>OCaml library</title>
 <script src="search.js"></script><script src="scroll.js"></script><script src="navigation.js"></script><link rel="shortcut icon" type="image/x-icon" href="favicon.ico"></head>
 <body><div class="api"><div id="sidebar-button"><span>☰</span></div><h1>The OCaml API</h1><div class="api_search"><input type="text" name="apisearch" id="api_search" class="api_search" oninput="mySearch(true);" onkeypress="this.oninput();" onclick="this.oninput();" onpaste="this.oninput();">
 <img src="search_icon.svg" alt="Search" class="api_search svg" onclick="mySearch(true)"><span class="search_comment">(search values, type signatures, and descriptions - case sensitive)<span id="help_icon" onclick="showHelp()">ⓘ</span><div id="search_help" class="hide"><ul><li>You may search bare values, like <code>map</code>, or indicate the module, like <code>List.map</code>, or type signatures, like <code>int -&gt; float</code>.</li><li>To combine several keywords, just separate them by a space. Quotes can be used to prevent from splitting words at spaces. For instance, <code>int array</code> will search for <code>int</code> and/or <code>array</code>, while <code>"int array"</code> will only list functions whose signature contains the <code>int array</code> type.</li><li>You may use the special chars <code>^</code> and <code>$</code> to indicate where the matched string should start or end, respectively. For instance <code>^zip</code> will not show you the <code>unzip</code> function.</li></ul></div></span></div>
@@ -100,193 +100,13 @@
 </div>
 
 <table class="indextable module-list">
-<tbody><tr><td class="module"><a href="Ocaml_operators.html">Ocaml_operators</a></td><td><div class="info">
-<p>Precedence level and associativity of operators</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Format_tutorial.html">Format_tutorial</a></td><td><div class="info">
+<tbody><tr><td class="module"><a href="Format_tutorial.html">Format_tutorial</a></td><td><div class="info">
 <p>Using the Format module</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="CamlinternalFormatBasics.html">CamlinternalFormatBasics</a></td><td></td></tr>
-<tr><td class="module"><a href="Stdlib.html">Stdlib</a></td><td><div class="info">
-<p>The OCaml Standard library.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Either.html">Either</a></td><td><div class="info">
-<p>Either type.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Sys.html">Sys</a></td><td><div class="info">
-<p>System interface.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Obj.html">Obj</a></td><td><div class="info">
-<p>Operations on internal representations of values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Atomic.html">Atomic</a></td><td><div class="info">
-<p>Atomic references.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="CamlinternalLazy.html">CamlinternalLazy</a></td><td><div class="info">
-<p>Run-time support for lazy values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Lazy.html">Lazy</a></td><td><div class="info">
-<p>Deferred computations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Seq.html">Seq</a></td><td><div class="info">
-<p>Sequences.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Option.html">Option</a></td><td><div class="info">
-<p>Option values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Result.html">Result</a></td><td><div class="info">
-<p>Result values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Bool.html">Bool</a></td><td><div class="info">
-<p>Boolean values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Char.html">Char</a></td><td><div class="info">
-<p>Character operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Uchar.html">Uchar</a></td><td><div class="info">
-<p>Unicode characters.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="List.html">List</a></td><td><div class="info">
-<p>List operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Int.html">Int</a></td><td><div class="info">
-<p>Integer values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Bytes.html">Bytes</a></td><td><div class="info">
-<p>Byte sequence operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="String.html">String</a></td><td><div class="info">
-<p>Strings.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Unit.html">Unit</a></td><td><div class="info">
-<p>Unit values.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Marshal.html">Marshal</a></td><td><div class="info">
-<p>Marshaling of data structures.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Array.html">Array</a></td><td><div class="info">
-<p>Array operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Float.html">Float</a></td><td><div class="info">
-<p>Floating-point arithmetic.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Int32.html">Int32</a></td><td><div class="info">
-<p>32-bit integers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Int64.html">Int64</a></td><td><div class="info">
-<p>64-bit integers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Nativeint.html">Nativeint</a></td><td><div class="info">
-<p>Processor-native integers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Lexing.html">Lexing</a></td><td><div class="info">
-<p>The run-time library for lexers generated by <code class="code">ocamllex</code>.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Parsing.html">Parsing</a></td><td><div class="info">
-<p>The run-time library for parsers generated by <code class="code">ocamlyacc</code>.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Set.html">Set</a></td><td><div class="info">
-<p>Sets over ordered types.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Map.html">Map</a></td><td><div class="info">
-<p>Association tables over ordered types.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Stack.html">Stack</a></td><td><div class="info">
-<p>Last-in first-out stacks.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Queue.html">Queue</a></td><td><div class="info">
-<p>First-in first-out queues.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Buffer.html">Buffer</a></td><td><div class="info">
-<p>Extensible buffers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Mutex.html">Mutex</a></td><td><div class="info">
-<p>Locks for mutual exclusion.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Condition.html">Condition</a></td><td><div class="info">
-<p>Condition variables.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Semaphore.html">Semaphore</a></td><td><div class="info">
-<p>Semaphores</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Domain.html">Domain</a></td><td><div class="info">
-</div>
-</td></tr>
-<tr><td class="module"><a href="CamlinternalFormat.html">CamlinternalFormat</a></td><td></td></tr>
-<tr><td class="module"><a href="Printf.html">Printf</a></td><td><div class="info">
-<p>Formatted output functions.</p>
+<tr><td class="module"><a href="Ocaml_operators.html">Ocaml_operators</a></td><td><div class="info">
+<p>Precedence level and associativity of operators</p>
 
 </div>
 </td></tr>
@@ -295,8 +115,109 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Printexc.html">Printexc</a></td><td><div class="info">
-<p>Facilities for printing exceptions and inspecting current call stack.</p>
+<tr><td class="module"><a href="Array.html">Array</a></td><td><div class="info">
+<p>Array operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="ArrayLabels.html">ArrayLabels</a></td><td><div class="info">
+<p>Array operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Atomic.html">Atomic</a></td><td><div class="info">
+<p>Atomic references.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Bigarray.html">Bigarray</a></td><td><div class="info">
+<p>Large, multi-dimensional, numerical arrays.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Bool.html">Bool</a></td><td><div class="info">
+<p>Boolean values.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Buffer.html">Buffer</a></td><td><div class="info">
+<p>Extensible buffers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Bytes.html">Bytes</a></td><td><div class="info">
+<p>Byte sequence operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="BytesLabels.html">BytesLabels</a></td><td><div class="info">
+<p>Byte sequence operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Callback.html">Callback</a></td><td><div class="info">
+<p>Registering OCaml values with the C runtime.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Char.html">Char</a></td><td><div class="info">
+<p>Character operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Complex.html">Complex</a></td><td><div class="info">
+<p>Complex numbers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Condition.html">Condition</a></td><td><div class="info">
+<p>Condition variables.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Digest.html">Digest</a></td><td><div class="info">
+<p>MD5 message digest.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Domain.html">Domain</a></td><td><div class="info">
+</div>
+</td></tr>
+<tr><td class="module"><a href="Dynlink.html">Dynlink</a></td><td><div class="info">
+<p>Dynamic loading of .cmo, .cma and .cmxs files.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Effect.html">Effect</a></td><td><div class="info">
+</div>
+</td></tr>
+<tr><td class="module"><a href="Either.html">Either</a></td><td><div class="info">
+<p>Either type.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Ephemeron.html">Ephemeron</a></td><td><div class="info">
+<p>Ephemerons and weak hash tables.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Event.html">Event</a></td><td><div class="info">
+<p>First-class synchronous communication.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Filename.html">Filename</a></td><td><div class="info">
+<p>Operations on file names.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Float.html">Float</a></td><td><div class="info">
+<p>Floating-point arithmetic.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Format.html">Format</a></td><td><div class="info">
+<p>Pretty-printing.</p>
 
 </div>
 </td></tr>
@@ -310,103 +231,8 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Digest.html">Digest</a></td><td><div class="info">
-<p>MD5 message digest.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Bigarray.html">Bigarray</a></td><td><div class="info">
-<p>Large, multi-dimensional, numerical arrays.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Random.html">Random</a></td><td><div class="info">
-<p>Pseudo-random number generators (PRNG).</p>
-
-</div>
-</td></tr>
 <tr><td class="module"><a href="Hashtbl.html">Hashtbl</a></td><td><div class="info">
 <p>Hash tables and hash functions.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Weak.html">Weak</a></td><td><div class="info">
-<p>Arrays of weak pointers and hash sets of weak pointers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Format.html">Format</a></td><td><div class="info">
-<p>Pretty-printing.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Scanf.html">Scanf</a></td><td><div class="info">
-<p>Formatted input functions.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Callback.html">Callback</a></td><td><div class="info">
-<p>Registering OCaml values with the C runtime.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="CamlinternalOO.html">CamlinternalOO</a></td><td><div class="info">
-<p>Run-time support for objects and classes.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Oo.html">Oo</a></td><td><div class="info">
-<p>Operations on objects</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="CamlinternalMod.html">CamlinternalMod</a></td><td><div class="info">
-<p>Run-time support for recursive modules.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Ephemeron.html">Ephemeron</a></td><td><div class="info">
-<p>Ephemerons and weak hash tables.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Filename.html">Filename</a></td><td><div class="info">
-<p>Operations on file names.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="Complex.html">Complex</a></td><td><div class="info">
-<p>Complex numbers.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="ArrayLabels.html">ArrayLabels</a></td><td><div class="info">
-<p>Array operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="ListLabels.html">ListLabels</a></td><td><div class="info">
-<p>List operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="BytesLabels.html">BytesLabels</a></td><td><div class="info">
-<p>Byte sequence operations.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="StringLabels.html">StringLabels</a></td><td><div class="info">
-<p>Strings.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="MoreLabels.html">MoreLabels</a></td><td><div class="info">
-<p>Extra labeled libraries.</p>
-
-</div>
-</td></tr>
-<tr><td class="module"><a href="StdLabels.html">StdLabels</a></td><td><div class="info">
-<p>Standard labeled libraries.</p>
 
 </div>
 </td></tr>
@@ -415,21 +241,188 @@
 
 </div>
 </td></tr>
+<tr><td class="module"><a href="Int.html">Int</a></td><td><div class="info">
+<p>Integer values.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Int32.html">Int32</a></td><td><div class="info">
+<p>32-bit integers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Int64.html">Int64</a></td><td><div class="info">
+<p>64-bit integers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Lazy.html">Lazy</a></td><td><div class="info">
+<p>Deferred computations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Lexing.html">Lexing</a></td><td><div class="info">
+<p>The run-time library for lexers generated by <code class="code">ocamllex</code>.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="List.html">List</a></td><td><div class="info">
+<p>List operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="ListLabels.html">ListLabels</a></td><td><div class="info">
+<p>List operations.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Map.html">Map</a></td><td><div class="info">
+<p>Association tables over ordered types.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Marshal.html">Marshal</a></td><td><div class="info">
+<p>Marshaling of data structures.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="MoreLabels.html">MoreLabels</a></td><td><div class="info">
+<p>Extra labeled libraries.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Mutex.html">Mutex</a></td><td><div class="info">
+<p>Locks for mutual exclusion.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Nativeint.html">Nativeint</a></td><td><div class="info">
+<p>Processor-native integers.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Obj.html">Obj</a></td><td><div class="info">
+<p>Operations on internal representations of values.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Oo.html">Oo</a></td><td><div class="info">
+<p>Operations on objects</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Option.html">Option</a></td><td><div class="info">
+<p>Option values.</p>
+
+</div>
+</td></tr>
 <tr><td class="module"><a href="Out_channel.html">Out_channel</a></td><td><div class="info">
 <p>Output channels.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Effect.html">Effect</a></td><td><div class="info">
+<tr><td class="module"><a href="Parsing.html">Parsing</a></td><td><div class="info">
+<p>The run-time library for parsers generated by <code class="code">ocamlyacc</code>.</p>
+
 </div>
 </td></tr>
-<tr><td class="module"><a href="Dynlink.html">Dynlink</a></td><td><div class="info">
-<p>Dynamic loading of .cmo, .cma and .cmxs files.</p>
+<tr><td class="module"><a href="Printexc.html">Printexc</a></td><td><div class="info">
+<p>Facilities for printing exceptions and inspecting current call stack.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Printf.html">Printf</a></td><td><div class="info">
+<p>Formatted output functions.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Queue.html">Queue</a></td><td><div class="info">
+<p>First-in first-out queues.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Random.html">Random</a></td><td><div class="info">
+<p>Pseudo-random number generators (PRNG).</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Result.html">Result</a></td><td><div class="info">
+<p>Result values.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Runtime_events.html">Runtime_events</a></td><td><div class="info">
+<p>Runtime events - ring buffer-based runtime tracing</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Scanf.html">Scanf</a></td><td><div class="info">
+<p>Formatted input functions.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Semaphore.html">Semaphore</a></td><td><div class="info">
+<p>Semaphores</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Seq.html">Seq</a></td><td><div class="info">
+<p>Sequences.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Set.html">Set</a></td><td><div class="info">
+<p>Sets over ordered types.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Stack.html">Stack</a></td><td><div class="info">
+<p>Last-in first-out stacks.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="StdLabels.html">StdLabels</a></td><td><div class="info">
+<p>Standard labeled libraries.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Stdlib.html">Stdlib</a></td><td><div class="info">
+<p>The OCaml Standard library.</p>
 
 </div>
 </td></tr>
 <tr><td class="module"><a href="Str.html">Str</a></td><td><div class="info">
 <p>Regular expressions and high-level string processing</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="String.html">String</a></td><td><div class="info">
+<p>Strings.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="StringLabels.html">StringLabels</a></td><td><div class="info">
+<p>Strings.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Sys.html">Sys</a></td><td><div class="info">
+<p>System interface.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Thread.html">Thread</a></td><td><div class="info">
+<p>Lightweight threads for Posix <code class="code">1003.1c</code> and Win32.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Uchar.html">Uchar</a></td><td><div class="info">
+<p>Unicode characters.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="Unit.html">Unit</a></td><td><div class="info">
+<p>Unit values.</p>
 
 </div>
 </td></tr>
@@ -443,18 +436,25 @@
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Thread.html">Thread</a></td><td><div class="info">
-<p>Lightweight threads for Posix <code class="code">1003.1c</code> and Win32.</p>
+<tr><td class="module"><a href="Weak.html">Weak</a></td><td><div class="info">
+<p>Arrays of weak pointers and hash sets of weak pointers.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Event.html">Event</a></td><td><div class="info">
-<p>First-class synchronous communication.</p>
+<tr><td class="module"><a href="CamlinternalFormat.html">CamlinternalFormat</a></td><td></td></tr>
+<tr><td class="module"><a href="CamlinternalFormatBasics.html">CamlinternalFormatBasics</a></td><td></td></tr>
+<tr><td class="module"><a href="CamlinternalLazy.html">CamlinternalLazy</a></td><td><div class="info">
+<p>Run-time support for lazy values.</p>
 
 </div>
 </td></tr>
-<tr><td class="module"><a href="Runtime_events.html">Runtime_events</a></td><td><div class="info">
-<p>Runtime events - ring buffer-based runtime tracing</p>
+<tr><td class="module"><a href="CamlinternalMod.html">CamlinternalMod</a></td><td><div class="info">
+<p>Run-time support for recursive modules.</p>
+
+</div>
+</td></tr>
+<tr><td class="module"><a href="CamlinternalOO.html">CamlinternalOO</a></td><td><div class="info">
+<p>Run-time support for objects and classes.</p>
 
 </div>
 </td></tr>


### PR DESCRIPTION
This PR patches the index files for the 4.13 to 5.0 API documentation to sort each link first by category:

- text tutorials
- stdlib and otherlibs modules
- internal stdlib modules

and then alphabetically inside each category.

cc @gasche 