### PR TITLE
OCaml 5: update default links and redirection

### DIFF
--- a/site/api
+++ b/site/api
@@ -1,1 +1,1 @@
-releases/4.14/api
+releases/5.0/api

--- a/site/docs/version_selector.js
+++ b/site/docs/version_selector.js
@@ -3,8 +3,8 @@
 // This variable should be manually modified when a new version appears.
 // TODO: do this automatically.
 
-var LAST_VERSION="4.14"
-var ALL_VERSIONS = [ "latest", "4.14", "4.13", "4.12", "4.11", "4.10", "4.09", "4.08", "4.07", "4.06",
+var LAST_VERSION="5.0"
+var ALL_VERSIONS = [ "latest", "5.0", "4.14", "4.13", "4.12", "4.11", "4.10", "4.09", "4.08", "4.07", "4.06",
 		     "4.05", "4.04", "4.03", "4.02", "4.01" ];
 
 
@@ -20,8 +20,9 @@ if ( CURRENT_VERSION_INDEX == null ) {
 // fact, it will probably be unnecessary, since we can directly link
 // to the first file of Part III.
 var tools_sec = {
-    "latest": 289,
-    "latest": 289,
+    "latest": 335,
+    "5.0"  : 335,
+    "4.14" : 290,
     "4.13" : 289,
     "4.12" : 286,
     "4.11" : 286,

--- a/site/manual
+++ b/site/manual
@@ -1,1 +1,1 @@
-releases/4.14/manual
+releases/5.0/manual


### PR DESCRIPTION
This PR updates the version selector in the documentation pages and the `manual` symbolic link to point to the 5.0 version.