### PR TITLE
FIX #1512

### DIFF
--- a/site/learn/tutorials/introduction_to_gtk.md
+++ b/site/learn/tutorials/introduction_to_gtk.md
@@ -4,8 +4,7 @@
 
 # Introduction to Gtk
 
-If you intend to try the code in this tutorial in the
-interactive toplevel, you
+If you intend to try the code in this tutorial in the [interactive toplevel](https://ocaml.org/learn/tutorials/a_first_hour_with_ocaml.html),, you
 must first issue (assuming you have installed `lablgtk` using
 [opam](../../docs/install.html)):
 


### PR DESCRIPTION
Fix: Dead link in https://ocaml.org/learn/tutorials/introduction_to_gtk.html #1512

# Issue Description

The first link in the Introduction to Gtk section is dead. I think the link should lead to https://ocaml.org/learn/tutorials/a_first_hour_with_ocaml.html

![114400206-a37b4b00-9b99-11eb-9c49-5d932dce843a](https://github.com/ocaml/v2.ocaml.org/assets/106783948/ec26c935-45ab-44b1-927b-efa8a6666df9)

Fixes #1512

## Changes Made

i have added the link to the word [interactive toplevel]

* **Please check if the PR fulfills these requirements**

- [ ] ❗ If the PR changes a markdown document in `site/`, a comment was added in https://github.com/ocaml/ood/issues/52 with a link to the PR
- [ ] PR is descriptively titled and links the original issue above
- [ ] Before/after screenshots (if this is a layout change)
- [ ] Details of which platforms the change was tested on (if this is a browser-specific change)
- [ ] Context for what motivated the change (if this is a change to some content)
