### PR TITLE
Bump opam repository commit in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ocaml/opam:debian-10-ocaml-4.10
-RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 08309af060417fac7143e968e41b9e67e80ba674 && opam update -u -y
+RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout c0f28ddb82787394b70d9be1a074975e8047ac5d && opam update -u -y
 WORKDIR /home/opam/src
 RUN sudo chown opam /home/opam/src
 COPY --chown=opam *.opam /home/opam/src

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,5 +1,5 @@
 FROM ocaml/opam:debian-10-ocaml-4.10 as build
-RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 08309af060417fac7143e968e41b9e67e80ba674 && opam update -u -y
+RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout c0f28ddb82787394b70d9be1a074975e8047ac5d && opam update -u -y
 WORKDIR /home/opam/src
 RUN sudo chown opam /home/opam/src
 COPY --chown=opam *.opam /home/opam/src

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -1,5 +1,5 @@
 FROM ocaml/opam:debian-10-ocaml-4.10 as build
-RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 08309af060417fac7143e968e41b9e67e80ba674 && opam update -u -y
+RUN git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout c0f28ddb82787394b70d9be1a074975e8047ac5d && opam update -u -y
 WORKDIR /home/opam/src
 RUN sudo chown opam /home/opam/src
 COPY --chown=opam *.opam /home/opam/src


### PR DESCRIPTION
# Issue Description

The Dockerfiles do not build.

```
# docker build .
<snip>
Note: checking out '08310af060417fac7143e968e41b9e67e80ba674'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at 08309af060 Merge pull request #21056 from smondet/smondet-zarith-js-conflict

<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
[default] synchronised from file:///home/opam/opam-repository

The following actions will be performed:
  - recompile ocaml-base-compiler 4.10.2*          [upstream changes]
  - recompile ocaml-config        1                [uses ocaml-base-compiler]
  - recompile ocaml               4.10.2           [uses ocaml-base-compiler]
  - downgrade opam-depext         1.2.1-1 to 1.2.1 [upstream changes]
===== 3 to recompile | 1 to downgrade =====

<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[ocaml-base-compiler.4.10.2] found in cache
[opam-depext.1.2.1] found in cache
[ERROR] The sources of the following couldn't be obtained, aborting:
          - ocaml-base-compiler.4.10.2: Bad checksum

The command '/bin/sh -c git -C /home/opam/opam-repository pull origin master && git -C /home/opam/opam-repository checkout 08309af060417fac7143e968e41b9e67e80ba674 && opam update -u -y' returned a non-zero code: 40
```

## Changes Made

Updated the opam commit in the Dockerfiles.
